### PR TITLE
🐛 Fix not opening navigation dropdown on latest edge browsers

### DIFF
--- a/frontend/scss/components/organisms/header.scss
+++ b/frontend/scss/components/organisms/header.scss
@@ -127,7 +127,12 @@
 
   &-main-link:hover ~ &-flyout,
   &-main-link:focus ~ &-flyout,
-  &-flyout:hover,
+  &-flyout:hover {
+    opacity: 1;
+    pointer-events: all;
+    transition: opacity 0.2s cubic-bezier(0.25, 0.1, 0.25, 1);
+  }
+
   &-flyout:focus-within {
     opacity: 1;
     pointer-events: all;


### PR DESCRIPTION
I splitted the css block that handles all :hover, :focus and :focus-within properties of the flyout navigation, because edge doesn't supports the `:focus-within` prop.
By splitting this in two, edge stops ignoring the whole block and still reveal the flyout on :hover and :focus #2532