### PR TITLE
Add gulp extract task, extract new strings, improve JA UI translation

### DIFF
--- a/frontend/templates/views/partials/breadcrumbs.j2
+++ b/frontend/templates/views/partials/breadcrumbs.j2
@@ -20,7 +20,7 @@ and the current page title #}
     <svg class="ap-a-ico ap-m-breadcrumbs-angle"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
   </span>
 
-  <div class="ap-m-breadcrumbs-crumb">{{ doc.collection.title }}</div>
+  <div class="ap-m-breadcrumbs-crumb">{{_(doc.collection.title)}}</div>
   {% endif %}
 </nav>
 {% elif doc.pod_path.startswith('/content/amp-dev/documentation/examples') %}

--- a/frontend/templates/views/partials/burger-menu.j2
+++ b/frontend/templates/views/partials/burger-menu.j2
@@ -21,7 +21,7 @@
       (g.collection('/content/amp-dev/documentation/'), None),
       (g.collection('/content/amp-dev/community/'), None),
       (g.collection('/content/amp-dev/events/'), None),
-      ('external', ('Blog', 'https://blog.amp.dev')),
+      ('external', (_('Blog'), 'https://blog.amp.dev')),
       (None, g.doc('/content/amp-dev/support/index.md', locale=doc.locale))
     ] %}
 
@@ -31,11 +31,11 @@
       <a class="ap-o-burger-menu-link ap-m-nav-link" href="{{ homepage[1] }}">{{ homepage[0] }}</a>
       {% elif not section and homepage %}
       <a class="ap-o-burger-menu-link ap-m-nav-link {{ active_class(homepage.pod_path) }}" href="{{ homepage.url.path}}">
-        {{ homepage.titles('navigation') }}
+        {{_(homepage.titles('navigation'))}}
       </a>
       {% else %}
       <label class="ap-o-burger-menu-link ap-m-nav-link {{ active_class(section.pod_path) }}">
-        {{ section.title }}
+        {{_(section.title)}}
       </label>
       <input class="ap-o-burger-menu-item-trigger" type="checkbox" aria-label="{{ section.title }}"/>
       {# The icons direction depends on the inputs checked state #}
@@ -49,7 +49,7 @@
         <li class="ap-o-burger-menu-item">
           {% set second_level_doc = g.doc(path, locale=doc.locale) %}
           <a class="ap-o-burger-menu-link ap-m-nav-link-2 {{ active_class(second_level_doc.pod_path) }}" href="{{ second_level_doc.url.path }}">
-            {{ second_level_doc.titles('navigation') }}
+            {{_(second_level_doc.titles('navigation'))}}
           </a>
         </li>
         {% endfor %}

--- a/frontend/templates/views/partials/header.j2
+++ b/frontend/templates/views/partials/header.j2
@@ -35,7 +35,7 @@
         (g.collection('/content/amp-dev/documentation/'), None),
         (g.collection('/content/amp-dev/community/'), None),
         (g.collection('/content/amp-dev/events/'), None),
-        ('external', ('Blog', 'https://blog.amp.dev')),
+        ('external', (_('Blog'), 'https://blog.amp.dev')),
         (g.collection('/content/amp-dev/support/'), None)
       ] %}
 
@@ -44,10 +44,10 @@
         {% if section == 'external' %}
         <a class="ap-o-header-main-link ap-m-nav-link" href="{{ homepage[1] }}">{{ homepage[0] }}</a>
         {% elif not section %}
-        <a class="ap-o-header-main-link ap-m-nav-link {{ active_class(homepage.pod_path) }}" href="{{ homepage.url.path }}">{{ homepage.titles('navigation') }}</a>
+        <a class="ap-o-header-main-link ap-m-nav-link {{ active_class(homepage.pod_path) }}" href="{{ homepage.url.path }}">{{_(homepage.titles('navigation'))}}</a>
         {% else %}
         <button class="ap-o-header-main-link ap-m-nav-link {{ active_class(section.pod_path) }}">
-          {{ section.title }}
+          {{_(section.title)}}
           <div class="ap-a-ico ap-o-header-main-link-icon">
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
           </div>
@@ -69,14 +69,14 @@
               </div>
 
               <div class="ap-o-header-flyout-primary-item-link-info{% if flyout.format %} ap-o-header-flyout-primary-item-link-info-{{ flyout.format }}{% endif %}">
-                <div class="ap-o-header-flyout-item-title">{{ flyout_doc.titles('navigation') }}</div>
-                <div class="ap-o-header-flyout-item-description">{{ flyout.description }}</div>
+                <div class="ap-o-header-flyout-item-title">{{_(flyout_doc.titles('navigation'))}}</div>
+                <div class="ap-o-header-flyout-item-description">{{_(flyout.description)}}</div>
               </div>
             </a>
           </li>
           {% else %}
           <li class="ap-o-header-flyout-item-secondary">
-            <a class="ap-o-header-flyout-item-title secondary" href="{{ flyout_doc.url.path }}">{{ flyout_doc.titles('navigation') }}</a>
+            <a class="ap-o-header-flyout-item-title secondary" href="{{ flyout_doc.url.path }}">{{_(flyout_doc.titles('navigation'))}}</a>
           </li>
           {% endif %}
           {% endfor %}

--- a/frontend/templates/views/partials/sidebar-toggle-button.j2
+++ b/frontend/templates/views/partials/sidebar-toggle-button.j2
@@ -3,9 +3,9 @@
 
 <label class="ap-a-sidebar-toggle-label ap-a-sidebar-mobile-toggle-label ap-a-sidebar-mobile-toggle-label-sidebar" for="sidebar" on="tap:sidebar-left.toggle" role="categoriemenutrigger" tabindex="0">
   <span class="label-icon"><svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sidebar-toggle"></use></svg></span>
-  <span class="label-title">Toggle Sidebar</span>
+  <span class="label-title">{{_('Toggle Sidebar')}}</span>
 </label>
 <label class="ap-a-sidebar-toggle-label ap-a-sidebar-desktop-toggle-label ap-a-sidebar-desktop-toggle-label-sidebar" for="sidebar-desktop" role="categoriemenutrigger-desktop" tabindex="0">
   <span class="label-icon"><svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sidebar-toggle"></use></svg></span>
-  <span class="label-title">Toggle Sidebar</span>
+  <span class="label-title">{{_('Toggle Sidebar')}}</span>
 </label>

--- a/gulpfile.js/develop.js
+++ b/gulpfile.js/develop.js
@@ -33,6 +33,19 @@ function develop() {
   gulp.series(gulp.parallel(build.buildFrontend, build.collectStatics), run)();
 }
 
+function extract() {
+  gulp.series(gulp.parallel(build.buildFrontend, build.collectStatics), () => {
+    config.configureGrow();
+
+    grow('translations extract')
+        .catch(() => {
+          signale.fatal('Grow had an error starting up. There probably is a broken' +
+            'document in the project. See the log above for details.');
+          process.exit(1);
+        });
+  })();
+}
+
 function run() {
   config.configureGrow();
   grow(`run --port ${config.hosts.pages.port}`).catch(() => {
@@ -52,3 +65,4 @@ function run() {
 
 exports.bootstrap = bootstrap;
 exports.develop = develop;
+exports.extract = extract;

--- a/pages/translations/ar/LC_MESSAGES/messages.po
+++ b/pages/translations/ar/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr ""
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -104,22 +116,22 @@ msgid ""
 "paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr ""
 
@@ -151,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -159,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "المستندات"
 
@@ -173,11 +185,11 @@ msgstr "المستندات"
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -185,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
 "Enable the experiment via the button below. Some components require the AMP "
 "Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr ""
 
@@ -216,27 +232,27 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
 "Get started quickly with a ready-made design. Templates designed to work with"
 " all devices - mobile, tablet and desktop."
@@ -246,27 +262,27 @@ msgstr ""
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
 "If the explanations on this page don't cover all of your questions feel free "
 "to reach out to other AMP users to discuss your exact use case."
@@ -288,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -296,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -312,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -320,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -332,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr ""
 
@@ -344,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -364,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr ""
 
@@ -380,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -420,29 +449,41 @@ msgstr ""
 msgid "Style & Layout"
 msgstr ""
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "الدعم"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
 "hope you'll become an ongoing participant in our open source community but we"
@@ -480,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr ""
 
@@ -504,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr ""
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -512,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -536,7 +582,7 @@ msgstr ""
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
 "You've read this document a dozen times but it doesn't really cover all of "
 "your questions? Maybe other people felt the same: reach out to them on Stack "
@@ -545,37 +591,169 @@ msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -586,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -617,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -634,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -652,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md

--- a/pages/translations/en/LC_MESSAGES/messages.po
+++ b/pages/translations/en/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr ""
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -104,22 +116,22 @@ msgid ""
 "paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr ""
 
@@ -151,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -159,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr ""
 
@@ -173,11 +185,11 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -185,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
 "Enable the experiment via the button below. Some components require the AMP "
 "Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr ""
 
@@ -216,27 +232,27 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
 "Get started quickly with a ready-made design. Templates designed to work with"
 " all devices - mobile, tablet and desktop."
@@ -246,27 +262,27 @@ msgstr ""
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
 "If the explanations on this page don't cover all of your questions feel free "
 "to reach out to other AMP users to discuss your exact use case."
@@ -288,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -296,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -312,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -320,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -332,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr ""
 
@@ -344,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -364,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr ""
 
@@ -380,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -420,29 +449,41 @@ msgstr ""
 msgid "Style & Layout"
 msgstr ""
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr ""
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
 "hope you'll become an ongoing participant in our open source community but we"
@@ -480,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr ""
 
@@ -504,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr ""
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -512,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -536,63 +582,416 @@ msgstr ""
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
 "You've read this document a dozen times but it doesn't really cover all of "
 "your questions? Maybe other people felt the same: reach out to them on Stack "
 "Overflow."
 msgstr ""
 
-msgid "introduction"
-msgstr "Introduction"
-
-msgid "components"
-msgstr "Components"
-
-msgid "guides"
-msgstr "Guides"
-
-msgid "advertising-analytics"
-msgstr "Advertising & Analytics"
-
+#: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
+#: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
+#: /content/amp-dev/documentation/components/reference/amp-experiment.md
+#: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
+#: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr "Advertising & Analytics"
 
-msgid "e-commerce"
-msgstr "E-Commerce"
-
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-access-poool.md
+#: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-action-macro.md
+#: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-byside-content.md
+#: /content/amp-dev/documentation/components/reference/amp-consent.md
+#: /content/amp-dev/documentation/components/reference/amp-date-picker.md
+#: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-geo.md
+#: /content/amp-dev/documentation/components/reference/amp-gist.md
+#: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
+#: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
+#: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-live-list.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-next-page.md
+#: /content/amp-dev/documentation/components/reference/amp-script.md
+#: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
+#: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
+#: /content/amp-dev/documentation/components/reference/amp-user-notification.md
+#: /content/amp-dev/documentation/components/reference/amp-video-docking.md
+#: /content/amp-dev/documentation/components/reference/amp-viewer-assistance.md
+#: /content/amp-dev/documentation/components/reference/amp-web-push.md
 msgid "dynamic-content"
 msgstr "Dynamic Content"
 
-msgid "interactivity-dynamic-content"
-msgstr "Interactivity & Dynamic Content"
-
-msgid "media"
-msgstr "Media"
-
-msgid "multimedia-animations"
-msgstr "Multimedia & Animations"
-
-msgid "news-publishing"
-msgstr "News & Publishing"
-
-msgid "personalization"
-msgstr "Personalization"
-
-msgid "social"
-msgstr "Social"
-
+#: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-app-banner.md
+#: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
+#: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-image-slider.md
+#: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
+#: /content/amp-dev/documentation/components/reference/amp-position-observer.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr "Layout"
 
-msgid "style-layout"
-msgstr "Style & Layout"
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-3q-player.md
+#: /content/amp-dev/documentation/components/reference/amp-anim.md
+#: /content/amp-dev/documentation/components/reference/amp-apester-media.md
+#: /content/amp-dev/documentation/components/reference/amp-audio.md
+#: /content/amp-dev/documentation/components/reference/amp-bodymovin-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-brid-player.md
+#: /content/amp-dev/documentation/components/reference/amp-brightcove.md
+#: /content/amp-dev/documentation/components/reference/amp-dailymotion.md
+#: /content/amp-dev/documentation/components/reference/amp-delight-player.md
+#: /content/amp-dev/documentation/components/reference/amp-embedly-card.md
+#: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
+#: /content/amp-dev/documentation/components/reference/amp-hulu.md
+#: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-imgur.md
+#: /content/amp-dev/documentation/components/reference/amp-izlesene.md
+#: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
+#: /content/amp-dev/documentation/components/reference/amp-kaltura-player.md
+#: /content/amp-dev/documentation/components/reference/amp-mowplayer.md
+#: /content/amp-dev/documentation/components/reference/amp-nexxtv-player.md
+#: /content/amp-dev/documentation/components/reference/amp-o2-player.md
+#: /content/amp-dev/documentation/components/reference/amp-ooyala-player.md
+#: /content/amp-dev/documentation/components/reference/amp-playbuzz.md
+#: /content/amp-dev/documentation/components/reference/amp-powr-player.md
+#: /content/amp-dev/documentation/components/reference/amp-reach-player.md
+#: /content/amp-dev/documentation/components/reference/amp-recaptcha-input.md
+#: /content/amp-dev/documentation/components/reference/amp-skimlinks.md
+#: /content/amp-dev/documentation/components/reference/amp-soundcloud.md
+#: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
+#: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-vimeo.md
+#: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
+#: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
+#: /content/amp-dev/documentation/components/reference/amp-yotpo.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
+msgid "media"
+msgstr "Media"
 
+#: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
+#: /content/amp-dev/documentation/components/reference/amp-date-display.md
+#: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
+#: /content/amp-dev/documentation/components/reference/amp-fit-text.md
+#: /content/amp-dev/documentation/components/reference/amp-font.md
+#: /content/amp-dev/documentation/components/reference/amp-mathml.md
+#: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
+#: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-timeago.md
+#: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr "Presentation"
 
-msgid "user-consent"
-msgstr "User Consent"
+#: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
+#: /content/amp-dev/documentation/components/reference/amp-beopinion.md
+#: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
+#: /content/amp-dev/documentation/components/reference/amp-facebook-like.md
+#: /content/amp-dev/documentation/components/reference/amp-facebook-page.md
+#: /content/amp-dev/documentation/components/reference/amp-facebook.md
+#: /content/amp-dev/documentation/components/reference/amp-gfycat.md
+#: /content/amp-dev/documentation/components/reference/amp-instagram.md
+#: /content/amp-dev/documentation/components/reference/amp-pinterest.md
+#: /content/amp-dev/documentation/components/reference/amp-reddit.md
+#: /content/amp-dev/documentation/components/reference/amp-riddle-quiz.md
+#: /content/amp-dev/documentation/components/reference/amp-twitter.md
+#: /content/amp-dev/documentation/components/reference/amp-vine.md
+#: /content/amp-dev/documentation/components/reference/amp-vk.md
+msgid "social"
+msgstr "Social"
 
-msgid "visual-effects"
-msgstr "Visual & Effects"

--- a/pages/translations/es/LC_MESSAGES/messages.po
+++ b/pages/translations/es/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr "Especificación AMP HTML"
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr "Acerca de"
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -100,25 +112,26 @@ msgstr ""
 
 #: /content/amp-dev/about/stories.html
 msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred paradise"
+"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
+"paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr "Componentes"
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr "Contribuye"
 
@@ -150,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -158,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "Documentos"
 
@@ -172,11 +185,11 @@ msgstr "Documentos"
 msgid "Documentation"
 msgstr "Documentación"
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -184,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
-"Enable the experiment via the button below. Some components require the AMP Dev "
-"Channel to be enabled as well."
+"Enable the experiment via the button below. Some components require the AMP "
+"Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "Eventos"
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr "Ejemplos"
 
@@ -215,60 +232,60 @@ msgstr ""
 msgid "FAQ"
 msgstr "FAQ"
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr "Empezar"
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with "
-"all devices - mobile, tablet and desktop."
+"Get started quickly with a ready-made design. Templates designed to work with"
+" all devices - mobile, tablet and desktop."
 msgstr ""
 
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
-"If the explanations on this page don't cover all of your questions feel free to "
-"reach out to other AMP users to discuss your exact use case."
+"If the explanations on this page don't cover all of your questions feel free "
+"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/_blueprint.yaml
@@ -287,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr "Aprender"
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -295,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr "¿Necesitas más ayuda?"
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -311,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -319,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -331,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr "Descripción general"
 
@@ -343,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -363,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr "Hoja de ruta"
 
@@ -379,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -419,34 +449,46 @@ msgstr "Empieza"
 msgid "Style & Layout"
 msgstr "Estilo y diseño"
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "Soporte"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we "
-"also welcome one-off contributions for the issues you're particularly passionate "
-"about."
+"hope you'll become an ongoing participant in our open source community but we"
+" also welcome one-off contributions for the issues you're particularly "
+"passionate about."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
@@ -479,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr "Herramientas"
 
@@ -503,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr ""
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -511,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -535,45 +582,178 @@ msgstr ""
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
-"You've read this document a dozen times but it doesn't really cover all of your "
-"questions? Maybe other people felt the same: reach out to them on Stack Overflow."
+"You've read this document a dozen times but it doesn't really cover all of "
+"your questions? Maybe other people felt the same: reach out to them on Stack "
+"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -584,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -615,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -632,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -650,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md
@@ -671,3 +994,4 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-vk.md
 msgid "social"
 msgstr ""
+

--- a/pages/translations/fr/LC_MESSAGES/messages.po
+++ b/pages/translations/fr/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr ""
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -104,22 +116,22 @@ msgid ""
 "paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr ""
 
@@ -151,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -159,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "Documents"
 
@@ -173,11 +185,11 @@ msgstr "Documents"
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -185,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
 "Enable the experiment via the button below. Some components require the AMP "
 "Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr ""
 
@@ -216,27 +232,27 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
 "Get started quickly with a ready-made design. Templates designed to work with"
 " all devices - mobile, tablet and desktop."
@@ -246,27 +262,27 @@ msgstr ""
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
 "If the explanations on this page don't cover all of your questions feel free "
 "to reach out to other AMP users to discuss your exact use case."
@@ -288,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -296,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -312,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -320,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -332,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr ""
 
@@ -344,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -364,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr ""
 
@@ -380,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -420,29 +449,41 @@ msgstr ""
 msgid "Style & Layout"
 msgstr ""
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "Assistance"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
 "hope you'll become an ongoing participant in our open source community but we"
@@ -480,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr ""
 
@@ -504,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr ""
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -512,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -536,7 +582,7 @@ msgstr ""
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
 "You've read this document a dozen times but it doesn't really cover all of "
 "your questions? Maybe other people felt the same: reach out to them on Stack "
@@ -545,37 +591,169 @@ msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -586,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -617,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -634,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -652,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md

--- a/pages/translations/id/LC_MESSAGES/messages.po
+++ b/pages/translations/id/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr "Konferensi AMP 2019"
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,9 +30,17 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr "Spesifikasi HTML AMP"
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
-msgstr "AMP Browser yang Didukung"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
+msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
 msgid "AMP's Layout System"
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr "Tentang"
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -100,25 +112,26 @@ msgstr ""
 
 #: /content/amp-dev/about/stories.html
 msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred paradise"
+"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
+"paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr "Komunitas"
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr "Komponen"
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr "Kontribusi"
 
@@ -150,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -158,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "Dokumen"
 
@@ -172,11 +185,11 @@ msgstr "Dokumen"
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -184,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
-"Enable the experiment via the button below. Some components require the AMP Dev "
-"Channel to be enabled as well."
+"Enable the experiment via the button below. Some components require the AMP "
+"Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "Acara"
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr "Contoh"
 
@@ -215,60 +232,60 @@ msgstr ""
 msgid "FAQ"
 msgstr "FAQ"
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr "Ikuti kami"
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr "Mulai"
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr "Mulai"
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with "
-"all devices - mobile, tablet and desktop."
+"Get started quickly with a ready-made design. Templates designed to work with"
+" all devices - mobile, tablet and desktop."
 msgstr ""
 
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr "Panduan & Tutorial"
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
-"If the explanations on this page don't cover all of your questions feel free to "
-"reach out to other AMP users to discuss your exact use case."
+"If the explanations on this page don't cover all of your questions feel free "
+"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/_blueprint.yaml
@@ -287,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr "Pelajari"
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -295,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr "Perlu bantuan lainnya?"
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -311,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -319,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -331,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr "Ringkasan"
 
@@ -343,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -363,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr "Rencana Kerja"
 
@@ -379,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -419,34 +449,46 @@ msgstr "Mulai"
 msgid "Style & Layout"
 msgstr "Gaya & Tata Letak"
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "Dukungan"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we "
-"also welcome one-off contributions for the issues you're particularly passionate "
-"about."
+"hope you'll become an ongoing participant in our open source community but we"
+" also welcome one-off contributions for the issues you're particularly "
+"passionate about."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
@@ -479,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr "Alat"
 
@@ -503,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr "Maaf. Telah terjadi error.\""
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -511,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -535,45 +582,178 @@ msgstr ""
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
-"You've read this document a dozen times but it doesn't really cover all of your "
-"questions? Maybe other people felt the same: reach out to them on Stack Overflow."
+"You've read this document a dozen times but it doesn't really cover all of "
+"your questions? Maybe other people felt the same: reach out to them on Stack "
+"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -584,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr "tata letak"
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -615,6 +872,17 @@ msgstr "tata letak"
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -632,15 +900,48 @@ msgstr "tata letak"
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -650,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr "presentasi"
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md
@@ -671,3 +994,4 @@ msgstr "presentasi"
 #: /content/amp-dev/documentation/components/reference/amp-vk.md
 msgid "social"
 msgstr "sosial"
+

--- a/pages/translations/it/LC_MESSAGES/messages.po
+++ b/pages/translations/it/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,9 +30,17 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr "Specifiche HTML AMP"
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
-msgstr "AMP Browser Supportati"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
+msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
 msgid "AMP's Layout System"
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr "Informazioni"
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -100,25 +112,26 @@ msgstr ""
 
 #: /content/amp-dev/about/stories.html
 msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred paradise"
+"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
+"paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr "Contribuire"
 
@@ -150,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -158,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "Documentazione"
 
@@ -172,11 +185,11 @@ msgstr "Documentazione"
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -184,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
-"Enable the experiment via the button below. Some components require the AMP Dev "
-"Channel to be enabled as well."
+"Enable the experiment via the button below. Some components require the AMP "
+"Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "Eventi"
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr "Esempi"
 
@@ -215,60 +232,60 @@ msgstr ""
 msgid "FAQ"
 msgstr "FAQ"
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr "Inizia"
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr "Inizia"
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with "
-"all devices - mobile, tablet and desktop."
+"Get started quickly with a ready-made design. Templates designed to work with"
+" all devices - mobile, tablet and desktop."
 msgstr ""
 
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
-"If the explanations on this page don't cover all of your questions feel free to "
-"reach out to other AMP users to discuss your exact use case."
+"If the explanations on this page don't cover all of your questions feel free "
+"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/_blueprint.yaml
@@ -287,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr "Impara"
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -295,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr "Serve ancora aiuto?"
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -311,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -319,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -331,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr "Panoramica"
 
@@ -343,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -363,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr "Roadmap"
 
@@ -379,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -419,34 +449,46 @@ msgstr ""
 msgid "Style & Layout"
 msgstr "Stile & Layout"
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "Assistenza"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we "
-"also welcome one-off contributions for the issues you're particularly passionate "
-"about."
+"hope you'll become an ongoing participant in our open source community but we"
+" also welcome one-off contributions for the issues you're particularly "
+"passionate about."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
@@ -479,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr ""
 
@@ -503,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr ""
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -511,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -535,45 +582,178 @@ msgstr ""
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
-"You've read this document a dozen times but it doesn't really cover all of your "
-"questions? Maybe other people felt the same: reach out to them on Stack Overflow."
+"You've read this document a dozen times but it doesn't really cover all of "
+"your questions? Maybe other people felt the same: reach out to them on Stack "
+"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -584,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -615,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -632,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -650,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md
@@ -671,3 +994,4 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-vk.md
 msgid "social"
 msgstr ""
+

--- a/pages/translations/ja/LC_MESSAGES/messages.po
+++ b/pages/translations/ja/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr "AMP HTML 仕様"
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr "AMP の概要"
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr "AMP について"
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr "ブログ"
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -104,22 +116,22 @@ msgid ""
 "paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
-msgstr ""
+msgstr "コミュニティ"
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
-msgstr ""
+msgstr "コンポーネント: "
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr "コンポーネント"
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr "貢献する"
 
@@ -141,29 +153,29 @@ msgstr "インタラクティブな AMP ページを作成する"
 
 #: /content/amp-dev/documentation/guides-and-tutorials/start/create/_blueprint.yaml
 msgid "Create your first AMP Page"
-msgstr ""
+msgstr "初めての AMP ページを作成する"
 
 #: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/_blueprint.yaml
 msgid "Create your first AMP Story"
-msgstr ""
+msgstr "視覚的な AMP ストーリーを作成する"
 
 #: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/_blueprint.yaml
 msgid "Create your first AMPHTML ad"
-msgstr ""
+msgstr "AMPHTML 広告を作成する"
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
-msgstr ""
+msgstr "テンプレート"
 
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/_blueprint.yaml
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "ドキュメント"
 
@@ -171,13 +183,13 @@ msgstr "ドキュメント"
 #: /views/partials/breadcrumbs.j2:29 /views/partials/breadcrumbs.j2:41
 #: /views/partials/breadcrumbs.j2:53
 msgid "Documentation"
-msgstr ""
+msgstr "ドキュメント"
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -185,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
 "Enable the experiment via the button below. Some components require the AMP "
 "Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "イベント"
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr "実例"
 
@@ -216,27 +232,27 @@ msgstr ""
 msgid "FAQ"
 msgstr "よくある質問"
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr "スタートガイド"
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
-msgstr ""
+msgstr "スタートガイド"
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
 "Get started quickly with a ready-made design. Templates designed to work with"
 " all devices - mobile, tablet and desktop."
@@ -246,27 +262,27 @@ msgstr ""
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
-msgstr ""
+msgstr "ガイドとチュートリアル"
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
 "If the explanations on this page don't cover all of your questions feel free "
 "to reach out to other AMP users to discuss your exact use case."
@@ -288,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr "詳細"
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -296,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr "ご不明な点がある場合"
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -312,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -320,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -332,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr ""
 
@@ -344,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -364,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr "ロードマップ"
 
@@ -380,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -420,29 +449,41 @@ msgstr ""
 msgid "Style & Layout"
 msgstr "スタイルとレイアウト"
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
-msgstr ""
+msgstr "成功事例"
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
-msgstr ""
+msgstr "成功事例"
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
-msgstr ""
+msgstr "成功事例"
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "サポート"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr "サポートブラウザ"
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr "サポートされるパートナーと統合"
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
 "hope you'll become an ongoing participant in our open source community but we"
@@ -480,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
 msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
+msgstr "トグルサイドバー"
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr "ツール"
 
@@ -504,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr "エラーが発生しました。"
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -512,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -536,7 +582,7 @@ msgstr "Wired"
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
 "You've read this document a dozen times but it doesn't really cover all of "
 "your questions? Maybe other people felt the same: reach out to them on Stack "
@@ -545,37 +591,169 @@ msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
-msgstr ""
+msgstr "広告と分析"
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -583,27 +761,104 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-viewer-assistance.md
 #: /content/amp-dev/documentation/components/reference/amp-web-push.md
 msgid "dynamic-content"
-msgstr ""
+msgstr "動的コンテンツ"
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
-msgstr ""
+msgstr "レイアウト"
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -617,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -634,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
-msgstr ""
+msgstr "メディア"
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -652,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
-msgstr ""
+msgstr "プレゼンテーション"
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md
@@ -672,5 +993,5 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-vine.md
 #: /content/amp-dev/documentation/components/reference/amp-vk.md
 msgid "social"
-msgstr ""
+msgstr "ソーシャル"
 

--- a/pages/translations/ko/LC_MESSAGES/messages.po
+++ b/pages/translations/ko/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr "AMP HTML 스펙"
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr "AMP에 대하여"
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -104,22 +116,22 @@ msgid ""
 "paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr "컴포넌트"
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr "기여"
 
@@ -151,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -159,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "문서"
 
@@ -173,11 +185,11 @@ msgstr "문서"
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -185,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
 "Enable the experiment via the button below. Some components require the AMP "
 "Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "이벤트"
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr "예제"
 
@@ -216,27 +232,27 @@ msgstr ""
 msgid "FAQ"
 msgstr "FAQ"
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr "시작하기"
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
 "Get started quickly with a ready-made design. Templates designed to work with"
 " all devices - mobile, tablet and desktop."
@@ -246,27 +262,27 @@ msgstr ""
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
 "If the explanations on this page don't cover all of your questions feel free "
 "to reach out to other AMP users to discuss your exact use case."
@@ -288,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr "알아보기"
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -296,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr "도움이 더 필요한가요?"
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -312,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -320,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -332,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr ""
 
@@ -344,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -364,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr "로드맵"
 
@@ -380,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -420,29 +449,41 @@ msgstr ""
 msgid "Style & Layout"
 msgstr "스타일 및 레이아웃"
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "지원"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
 "hope you'll become an ongoing participant in our open source community but we"
@@ -480,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr "도구들"
 
@@ -504,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr "오류가 발생했습니다."
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -512,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -536,7 +582,7 @@ msgstr "Wired"
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
 "You've read this document a dozen times but it doesn't really cover all of "
 "your questions? Maybe other people felt the same: reach out to them on Stack "
@@ -545,37 +591,169 @@ msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -586,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -617,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -634,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -652,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md

--- a/pages/translations/messages.pot
+++ b/pages/translations/messages.pot
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr ""
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -104,22 +116,22 @@ msgid ""
 "paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr ""
 
@@ -151,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -159,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr ""
 
@@ -173,11 +185,11 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -185,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
 "Enable the experiment via the button below. Some components require the AMP "
 "Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr ""
 
@@ -216,27 +232,27 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
 "Get started quickly with a ready-made design. Templates designed to work with"
 " all devices - mobile, tablet and desktop."
@@ -246,27 +262,27 @@ msgstr ""
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
 "If the explanations on this page don't cover all of your questions feel free "
 "to reach out to other AMP users to discuss your exact use case."
@@ -288,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -296,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -312,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -320,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -332,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr ""
 
@@ -344,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -364,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr ""
 
@@ -380,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -420,29 +449,41 @@ msgstr ""
 msgid "Style & Layout"
 msgstr ""
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr ""
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
 "hope you'll become an ongoing participant in our open source community but we"
@@ -480,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr ""
 
@@ -504,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr ""
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -512,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -536,7 +582,7 @@ msgstr ""
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
 "You've read this document a dozen times but it doesn't really cover all of "
 "your questions? Maybe other people felt the same: reach out to them on Stack "
@@ -545,37 +591,169 @@ msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -586,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -617,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -634,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -652,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md

--- a/pages/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/pages/translations/pt_BR/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr "Especificações de HTML das AMP"
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr "Sobre"
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -104,22 +116,22 @@ msgid ""
 "paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr "Componentes"
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr "Contribuir"
 
@@ -151,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -159,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "Documentos"
 
@@ -173,11 +185,11 @@ msgstr "Documentos"
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -185,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
 "Enable the experiment via the button below. Some components require the AMP "
 "Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "Eventos"
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr "Exemplos"
 
@@ -216,27 +232,27 @@ msgstr ""
 msgid "FAQ"
 msgstr "Perguntas frequentes"
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr "Primeiros passos"
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
 "Get started quickly with a ready-made design. Templates designed to work with"
 " all devices - mobile, tablet and desktop."
@@ -246,27 +262,27 @@ msgstr ""
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
 "If the explanations on this page don't cover all of your questions feel free "
 "to reach out to other AMP users to discuss your exact use case."
@@ -288,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr "Aprenda"
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -296,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr "Precisa de mais ajuda?"
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -312,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -320,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -332,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr ""
 
@@ -344,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -364,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr "Roteiro"
 
@@ -380,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -420,29 +449,41 @@ msgstr ""
 msgid "Style & Layout"
 msgstr "Estilo e layout"
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "Suporte"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
 "hope you'll become an ongoing participant in our open source community but we"
@@ -480,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr "Ferramentas"
 
@@ -504,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr "Ah, não! Ocorreu um erro."
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -512,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -536,7 +582,7 @@ msgstr "Wired"
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
 "You've read this document a dozen times but it doesn't really cover all of "
 "your questions? Maybe other people felt the same: reach out to them on Stack "
@@ -545,37 +591,169 @@ msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -586,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -617,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -634,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -652,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md

--- a/pages/translations/ru/LC_MESSAGES/messages.po
+++ b/pages/translations/ru/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr ""
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -104,22 +116,22 @@ msgid ""
 "paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr ""
 
@@ -151,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -159,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "Справка"
 
@@ -173,11 +185,11 @@ msgstr "Справка"
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -185,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
 "Enable the experiment via the button below. Some components require the AMP "
 "Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr ""
 
@@ -216,27 +232,27 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
 "Get started quickly with a ready-made design. Templates designed to work with"
 " all devices - mobile, tablet and desktop."
@@ -246,27 +262,27 @@ msgstr ""
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
 "If the explanations on this page don't cover all of your questions feel free "
 "to reach out to other AMP users to discuss your exact use case."
@@ -288,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -296,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -312,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -320,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -332,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr ""
 
@@ -344,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -364,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr ""
 
@@ -380,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -420,29 +449,41 @@ msgstr ""
 msgid "Style & Layout"
 msgstr ""
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "Поддержка"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
 "hope you'll become an ongoing participant in our open source community but we"
@@ -480,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr ""
 
@@ -504,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr ""
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -512,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -536,7 +582,7 @@ msgstr ""
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
 "You've read this document a dozen times but it doesn't really cover all of "
 "your questions? Maybe other people felt the same: reach out to them on Stack "
@@ -545,37 +591,169 @@ msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -586,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -617,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -634,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -652,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md

--- a/pages/translations/tr/LC_MESSAGES/messages.po
+++ b/pages/translations/tr/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr ""
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -104,22 +116,22 @@ msgid ""
 "paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr ""
 
@@ -151,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -159,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "Dokümanlar"
 
@@ -173,11 +185,11 @@ msgstr "Dokümanlar"
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -185,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
 "Enable the experiment via the button below. Some components require the AMP "
 "Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr ""
 
@@ -216,27 +232,27 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
 "Get started quickly with a ready-made design. Templates designed to work with"
 " all devices - mobile, tablet and desktop."
@@ -246,27 +262,27 @@ msgstr ""
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
 "If the explanations on this page don't cover all of your questions feel free "
 "to reach out to other AMP users to discuss your exact use case."
@@ -288,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -296,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -312,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -320,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -332,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr ""
 
@@ -344,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -364,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr ""
 
@@ -380,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -420,29 +449,41 @@ msgstr ""
 msgid "Style & Layout"
 msgstr ""
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "Destek"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
 "hope you'll become an ongoing participant in our open source community but we"
@@ -480,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr ""
 
@@ -504,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr ""
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -512,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -536,7 +582,7 @@ msgstr ""
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
 "You've read this document a dozen times but it doesn't really cover all of "
 "your questions? Maybe other people felt the same: reach out to them on Stack "
@@ -545,37 +591,169 @@ msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -586,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -617,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -634,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -652,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md

--- a/pages/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/pages/translations/zh_CN/LC_MESSAGES/messages.po
@@ -10,19 +10,19 @@ msgstr ""
 msgid "A website screenshot."
 msgstr ""
 
+#: /views/partials/footer.j2:73
+msgid "AMP Brand Materials"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
 msgid "AMP Caches & CORS"
 msgstr ""
 
-#: /views/partials/footer.j2:70
+#: /views/partials/footer.j2:71
 msgid "AMP Conf 2019"
 msgstr ""
 
-#: /views/partials/banner.j2:7
-msgid "AMP Conf 2019. April 17/18. Tokyo."
-msgstr ""
-
-#: /views/partials/footer.j2:42
+#: /views/partials/footer.j2:43
 msgid "AMP Framework"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "AMP HTML Specification"
 msgstr "AMP HTML 规范"
 
-#: /content/amp-dev/support/faq/supported-browsers.md
-msgid "AMP Supported Browsers"
+#: /content/amp-dev/support/faq/overview.md
+msgid "AMP Overview"
+msgstr ""
+
+#: /views/partials/banner.j2:5
+msgid "AMP Roadshow is coming to Atlanta & Berlin!"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/_blueprint.yaml
+msgid "AMP for Email Specification"
 msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -42,7 +50,7 @@ msgstr ""
 msgid "About"
 msgstr "简介"
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Accept use of cookies"
 msgstr ""
 
@@ -58,7 +66,7 @@ msgstr ""
 msgid "Advanced Course"
 msgstr ""
 
-#: /views/examples/documentation.j2:222
+#: /views/examples/documentation.j2:217
 msgid "An unexplained feature?"
 msgstr ""
 
@@ -78,7 +86,7 @@ msgstr ""
 msgid "Back to home"
 msgstr ""
 
-#: /views/examples/preview.j2:27
+#: /views/examples/preview.j2:28
 msgid "Back to sample"
 msgstr ""
 
@@ -90,7 +98,11 @@ msgstr ""
 msgid "Beginning Course"
 msgstr ""
 
-#: /views/partials/burger-menu.j2:7
+#: /views/partials/burger-menu.j2:24 /views/partials/header.j2:38
+msgid "Blog"
+msgstr ""
+
+#: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
 msgstr ""
 
@@ -104,22 +116,22 @@ msgid ""
 "paradise"
 msgstr ""
 
-#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:60
+#: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
 msgid "Community"
 msgstr ""
 
-#: /views/partials/structured-data.j2:44
+#: /views/partials/structured-data.j2:54
 msgid "Component: "
 msgstr ""
 
 #: /content/amp-dev/documentation/components/_blueprint.yaml
 #: /content/amp-dev/documentation/components/reference/_blueprint.yaml
-#: /views/partials/footer.j2:53
+#: /views/partials/footer.j2:54
 msgid "Components"
 msgstr "组件"
 
 #: /content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
-#: /views/partials/footer.j2:63
+#: /views/partials/footer.j2:64
 msgid "Contribute"
 msgstr "贡献"
 
@@ -151,7 +163,7 @@ msgstr ""
 msgid "Create your first AMPHTML ad"
 msgstr ""
 
-#: /views/partials/footer.j2:55
+#: /views/partials/footer.j2:56
 msgid "Design Templates"
 msgstr ""
 
@@ -159,11 +171,11 @@ msgstr ""
 msgid "Develop"
 msgstr ""
 
-#: /views/partials/consent.j2:26
+#: /views/partials/consent.j2:28
 msgid "Dismiss consent"
 msgstr ""
 
-#: /views/partials/footer.j2:49
+#: /views/partials/footer.j2:50
 msgid "Docs"
 msgstr "文档"
 
@@ -173,11 +185,11 @@ msgstr "文档"
 msgid "Documentation"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:19
+#: /content/amp-dev/documentation/templates/index.html:20
 msgid "Easily build user first websites with our templates"
 msgstr ""
 
-#: /views/examples/documentation.j2:226
+#: /views/examples/documentation.j2:221
 msgid "Edit sample on GitHub"
 msgstr ""
 
@@ -185,26 +197,30 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid ""
 "Enable the experiment via the button below. Some components require the AMP "
 "Dev Channel to be enabled as well."
 msgstr ""
 
-#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:68
+#: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "活动"
 
-#: /views/partials/structured-data.j2:42
+#: /content/tests/examples/_blueprint.yaml
+msgid "Example Source Code"
+msgstr ""
+
+#: /views/partials/structured-data.j2:52
 msgid "Example preview: "
 msgstr ""
 
-#: /views/partials/structured-data.j2:40
+#: /views/partials/structured-data.j2:50
 msgid "Example: "
 msgstr ""
 
 #: /content/amp-dev/documentation/examples/_blueprint.yaml
-#: /views/partials/footer.j2:54
+#: /views/partials/footer.j2:55
 msgid "Examples"
 msgstr "示例"
 
@@ -216,27 +232,27 @@ msgstr ""
 msgid "FAQ"
 msgstr "常见问题解答"
 
-#: /views/partials/footer.j2:11
+#: /views/partials/footer.j2:12
 msgid "Follow us"
 msgstr ""
 
-#: /views/detail/component-detail.j2:33
+#: /views/detail/component-detail.j2:37
 msgid "Found a bug or missing a feature?"
 msgstr ""
 
-#: /views/partials/footer.j2:45
+#: /views/partials/footer.j2:46
 msgid "Functionality"
 msgstr ""
 
-#: /views/partials/footer.j2:51
+#: /views/partials/footer.j2:52
 msgid "Get Started"
 msgstr "开始使用"
 
-#: /views/detail/docs-detail.j2:33
+#: /views/detail/docs-detail.j2:37
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:68
+#: /content/amp-dev/documentation/templates/index.html:70
 msgid ""
 "Get started quickly with a ready-made design. Templates designed to work with"
 " all devices - mobile, tablet and desktop."
@@ -246,27 +262,27 @@ msgstr ""
 msgid "Get the courses"
 msgstr ""
 
-#: /views/detail/component-detail.j2:37
+#: /views/detail/component-detail.j2:41
 msgid "Go to GitHub"
 msgstr ""
 
-#: /views/detail/component-detail.j2:30 /views/examples/documentation.j2:219
+#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:214
 msgid "Go to Stack Overflow"
 msgstr ""
 
-#: /views/partials/consent.j2:34
+#: /views/partials/consent.j2:36
 msgid "Got it!"
 msgstr ""
 
-#: /views/partials/footer.j2:52
+#: /views/partials/footer.j2:53
 msgid "Guides and Tutorials"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:18
+#: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr ""
 
-#: /views/examples/documentation.j2:216
+#: /views/examples/documentation.j2:211
 msgid ""
 "If the explanations on this page don't cover all of your questions feel free "
 "to reach out to other AMP users to discuss your exact use case."
@@ -288,6 +304,10 @@ msgstr ""
 msgid "Learn"
 msgstr "了解"
 
+#: /views/partials/footer.j2:76
+msgid "Logos"
+msgstr ""
+
 #: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
 msgid "Monetize your AMP page with ads"
 msgstr ""
@@ -296,15 +316,15 @@ msgstr ""
 msgid "Multiple Image"
 msgstr ""
 
-#: /views/examples/documentation.j2:215
+#: /views/examples/documentation.j2:210
 msgid "Need further explanation?"
 msgstr ""
 
-#: /views/detail/component-detail.j2:26
+#: /views/detail/component-detail.j2:30
 msgid "Need more help?"
 msgstr "需要更多帮助？"
 
-#: /views/detail/docs-detail.j2:48
+#: /views/detail/docs-detail.j2:52
 msgid "Next chapter"
 msgstr ""
 
@@ -312,7 +332,7 @@ msgstr ""
 msgid "Nueve hoteles en los que tienes que dormir antes de morir"
 msgstr ""
 
-#: /views/partials/footer.j2:8
+#: /views/partials/footer.j2:9
 msgid "Of course, this site is made with AMP!"
 msgstr ""
 
@@ -320,11 +340,12 @@ msgstr ""
 msgid "Open Use Case"
 msgstr ""
 
-#: /views/examples/documentation.j2:164
+#: /views/examples/documentation.j2:159
 msgid "Open in playground"
 msgstr ""
 
-#: /views/examples/documentation.j2:204
+#: /views/examples/documentation.j2:199
+#: /views/partials/code-preview/code-preview.j2:18
 msgid "Open this snippet in playground"
 msgstr ""
 
@@ -332,7 +353,7 @@ msgstr ""
 msgid "Optimize & Measure"
 msgstr ""
 
-#: /views/partials/footer.j2:40
+#: /views/partials/footer.j2:41
 msgid "Overview"
 msgstr ""
 
@@ -344,19 +365,23 @@ msgstr ""
 msgid "Parallax Storytelling in AMP"
 msgstr ""
 
-#: /views/partials/footer.j2:62
+#: /content/amp-dev/support/faq/platform-involvement.md
+msgid "Platform and Technology Company Involvement"
+msgstr ""
+
+#: /views/partials/footer.j2:63
 msgid "Platform and Vendor Partners"
 msgstr ""
 
-#: /views/examples/preview.j2:18
+#: /views/examples/preview.j2:19
 msgid "Preview"
 msgstr ""
 
-#: /views/detail/docs-detail.j2:42
+#: /views/detail/docs-detail.j2:46
 msgid "Previous chapter"
 msgstr ""
 
-#: /views/partials/footer.j2:76
+#: /views/partials/footer.j2:82
 msgid "Privacy Policy"
 msgstr ""
 
@@ -364,7 +389,11 @@ msgstr ""
 msgid "Protecting the Antarctic - A journey to a continent in distress"
 msgstr ""
 
-#: /views/partials/footer.j2:64
+#: /content/amp-dev/support/faq/publisher-monetization.md
+msgid "Publisher Monetization"
+msgstr ""
+
+#: /views/partials/footer.j2:65
 msgid "Roadmap"
 msgstr "蓝图"
 
@@ -380,19 +409,19 @@ msgstr ""
 msgid "See all use cases"
 msgstr ""
 
-#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:133
+#: /views/partials/teaser-grid.j2:135 /views/partials/teaser.j2:140
 msgid "See example"
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:10
+#: /content/amp-dev/about/success-stories/index.html:14
 msgid "See what others have built"
 msgstr ""
 
-#: /views/partials/header.j2:88
+#: /views/partials/header.j2:91
 msgid "Select a language"
 msgstr ""
 
-#: /content/amp-dev/index.html:254
+#: /content/amp-dev/index.html:257
 msgid "Show everything"
 msgstr ""
 
@@ -420,29 +449,41 @@ msgstr ""
 msgid "Style & Layout"
 msgstr "样式与布局"
 
+#: /views/partials/footer.j2:75
+msgid "Styleguide"
+msgstr ""
+
 #: /content/amp-dev/about/success-stories/_blueprint.yaml
 #: /content/amp-dev/about/success-stories/index.html
 msgid "Success Stories"
 msgstr ""
 
-#: /views/partials/structured-data.j2:46
+#: /views/partials/structured-data.j2:56
 msgid "Success Story: "
 msgstr ""
 
-#: /content/amp-dev/about/success-stories/index.html:11
-#: /views/partials/footer.j2:44
+#: /content/amp-dev/about/success-stories/index.html:15
+#: /views/partials/footer.j2:45
 msgid "Success stories"
 msgstr ""
 
-#: /content/amp-dev/support/_blueprint.yaml
+#: /content/amp-dev/support/_blueprint.yaml /views/partials/breadcrumbs.j2:73
 msgid "Support"
 msgstr "支持"
 
-#: /views/examples/documentation.j2:90
+#: /content/amp-dev/support/faq/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+#: /content/amp-dev/support/faq/platform-and-vendor-partners.md
+msgid "Supported Platforms"
+msgstr ""
+
+#: /views/examples/documentation.j2:85
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:34 /views/examples/documentation.j2:223
+#: /views/detail/component-detail.j2:38 /views/examples/documentation.j2:218
 msgid ""
 "The AMP project strongly encourages your participation and contributions! We "
 "hope you'll become an ongoing participant in our open source community but we"
@@ -480,15 +521,20 @@ msgid ""
 "Union"
 msgstr ""
 
-#: /views/examples/documentation.j2:131
+#: /views/examples/documentation.j2:126
 msgid "This example uses the following experimental feature:"
+msgstr ""
+
+#: /views/partials/sidebar-toggle-button.j2:6
+#: /views/partials/sidebar-toggle-button.j2:10
+msgid "Toggle Sidebar"
 msgstr ""
 
 #: /views/partials/case-grid.j2:6
 msgid "Too much choice"
 msgstr ""
 
-#: /views/partials/footer.j2:56
+#: /views/partials/footer.j2:57
 msgid "Tools"
 msgstr "工具"
 
@@ -504,7 +550,7 @@ msgstr ""
 msgid "Uh oh! That's an error."
 msgstr ""
 
-#: /views/partials/footer.j2:43
+#: /views/partials/footer.j2:44
 msgid "Use Cases"
 msgstr ""
 
@@ -512,7 +558,7 @@ msgstr ""
 msgid "Validation Workflow"
 msgstr ""
 
-#: /views/examples/documentation.j2:159
+#: /views/examples/documentation.j2:154
 msgid "View demo"
 msgstr ""
 
@@ -536,7 +582,7 @@ msgstr ""
 msgid "You're currently not connected to the internet."
 msgstr ""
 
-#: /views/detail/component-detail.j2:27
+#: /views/detail/component-detail.j2:31
 msgid ""
 "You've read this document a dozen times but it doesn't really cover all of "
 "your questions? Maybe other people felt the same: reach out to them on Stack "
@@ -545,37 +591,169 @@ msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit.md
 #: /content/amp-dev/documentation/components/reference/amp-ad.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@es.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@id.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@it.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-ad@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-analytics.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@es.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@id.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@it.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-analytics@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-auto-ads.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@es.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@id.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@it.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-auto-ads@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-call-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-experiment.md
 #: /content/amp-dev/documentation/components/reference/amp-mraid.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-pixel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-share-tracking.md
 #: /content/amp-dev/documentation/components/reference/amp-smartlinks.md
 #: /content/amp-dev/documentation/components/reference/amp-social-share.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@es.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@id.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@it.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-social-share@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad.md
 msgid "ads-analytics"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access-laterpay@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-access-poool.md
 #: /content/amp-dev/documentation/components/reference/amp-access.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-access@es.md
+#: /content/amp-dev/documentation/components/reference/amp-access@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@id.md
+#: /content/amp-dev/documentation/components/reference/amp-access@it.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-access@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-access@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-access@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-access@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-action-macro.md
 #: /content/amp-dev/documentation/components/reference/amp-bind.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@es.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@id.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@it.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-bind@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-byside-content.md
 #: /content/amp-dev/documentation/components/reference/amp-consent.md
 #: /content/amp-dev/documentation/components/reference/amp-date-picker.md
 #: /content/amp-dev/documentation/components/reference/amp-form.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-form@es.md
+#: /content/amp-dev/documentation/components/reference/amp-form@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@id.md
+#: /content/amp-dev/documentation/components/reference/amp-form@it.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-form@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-form@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-form@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-form@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-geo.md
 #: /content/amp-dev/documentation/components/reference/amp-gist.md
 #: /content/amp-dev/documentation/components/reference/amp-google-document-embed.md
 #: /content/amp-dev/documentation/components/reference/amp-install-serviceworker.md
 #: /content/amp-dev/documentation/components/reference/amp-list.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-list@es.md
+#: /content/amp-dev/documentation/components/reference/amp-list@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@id.md
+#: /content/amp-dev/documentation/components/reference/amp-list@it.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-list@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-list@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-list@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-list@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-live-list.md
 #: /content/amp-dev/documentation/components/reference/amp-mustache.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@es.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@id.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@it.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-mustache@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-next-page.md
 #: /content/amp-dev/documentation/components/reference/amp-script.md
 #: /content/amp-dev/documentation/components/reference/amp-selector.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@es.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@id.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@it.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-selector@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions-google.md
 #: /content/amp-dev/documentation/components/reference/amp-subscriptions.md
 #: /content/amp-dev/documentation/components/reference/amp-user-notification.md
@@ -586,24 +764,101 @@ msgid "dynamic-content"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@es.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@id.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@it.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-accordion@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-app-banner.md
 #: /content/amp-dev/documentation/components/reference/amp-base-carousel.md
 #: /content/amp-dev/documentation/components/reference/amp-carousel.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@es.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@id.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@it.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-carousel@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-collection.md
 #: /content/amp-dev/documentation/components/reference/amp-fx-flying-carpet.md
 #: /content/amp-dev/documentation/components/reference/amp-iframe.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@es.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@id.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@it.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-iframe@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-image-lightbox.md
 #: /content/amp-dev/documentation/components/reference/amp-image-slider.md
 #: /content/amp-dev/documentation/components/reference/amp-layout.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@es.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@id.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@it.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-layout@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox-gallery.md
 #: /content/amp-dev/documentation/components/reference/amp-lightbox.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@es.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@id.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@it.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-lightbox@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-orientation-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-position-observer.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@es.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@id.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@it.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-sidebar@zh_cn.md
 msgid "layout"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@es.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@id.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@it.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-3d-gltf@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-3q-player.md
 #: /content/amp-dev/documentation/components/reference/amp-anim.md
 #: /content/amp-dev/documentation/components/reference/amp-apester-media.md
@@ -617,6 +872,17 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-google-vrview-image.md
 #: /content/amp-dev/documentation/components/reference/amp-hulu.md
 #: /content/amp-dev/documentation/components/reference/amp-ima-video.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-img@es.md
+#: /content/amp-dev/documentation/components/reference/amp-img@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@id.md
+#: /content/amp-dev/documentation/components/reference/amp-img@it.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-img@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-img@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-img@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-img@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-imgur.md
 #: /content/amp-dev/documentation/components/reference/amp-izlesene.md
 #: /content/amp-dev/documentation/components/reference/amp-jwplayer.md
@@ -634,15 +900,48 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-springboard-player.md
 #: /content/amp-dev/documentation/components/reference/amp-video-iframe.md
 #: /content/amp-dev/documentation/components/reference/amp-video.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-video@es.md
+#: /content/amp-dev/documentation/components/reference/amp-video@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@id.md
+#: /content/amp-dev/documentation/components/reference/amp-video@it.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-video@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-video@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-video@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-video@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-vimeo.md
 #: /content/amp-dev/documentation/components/reference/amp-viqeo-player.md
 #: /content/amp-dev/documentation/components/reference/amp-wistia-player.md
 #: /content/amp-dev/documentation/components/reference/amp-yotpo.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@es.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@id.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@it.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-youtube@zh_cn.md
 msgid "media"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-animation.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@es.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@id.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@it.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-animation@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-date-countdown.md
 #: /content/amp-dev/documentation/components/reference/amp-date-display.md
 #: /content/amp-dev/documentation/components/reference/amp-dynamic-css-classes.md
@@ -652,12 +951,34 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-pan-zoom.md
 #: /content/amp-dev/documentation/components/reference/amp-story-auto-ads.md
 #: /content/amp-dev/documentation/components/reference/amp-story.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-story@es.md
+#: /content/amp-dev/documentation/components/reference/amp-story@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@id.md
+#: /content/amp-dev/documentation/components/reference/amp-story@it.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-story@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-story@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-story@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-story@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-timeago.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega.md
 msgid "presentation"
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ar.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@es.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@fr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@id.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@it.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ja.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ko.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@pt_br.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@ru.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@tr.md
+#: /content/amp-dev/documentation/components/reference/amp-addthis@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-beopinion.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-comments.md
 #: /content/amp-dev/documentation/components/reference/amp-facebook-like.md


### PR DESCRIPTION
I noticed that our UI is still embarassingly untranslated so I:

1. Created a "gulp extract" task to be able to extract new strings into messages.pot regularly
2. Made a lot of untranslated strings translatable
3. Ported some untranslated strings over from the original Japanese messages.po file to the new one (this also needs to be done for all other languages, but is outside of the scope of this PR).