### PR TITLE
Refactor tools styling files to save bytes on the about pages (~4.6 KB)

### DIFF
--- a/frontend/scss/components/organisms/tools-teaser.scss
+++ b/frontend/scss/components/organisms/tools-teaser.scss
@@ -18,389 +18,208 @@ The tools cards on the tools page and in widget form.
 @import '../atoms/_headline';
 @import '../atoms/_text';
 
-@import '../molecules/copy';
-
-@import '../templates/_default';
-
 section.#{utility('tools')} {
-    .#{organism('tool-section')} {
-      margin-bottom: 3em;
-      padding: 0 30px;
+  .#{organism('teaser-grid')} {
+    grid-column: 1 / -1;
+    width: 100%;
+    margin-bottom: 2em;
+
+    &-list {
+      display: grid;
+      grid-template-columns: 1fr;
+      grid-gap: 50px;
+      margin: 0;
+      align-items: stretch;
+
+      @media (min-width: 575px) {
+        grid-template-columns: repeat(12, 1fr);
+        margin: 0;
+      }
 
       @media (min-width: 768px) {
-        margin-top: 4em;
+        grid-gap: 30px;
       }
 
-      &-title { grid-column: 1 / -1; }
-      &-title > h2 { opacity: 0.35; }
-      &-title > .show ~ .hide ~ h2, .show + h2 { opacity: 1; }
-    }
-
-    .#{organism('tool-format-filter-container')} {
-      grid-row-gap: 0;
-      margin-top: 0;
-    }
-
-    .#{organism('tool-format-filter-caption')} {
-      grid-column: 1 / -1;
-    }
-
-    .#{organism('tool-format-filter')} {
-      grid-column: 1 / -1;
-      list-style: none;
-      padding: 0;
-      margin: 0 -8px;
-
-      li {
-        display: inline-block;
-        margin: 10px 8px;
-      }
-    }
-
-    .#{molecule('filter-bubble')} {
-      position: relative;
-      display: inline-block;
-      padding: 5px 20px;
-      margin: 0;
-      font-size: 12px;
-      font-family: 'Noto Sans', sans-serif;
-      color: color('silver');
-      background: color('white');
-      transition: 200ms;
-      box-shadow: 0 5px 25px 0px rgba(0,0,0,0.25);
-
-      &:hover {
-        box-shadow: 0 15px 35px 0px rgba(0,0,0,0.15);
-      }
-
-      &.websites .#{atom('ico')} { fill: #CCC; font-size: 21px; }
-      &.ads .#{atom('ico')} { fill: #CCC; font-size: 19px; }
-      &.stories .#{atom('ico')} { fill: #CCC; font-size: 19px; }
-      &.email .#{atom('ico')} { fill: #CCC; font-size: 19px; }
-
-      &.chosen {
-        padding-left: 12px;
-        padding-right: 28px;
-      }
-
-      &.hover,
-      &.active {
-        &.websites {
-          @include gradient-websites; color: color('white');
-          .#{atom('ico')} { fill: color('white'); }
-        }
-
-        &.stories {
-          @include gradient-stories; color: color('pigment-indigo');
-          .#{atom('ico')} { fill: color('pigment-indigo'); }
-        }
-
-        &.ads {
-          @include gradient-ads; color: color('white');
-          .#{atom('ico')} { fill: color('white'); }
-        }
-
-        &.email {
-          @include gradient-e-mails; color: color('ultramarine');
-          .#{atom('ico')} { fill: color('ultramarine'); }
-        }
-      }
-
-      &-icon {
-        display: inline-flex;
-        margin: 0 2px 2px 0;
-        vertical-align: middle;
-      }
-
-      &-reset {
-        overflow: hidden;
+      .#{molecule('teaser-card')}{
         display: flex;
-        justify-content: flex-end;
-        align-items: center;
-        position: absolute;
-        width: 0;
-        height: 100%;
-        top: 0;
-        right: 0;
+        flex-direction: column;
+        width: 100%;
+        margin: 0;
+        border-radius: 4px;
+        box-shadow: inset 0 0 0 1px color('athens-gray'), 0 30px 75px -13px rgba(0,0,0,.25);
 
-        svg {
-          width: 8px;
-          height: 8px;
-          margin: 1px -10px 0 0;
-          opacity: 0;
-          transition: 200ms;
+        &:hover {
+          box-shadow: inset 0 0 0 1px color('athens-gray'), 0 40px 100px -13px rgba(0,0,0,0.15);
         }
 
-        &.show {
-          width: 100%;
+        & > div:last-child {
+          flex: 1 1 auto;
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+        }
+      }
 
-          svg {
-            margin-right: 10px;
-            opacity: 1;
+      .#{molecule('teaser-content')} {
+        position: relative;
+        padding-left: 15px;
+        padding-right: 15px;
+      }
+
+      .#{molecule('teaser-tag')}{
+        right: 13px;
+        top: auto;
+        bottom: 10px;
+        padding: 5px 20px;
+        line-height: 1.6rem;
+        font-size: 12px;
+        font-family: 'Noto Sans', sans-serif;
+        font-weight: bold;
+        border-radius: 20px;
+        transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+        cursor: pointer;
+
+        &:hover {
+          & + a {
+            transform: translateY(-2px);
+
+            & > .#{molecule('teaser-card')} {
+              box-shadow: inset 0 0 0 1px color('athens-gray'), 0 25px 60px 0px rgba(0,0,0,0.1);
+            }
           }
         }
 
-        &:focus {
-          outline: none;
+        &-icon {
+          display: inline-flex;
+          margin: 0 2px 2px 0;
+          vertical-align: middle;
+          font-size: 19px;
+        }
+
+        &-websites { fill: color('white'); }
+        &-stories { fill: color('pigment-indigo'); }
+        &-ads { fill: color('white'); }
+        &-email { fill: color('ultramarine'); }
+      }
+
+      .#{molecule('teaser')}:hover {
+        .#{molecule('teaser-tag')} {
+          transform: translateY(-2px);
         }
       }
 
-      &:focus {
-        outline: none;
+      .#{molecule('teaser-logo')}{
+        position: absolute;
+        left: 30px;
+        bottom: 100%;
+        margin: 0 0 3px;
+        width: 20px;
+        height: 20px;
+        fill: color('blue-ribbon');
+
+        svg {
+          z-index: 2;
+        }
+
+        &::before {
+          content: '';
+          position: absolute;
+          left: 10px;
+          bottom: -4px;
+          transform: translateX(-50%);
+          width: 70px;
+          height: 28px;
+          z-index: 1;
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 70 28'%3E%3Cpath d='M35 0.4v0c-20.5 0-11.8 26.6-35 26.6v1h70v-1c-23.2 0-14.5-26.6-35-26.6z' fill='%23fff'/%3E%3C/svg%3E");
+        }
       }
-    }
 
-    h1, h2 {
-      @include hl;
-      @include hl-h1;
-      margin-top: 0;
-    }
+      .#{molecule('teaser-image')}{
+        &.contain {
+          amp-img {
+            margin: 0 10px;
 
-    .#{organism('teaser-grid')} {
-      grid-column: 1 / -1;
-      width: 100%;
-      margin-bottom: 2em;
+            @media (min-width: 768px) {
+              margin: 15px 30px;
+            }
+          }
 
-      &-list {
-        display: grid;
-        grid-template-columns: 1fr;
-        grid-gap: 50px;
+          &:before {
+            opacity: 0.5;
+          }
+        }
+      }
+
+      .#{molecule('teaser-card-essential')}{
+        .#{molecule('teaser-card')}{
+          background-color: color('limed-spruce');
+
+          .#{molecule('teaser-content')} > * {
+            color: #fff;
+          }
+
+          .#{molecule('teaser-logo')} {
+            fill: #fff;
+            background-color: color('limed-spruce');
+
+            &::before {
+              background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 70 28'%3E%3Cpath d='M35 0.4v0c-20.5 0-11.8 26.6-35 26.6v1h70v-1c-23.2 0-14.5-26.6-35-26.6z' fill='%23333D47'/%3E%3C/svg%3E");
+            }
+          }
+        }
+      }
+
+      .#{molecule('teaser-type')}{
+        display: flex;
+        align-items: center;
+        height: 55px;
+        padding: 0 120px 0 15px;
+        @include txt-3;
+        color: color('river-bed');
+        border-top: 2px solid color('gallery');
+
+        &-essential {
+          color: #fff;
+        }
+      }
+
+      .#{molecule('teaser')}{
+        grid-column: 1;
         margin: 0;
-        align-items: stretch;
+        display: flex;
 
         @media (min-width: 575px) {
-          grid-template-columns: repeat(12, 1fr);
-          /*grid-auto-rows: 1fr;*/ /*looks a little better when multiple rows are present but wastes space */
-          margin: 0;
+          grid-column: span 6;
         }
 
         @media (min-width: 768px) {
-          grid-gap: 30px;
+          grid-column: span 4;
         }
 
-        .#{molecule('teaser-card')}{
+        @media (min-width: 1120px) {
+          grid-column: span 3;
+        }
+
+        amp-img img {
+          object-fit: cover;
+        }
+
+        amp-img.contain img {
+          object-fit: contain;
+        }
+
+        & > a {
           display: flex;
-          flex-direction: column;
           width: 100%;
-          margin: 0;
-          border-radius: 4px;
-          box-shadow: 0 30px 75px -13px rgba(0,0,0,.25);
-
-          &:hover {
-            box-shadow: 0 40px 100px -13px rgba(0,0,0,0.15);
-          }
-
-          > div:last-child {
-            flex: 1 1 auto;
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
-          }
         }
 
-        .#{molecule('teaser-content')} {
-          position: relative;
-          padding-left: 15px;
-          padding-right: 15px;
-        }
-
-        .#{molecule('teaser-tag')}{
-          right: 13px;
-          top: auto;
-          bottom: 10px;
-          padding: 5px 20px;
-          line-height: 1.6rem;
-          font-size: 12px;
-          font-family: 'Noto Sans', sans-serif;
-          font-weight: bold;
-          border-radius: 20px;
-          transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
-          cursor: pointer;
-
-          &:hover {
-            & + a {
-              transform: translateY(-2px);
-
-              & > .#{molecule('teaser-card')} {
-                box-shadow: 0 25px 60px 0px rgba(0,0,0,0.1);
-              }
-            }
-          }
-
-          &-icon {
-            display: inline-flex;
-            margin: 0 2px 2px 0;
-            vertical-align: middle;
-            font-size: 19px;
-          }
-
-          &-websites { fill: color('white'); }
-          &-stories { fill: color('pigment-indigo'); }
-          &-ads { fill: color('white'); }
-          &-email { fill: color('ultramarine'); }
-        }
-
-        .#{molecule('teaser')}:hover {
-          .#{molecule('teaser-tag')} {
-            transform: translateY(-2px);
-          }
-        }
-
-        .#{molecule('teaser-logo')}{
-          position: absolute;
-          left: 30px;
-          bottom: 100%;
-          margin: 0 0 3px;
-          width: 20px;
-          height: 20px;
-          fill: color('blue-ribbon');
-
-          svg {
-            z-index: 2;
-          }
-
-          &::before {
-            content: '';
-            position: absolute;
-            left: 10px;
-            bottom: -4px;
-            transform: translateX(-50%);
-            width: 70px;
-            height: 28px;
-            z-index: 1;
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 70 28'%3E%3Cpath d='M35 0.4v0c-20.5 0-11.8 26.6-35 26.6v1h70v-1c-23.2 0-14.5-26.6-35-26.6z' fill='%23fff'/%3E%3C/svg%3E");
-          }
-        }
-
-        .#{molecule('teaser-image')}{
-          &.contain {
-            amp-img {
-              margin: 0 10px;
-
-              @media (min-width: 768px) {
-                margin: 15px 30px;
-              }
-            }
-            &:before {
-              opacity: 0.5;
-            }
-          }
-        }
-
-        .#{molecule('teaser-card-essential')}{
-          .#{molecule('teaser-card')}{
-            background-color: color('limed-spruce');
-
-            .#{molecule('teaser-content')} > * {
-              color: #fff;
-            }
-
-            .#{molecule('teaser-logo')} {
-              fill: #fff;
-              background-color: color('limed-spruce');
-
-              &::before {
-                background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 70 28'%3E%3Cpath d='M35 0.4v0c-20.5 0-11.8 26.6-35 26.6v1h70v-1c-23.2 0-14.5-26.6-35-26.6z' fill='%23333D47'/%3E%3C/svg%3E");
-              }
-            }
-          }
-        }
-
-        .#{molecule('teaser-type')}{
-          display: flex;
-          align-items: center;
-          height: 55px;
-          padding: 0 120px 0 15px;
-          @include txt-3;
-          color: color('river-bed');
-          border-top: 2px solid color('gallery');
-
-          &-essential {
-            color: #fff;
-          }
-        }
-
-        .#{molecule('teaser')}{
-          grid-column: 1;
-          margin: 0;
-          display: flex;
-
-          @media (min-width: 575px) {
-            grid-column: span 6;
-          }
-
-          @media (min-width: 768px) {
-            grid-column: span 4;
-          }
-
-          @media (min-width: 1120px) {
-            grid-column: span 3;
-          }
-
-          amp-img img {
-            object-fit: cover;
-          }
-
-          amp-img.contain img {
-            object-fit: contain;
-          }
-
-          > a {
-            display: flex;
-            width: 100%;
-          }
-
-          p {
-            color: #20202A;
-            font-weight: normal;
-            font-size: 0.8em;
-            margin-bottom: 0;
-          }
-
+        p {
+          color: #20202A;
+          font-weight: normal;
+          font-size: 0.8em;
+          margin-bottom: 0;
         }
       }
     }
-
-    /* overrides for tools widget (doesn't apply to standalone tools page) */
-    .ap--content {
-        margin-bottom: 2em;
-    }
-
-    .ap--tools-widget {
-
-        margin-bottom: 0;
-
-        .#{organism('teaser-grid')} {
-
-            margin-bottom: 0;
-
-            &-list {
-
-                display: flex;
-                overflow: auto;
-                margin: -40px -20px;
-                margin-left: 0;
-                padding-top: 0;
-
-                .#{molecule('teaser')} {
-                    display: flex;
-                    margin: 40px 20px;
-                    max-width: 300px;
-
-                    @media (min-width: 768px) {
-                        &:first-child {
-                            margin-left: calc((((100vw - (30px * 23)) / 24) * 3) + (30px * 3));
-                        }
-                      }
-
-                }
-
-            }
-        }
-    }
-
-    .#{organism('component-visual-link')} {
-        grid-column: 4 / 25;
-    }
-
   }
+}

--- a/frontend/scss/components/organisms/tools-widget.scss
+++ b/frontend/scss/components/organisms/tools-widget.scss
@@ -1,0 +1,60 @@
+/*
+
+##############################
+### ORGANISM: tools widget ###
+##############################
+
+### INFO:
+
+The tools cards in widget form on the bottom of the about pages.
+
+*/
+@import '../../extends';
+@import '../../functions';
+@import '../../mixins';
+@import '../../variables';
+
+@import '../atoms/_color';
+@import '../atoms/_headline';
+@import '../atoms/_text';
+
+section.#{utility('tools-widget')} {
+  margin-bottom: 0;
+
+  .#{organism('teaser-grid')} {
+    margin-bottom: 0;
+
+    &-list {
+      display: flex;
+      overflow: auto;
+      margin: -40px 0 -120px;
+      padding: 0 10px 70px;
+
+      @media (min-width: 768px) {
+        padding: 0 0 70px;
+      }
+
+      .#{molecule('teaser')} {
+        display: flex;
+        margin: 40px 20px;
+        max-width: 300px;
+
+        @media (min-width: 768px) {
+          &:first-child {
+            margin-left: calc((((100vw - (30px * 23)) / 24) * 3) + (30px * 3));
+          }
+        }
+      }
+    }
+  }
+}
+
+section.#{utility('tools')} {
+  .#{utility('content')} {
+    margin-bottom: 2em;
+  }
+
+  .#{organism('component-visual-link')} {
+    grid-column: 4 / 25;
+  }
+}

--- a/frontend/scss/components/templates/tools.scss
+++ b/frontend/scss/components/templates/tools.scss
@@ -25,7 +25,6 @@ The page with all AMP tools.
 @import '../organisms/tools-teaser';
 
 .#{utility('stage')} {
-
   .#{organism('stage')} {
     margin-bottom: 50px;
 
@@ -65,6 +64,139 @@ The page with all AMP tools.
   overflow: visible;
 }
 
-.#{utility('tools')} {
+section.#{utility('tools')} {
   padding: 0 25px;
+
+  .#{organism('tool-section')} {
+    margin-bottom: 3em;
+    padding: 0 30px;
+
+    @media (min-width: 768px) {
+      margin-top: 4em;
+    }
+
+    &-title { grid-column: 1 / -1; }
+    &-title > h2 { opacity: 0.35; }
+    &-title > .show ~ .hide ~ h2, .show + h2 { opacity: 1; }
+  }
+
+  .#{organism('tool-format-filter-container')} {
+    grid-row-gap: 0;
+    margin-top: 0;
+  }
+
+  .#{organism('tool-format-filter-caption')} {
+    grid-column: 1 / -1;
+  }
+
+  .#{organism('tool-format-filter')} {
+    grid-column: 1 / -1;
+    list-style: none;
+    padding: 0;
+    margin: 0 -8px;
+
+    li {
+      display: inline-block;
+      margin: 10px 8px;
+    }
+  }
+
+  .#{molecule('filter-bubble')} {
+    position: relative;
+    display: inline-block;
+    padding: 5px 20px;
+    margin: 0;
+    font-size: 12px;
+    font-family: 'Noto Sans', sans-serif;
+    color: color('silver');
+    background: color('white');
+    transition: 200ms;
+    box-shadow: 0 5px 25px 0px rgba(0,0,0,0.25);
+
+    &:hover {
+      box-shadow: 0 15px 35px 0px rgba(0,0,0,0.15);
+    }
+
+    &.websites .#{atom('ico')} { fill: #CCC; font-size: 21px; }
+    &.ads .#{atom('ico')} { fill: #CCC; font-size: 19px; }
+    &.stories .#{atom('ico')} { fill: #CCC; font-size: 19px; }
+    &.email .#{atom('ico')} { fill: #CCC; font-size: 19px; }
+
+    &.chosen {
+      padding-left: 12px;
+      padding-right: 28px;
+    }
+
+    &.hover,
+    &.active {
+      &.websites {
+        @include gradient-websites; color: color('white');
+        .#{atom('ico')} { fill: color('white'); }
+      }
+
+      &.stories {
+        @include gradient-stories; color: color('pigment-indigo');
+        .#{atom('ico')} { fill: color('pigment-indigo'); }
+      }
+
+      &.ads {
+        @include gradient-ads; color: color('white');
+        .#{atom('ico')} { fill: color('white'); }
+      }
+
+      &.email {
+        @include gradient-e-mails; color: color('ultramarine');
+        .#{atom('ico')} { fill: color('ultramarine'); }
+      }
+    }
+
+    &-icon {
+      display: inline-flex;
+      margin: 0 2px 2px 0;
+      vertical-align: middle;
+    }
+
+    &-reset {
+      overflow: hidden;
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      position: absolute;
+      width: 0;
+      height: 100%;
+      top: 0;
+      right: 0;
+
+      svg {
+        width: 8px;
+        height: 8px;
+        margin: 1px -10px 0 0;
+        opacity: 0;
+        transition: 200ms;
+      }
+
+      &.show {
+        width: 100%;
+
+        svg {
+          margin-right: 10px;
+          opacity: 1;
+        }
+      }
+
+      &:focus {
+        outline: none;
+      }
+    }
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  h1, h2 {
+    @include hl;
+    @include hl-h1;
+    margin-top: 0;
+  }
 }

--- a/frontend/templates/views/partials/tools-widget.j2
+++ b/frontend/templates/views/partials/tools-widget.j2
@@ -1,4 +1,5 @@
 {% set tools = g.yaml('/shared/data/tools.yaml') %}
+{% do doc.styles.addCssFile('css/components/organisms/tools-widget.css') %}
 {% do doc.styles.addCssFile('css/components/organisms/tools-teaser.css') %}
 
 <section class="ap--tools">
@@ -12,7 +13,7 @@
   </div>
 </section>
 
-<section class="ap--content ap--tools-widget ap--teaser-grid">
+<section class="ap--tools-widget ap--teaser-grid">
     <div class="ap-o-teaser-grid">
         <div class="ap-o-teaser-grid-list">
         {% for tool in tools[group] %}


### PR DESCRIPTION
I seperated the styling of the tools elements: tools-template, tools-teaser, tools-widget.
This prevents the tools-widget (chosen tool-cards on the bottom of the about pages) from loading the complete css for the tools page, which was never used on the about pages. This is saving us round about 4.6 KB and should fix the css limit error on the about/ads page, see here #2561 

Furthermore I cleaned the code a bit and fixed some UI bugs like cropped box shadow and spacings etc.

No screenshot, because the look hasn't really changed.