### PR TITLE
🎨Change component docs title to Documentation and  add < > to title tag

### DIFF
--- a/frontend/templates/views/partials/structured-data.j2
+++ b/frontend/templates/views/partials/structured-data.j2
@@ -55,7 +55,7 @@
 {% elif doc.pod_path.startswith('/content/amp-dev/documentation/examples/previews/') %}
 {% set title_prefix = _('Demo: ') %}
 {% elif doc.pod_path.startswith('/content/amp-dev/documentation/components/reference/') %}
-{% set title_prefix = _('Component: ') %}
+{% set title_prefix = _('Documentation: ') %}
 {% elif doc.pod_path.startswith('/content/amp-dev/about/success-stories/') and not 'index.html' in doc.pod_path %}
 {% set title_prefix = _('Success Story: ') %}
 {% endif %}

--- a/frontend/templates/views/partials/structured-data.j2
+++ b/frontend/templates/views/partials/structured-data.j2
@@ -10,6 +10,10 @@
 {% if title and '[=' in title %}
 {% set title = title|safe %}
 {% endif %}
+{% if doc.base.startswith('amp-') and not '_' in doc.base and not ' ' in doc.base %}
+{% set title = '<' + doc.base + '>' %}
+{% endif %}
+
 
 {% set base_url = podspec.base_urls.platform %}
 {% set canonical = doc.url %}
@@ -49,7 +53,7 @@
 {% if doc.pod_path.startswith('/content/amp-dev/documentation/examples/documentation/') %}
 {% set title_prefix = _('Example: ') %}
 {% elif doc.pod_path.startswith('/content/amp-dev/documentation/examples/previews/') %}
-{% set title_prefix = _('Example preview: ') %}
+{% set title_prefix = _('Demo: ') %}
 {% elif doc.pod_path.startswith('/content/amp-dev/documentation/components/reference/') %}
 {% set title_prefix = _('Component: ') %}
 {% elif doc.pod_path.startswith('/content/amp-dev/about/success-stories/') and not 'index.html' in doc.pod_path %}


### PR DESCRIPTION
Fixes #2491 The Docs pages for amp-components have < > in the title tag and get a new prefix Documentation/Example/Demo