### PR TITLE
AMP Story landscape preview mode

### DIFF
--- a/contributing/samples.md
+++ b/contributing/samples.md
@@ -51,17 +51,28 @@ experiments:
 Other supported flags are:
 
 ```yaml
-formats # [default: websites,ads,email,stories]:
-  - websites
-  - ads
-  - email
-  - stories
+**validAmp:** marks the sample as intentionally invalid AMP skipping validation during build.
 validAmp # [default: true]
   - true
   - false
+```
+
+**draft:** marks the sample as draft and it won't be linked from the homepage, but is still accessible via URL.
+```yaml
 draft # [default: true]
   - true
   - false
+```
+
+**landscape (only for AMP Stories):** use landscape mode previews.
+```yaml
+draft # [default: false]
+  - true
+  - false
+```
+
+**tags:** for assign the sample to multiple categories.
+```yaml
 tags # [default: '']
   - ads-analytics
   - dynamic-content

--- a/examples/source/0.introduction/Stories_in_AMP.html
+++ b/examples/source/0.introduction/Stories_in_AMP.html
@@ -1,9 +1,3 @@
-<!---
-
-skipValidation: 'true'
-
---->
-
 <!--
   ## Introduction
 

--- a/examples/source/e-commerce/AMP_for_E-Commerce_Getting_Started.html
+++ b/examples/source/e-commerce/AMP_for_E-Commerce_Getting_Started.html
@@ -45,23 +45,6 @@ author: sebastianbenz
       text-decoration: none;
       word-wrap: normal;
     }
-    .abe-viewer-preview {
-      display: flex;
-    }
-    .www-component-desc>.ampstart-mobile-frame {
-      width: 380px;
-      height: 669px;
-      margin: 1rem auto;
-      border-radius: 17px;
-      position: relative;
-    }
-    .ampstart-mobile-frame amp-iframe {
-      margin: 1px;
-      top: 54px;
-      bottom: 56px;
-      left: 31px;
-      right: 30px;
-    }
   </style>
 </head>
 
@@ -82,7 +65,7 @@ author: sebastianbenz
     It's possible with AMP to create beautiful and interactive product pages. [This sample](/documentation/examples/e-commerce/product_page/preview/) demonstrates how to build a complex product page with dynamic product configuration and an add-to-cart flow. With the introduction of [amp-bind]({{g.doc('/content/amp-dev/documentation/components/reference/amp-bind.md', locale=doc.locale).url.path}}) it's now possible to create truly interactive AMP pages: it can be used to coordinate page state based on user interaction to show and hide arbitrary `div`s.
 
     <div class="ap-o-code-preview-preview-iframe">
-      <amp-iframe class="ap-o-code-preview-iframe" media="(min-width: 650px)" src="<% hosts.preview %>/documentation/examples/e-commerce/product_page" width="440" height="732" sandbox="allow-scripts allow-popups allow-same-origin" frameborder="0"></amp-iframe>
+      <amp-iframe class="ap-o-code-preview-iframe" src="<% hosts.preview %>/documentation/examples/e-commerce/product_page" width="440" height="732" sandbox="allow-scripts allow-popups allow-same-origin" frameborder="0"></amp-iframe>
     </div>
 
     These samples help you get started with building a product landing page with AMP:
@@ -99,7 +82,7 @@ author: sebastianbenz
     As popular landing pages for users, product category pages are well suited for AMP. They are often a mix of editorial content and the hero-style presentation of products. [Here](/documentation/examples/e-commerce/product_browse_page/preview/) is a working sample of a product pages demonstrating common features of a category pages such as product listings or search.
 
     <div class="ap-o-code-preview-preview-iframe">
-      <amp-iframe class="ap-o-code-preview-iframe" media="(min-width: 650px)" src="<% hosts.preview %>/documentation/examples/e-commerce/product_browse_page" width="440" height="732" sandbox="allow-scripts allow-popups allow-same-origin" frameborder="0"></amp-iframe>
+      <amp-iframe class="ap-o-code-preview-iframe" src="<% hosts.preview %>/documentation/examples/e-commerce/product_browse_page" width="440" height="732" sandbox="allow-scripts allow-popups allow-same-origin" frameborder="0"></amp-iframe>
     </div>
 
     Creating category pages with AMP is possible:
@@ -117,7 +100,7 @@ author: sebastianbenz
 
     Here is a sample how to render product name and price using amp-list:
   -->
-  <amp-list height="24" layout="fixed-height" src="/static/samples/json/product.json" binding="no" class="m1">
+  <amp-list height="24" layout="fixed-height" src="/static/samples/json/product.json" binding="no">
     <template type="amp-mustache">
       {{name}}: ${{price}}
     </template>
@@ -150,7 +133,7 @@ author: sebastianbenz
 
     Another approach is to use [amp-bind]({{g.doc('/content/amp-dev/documentation/components/reference/amp-bind.md',locale=doc.locale).url.path}}) with a JSON endpoint, This works well if up-to-date data needs to be available after an user interaction, for example, a hotel page displays room availability when the user selects specific dates.
   -->
-  <div class="p1">
+  <div>
     <amp-state id="products" src="/static/samples/json/products.json"></amp-state>
     <amp-img on="tap:AMP.setState({ productId: 0})" src="/static/samples/img/red_apple_1_60x40.jpg" width="60" height="40" role="button" tabindex="0">
     </amp-img>

--- a/examples/source/style-layout/Desktop_and_Landscape_Mode_Support.html
+++ b/examples/source/style-layout/Desktop_and_Landscape_Mode_Support.html
@@ -1,7 +1,5 @@
 <!---
-
-skipValidation: 'true'
-
+landscape: true
 --->
 
 <!--

--- a/frontend/scss/components/organisms/code-preview.scss
+++ b/frontend/scss/components/organisms/code-preview.scss
@@ -45,13 +45,32 @@
     position: relative;
     top: 1em;
     margin: 1em;
+
+    amp-iframe {
+      @media screen and (max-width: 412px) {
+        width: 240px;
+        height: 427px;
+      }
+      @media screen and (min-width: 413px) {
+        width: 320px;
+        height: 569px;
+      }
+    }
+
+    &.landscape {
+      display: block;
+      amp-iframe {
+        width: auto;
+        height: auto;
+      }
+    }
   }
 
-    &-iframe {
-      background: color('white');
-      box-shadow: 0 2px 10px 0 rgba(0,0,0,0.07);
-      margin-bottom: 1em;
-    }
+  &-iframe {
+    background: color('white');
+    box-shadow: 0 2px 10px 0 rgba(0,0,0,0.07);
+    margin-bottom: 1em;
+  }
 
   .#{molecule('code-snippet')} {
     background: none;

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -179,8 +179,16 @@
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#reload"></use></svg>
           </div>
         </button>
-        <div class="ap-o-code-preview-preview-iframe">
-          <amp-iframe class="ap-o-code-preview-iframe" media="(min-width: 650px)" src="{{ story_preview_embed }}" [src]="{{ section.storyPageId }}" width="440" height="732" sandbox="allow-scripts allow-popups allow-same-origin" frameborder="0"></amp-iframe>
+        <div class="ap-o-code-preview-preview-iframe{% if doc.example.document.metadata.landscape %} landscape{% endif %}">
+          <div>
+            <amp-iframe class="ap-o-code-preview-iframe" src="{{ story_preview_embed }}" [src]="{{ section.storyPageId }}"
+            {% if doc.example.document.metadata.landscape %}
+            width="16" height="9" layout="responsive"
+            {% else %}
+            layout="flex-item"
+            {% endif %}
+            sandbox="allow-scripts allow-popups allow-same-origin" frameborder="0"><div placeholder></div></amp-iframe>
+          </div>
         </div>
         {% elif not doc.example.document.isAmpStory and show_preview %}
         <div class="ap-o-code-preview-preview">


### PR DESCRIPTION
* frontmatter can configure landscape mode for stories via `landscape:
true`
* don't hide story previews on mobile
* remove `media` attribute blocking SSR
* update contribution docs

Fixes 2562