### PR TITLE
Fix roadshow maps duplicate locations and event box styling

### DIFF
--- a/frontend/scss/components/molecules/event.scss
+++ b/frontend/scss/components/molecules/event.scss
@@ -26,20 +26,22 @@ none
 @import 'components/atoms/_icon.scss';
 
 
-
 .#{molecule('event')} {
+
   @include roadshow-event-shadow;
+  flex: 0 0 calc(100% - 15px);
   display: flex;
   background-color: color('white');
   margin: 10px 0;
-  padding: 20px 30px;
-  min-width: 100%;
+  padding: 20px 15px 20px 30px;
 
   @media (min-width: 768px) {
-    max-width: 350px;
-    min-width: 350px;
-    margin: 20px;
-    margin-left: 0;
+    flex: 0 0 calc(50% - 10px);
+    margin: 20px 0;
+  }
+
+  @media (min-width: 1024px) {
+    flex: 0 0 calc(33.33333333% - 20px);
   }
 
 	&-date {
@@ -91,6 +93,7 @@ none
       @include txt-hl;
       @include color-blue-ribbon;
 
+      margin-top: 0;
       margin-bottom: 0.5em;
     }
 
@@ -102,6 +105,7 @@ none
 
         display: inline-flex;
         align-items: center;
+        white-space: nowrap;
         line-height: 1.4rem;
       }
 
@@ -111,7 +115,7 @@ none
 
         display: inline-flex;
         align-items: center;
-        line-height: 1.4rem;
+        line-height: 1.4;
       }
 
       &-icon {

--- a/frontend/scss/components/molecules/event.scss
+++ b/frontend/scss/components/molecules/event.scss
@@ -41,7 +41,7 @@ none
   }
 
   @media (min-width: 1024px) {
-    flex: 0 0 calc(33.33333333% - 20px);
+    flex: 0 0 calc(33.33% - 20px);
   }
 
 	&-date {

--- a/frontend/scss/components/organisms/cities.scss
+++ b/frontend/scss/components/organisms/cities.scss
@@ -218,12 +218,8 @@
     &-list {
       display: flex;
       flex-wrap: wrap;
+      justify-content: space-between;
       margin: 20px 0 60px;
-
-      .#{molecule('event')} {
-        flex: 1 0 auto;
-        min-width: 0;
-      }
     }
 
     &-checkback {

--- a/pages/content/amp-dev/events/amp-roadshow.html
+++ b/pages/content/amp-dev/events/amp-roadshow.html
@@ -109,7 +109,9 @@ section_links:
       {% endif %}
 
       <aside class="ap-o-cities-map-grid">
+        {% set next_cities = [] %}
         {% for place in doc.roadshow.nextstop if doc.roadshow.nextstop %}
+          {% set push = next_cities.append(place.title|slug) %}
           {% if place.coords %}
           {% set col = place.coords.split('x')[0]|int + 1 %}
           {% set row = place.coords.split('x')[1]|int + 1 %}
@@ -123,7 +125,7 @@ section_links:
           {% endif %}
         {% endfor %}
 
-        {% for place in doc.roadshow.past if doc.roadshow.past %}
+        {% for place in doc.roadshow.past if doc.roadshow.past and place.title|slug not in next_cities %}
           {% if place.coords %}
           {% set col = place.coords.split('x')[0]|int + 1 %}
           {% set row = place.coords.split('x')[1]|int + 1 %}

--- a/pages/content/amp-dev/events/amp-roadshow.html
+++ b/pages/content/amp-dev/events/amp-roadshow.html
@@ -111,7 +111,7 @@ section_links:
       <aside class="ap-o-cities-map-grid">
         {% set next_cities = [] %}
         {% for place in doc.roadshow.nextstop if doc.roadshow.nextstop %}
-          {% set push = next_cities.append(place.title|slug) %}
+          {% do next_cities.append(place.title|slug) %}
           {% if place.coords %}
           {% set col = place.coords.split('x')[0]|int + 1 %}
           {% set row = place.coords.split('x')[1]|int + 1 %}


### PR DESCRIPTION
This fixes the duplicate city issue for the roadshow map.
A past-city will only be added to the map if it doesn't exist in the upcoming-city list.
Also this PR fixes the latest styling issue of the event boxes.

![roadshow-map-events](https://user-images.githubusercontent.com/22053023/61302484-22d1c400-a7e6-11e9-99f0-901d23c01b50.png)