### PR TITLE
Remove html from TOC item names

### DIFF
--- a/pages/extensions/markdown_toc_patch/__init__.py
+++ b/pages/extensions/markdown_toc_patch/__init__.py
@@ -1,0 +1,1 @@
+from markdown_toc_patch import *

--- a/pages/extensions/markdown_toc_patch/custom_toc_tree_processor.py
+++ b/pages/extensions/markdown_toc_patch/custom_toc_tree_processor.py
@@ -1,0 +1,28 @@
+from markdown import util
+from markdown.extensions.toc import TocExtension
+from markdown.extensions.toc import TocTreeprocessor
+
+class CustomTocTreeProcessor(TocTreeprocessor):
+  """
+  Since html code that may be inside the headlines causes problems in the TOC we remove them
+  """
+
+  def strip_html_from_names(self, toc_list):
+    for item in toc_list:
+      text = item.get('name', '')
+      # The markdown classes insert placeholder for html tags
+      # we simply remove those placeholders with the HTML_PLACEHOLDER_RE regex that matches those
+      text = util.HTML_PLACEHOLDER_RE.sub('', text)
+      item['name'] = text
+      if item['children']:
+        self.strip_html_from_names(item['children'])
+
+  def build_toc_div(self, toc_list):
+    self.strip_html_from_names(toc_list)
+    div = super(CustomTocTreeProcessor, self).build_toc_div(toc_list)
+    return div
+
+  @staticmethod
+  def connect_hook():
+    TocExtension.TreeProcessorClass = CustomTocTreeProcessor
+

--- a/pages/extensions/markdown_toc_patch/markdown_toc_patch.py
+++ b/pages/extensions/markdown_toc_patch/markdown_toc_patch.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from grow import extensions
+from custom_toc_tree_processor import CustomTocTreeProcessor
+
+
+class MarkdownTocPatchExtension(extensions.BaseExtension):
+  """
+  The extension class has no logic.
+  But we hook other classes when this file is loaded.
+
+  - CustomTocTreeProcessor replaces the markdown TocTreeProcessor class to remove html from toc item names
+
+  """
+  pass
+
+CustomTocTreeProcessor.connect_hook()
+

--- a/pages/extensions/markdown_toc_patch/readme.md
+++ b/pages/extensions/markdown_toc_patch/readme.md
@@ -1,0 +1,20 @@
+# amp.dev patch for markdown toc generation
+
+
+## Purpose
+
+HTML code inside the headlines can cause problems when it is included in the TOC
+For example anchor tags will break the TOCs own anchor tag!
+
+This extensions hooks into the markdown TOC extension to remove all HTML tags
+from the TOC items before the TOC is rendered.
+
+
+## Activation
+
+This extension has to be activated in the podspec.yaml
+
+```yaml
+ext:
+  - extensions.markdown_toc_patch.MarkdownTocPatchExtension 
+```

--- a/platform/config/podspec.yaml
+++ b/platform/config/podspec.yaml
@@ -30,3 +30,4 @@ ext:
 - extensions.amp_dev.AmpDevExtension
 - extensions.url_beautifier.UrlBeautifierExtension
 - extensions.jinja2_optimized_codehilite.Jinja2OptimizedCodehiliteExtension
+- extensions.markdown_toc_patch.MarkdownTocPatchExtension


### PR DESCRIPTION
Fixes https://github.com/ampproject/amp.dev/issues/2556 by removing all html tags from the headlines before using them in the TOC.

The markdown toc extension that is used by grow can not remove html tags in the TOC item names by itself. So we created a grow hook, that hooks into the markdown toc extension to perform this. 
