### PR TITLE
♿️ Fix focus state / keyboard access for many areas

### DIFF
--- a/frontend/scss/components/atoms/sidebar-toggle.scss
+++ b/frontend/scss/components/atoms/sidebar-toggle.scss
@@ -68,10 +68,6 @@ $originalEasing: cubic-bezier(0,0,.21,1);
     display: flex;
     align-items: center;
 
-    &:focus {
-      outline: none;
-    }
-
     .label-icon {
       border-radius: 4px;
       background: color('blue-ribbon');

--- a/frontend/scss/components/molecules/filter-bubble.scss
+++ b/frontend/scss/components/molecules/filter-bubble.scss
@@ -49,7 +49,10 @@ The filter-bubble molecule is a simple button used to filter content based on th
     background: color('blue-ribbon');
     color: color('white');
   }
-  &:focus {
-    outline: none;
+
+  &-reset {
+    &:focus {
+      outline: none;
+    }
   }
 }

--- a/frontend/scss/components/molecules/language-selector.scss
+++ b/frontend/scss/components/molecules/language-selector.scss
@@ -26,18 +26,38 @@
     display: block;
   }
 
-  &-toggle {
+  &-label {
     display: flex;
     align-items: center;
+    font-size: 11px;
     border: none;
     background: none;
+
+    &:hover {
+      color: color('blue-ribbon');
+    }
   }
 
-    &-icon {
-      width: 10px;
-      height: 10px;
-      margin-left: 5px;
+  &-toggle {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    -webkit-appearance: none;
+
+    @media (min-width: 1024px) {
+      width: calc(100% - 30px);
     }
+  }
+
+  &-icon {
+    width: 10px;
+    height: 10px;
+    margin-left: 5px;
+  }
 
   &-list {
     list-style: none;
@@ -55,9 +75,13 @@
     }
 
   /* For when the selector is active */
-  &-toggle:focus ~ &-list,
   &-toggle:hover ~ &-list,
+  &-toggle:checked ~ &-list,
   &-list:hover {
+      display: block;
+  }
+
+  &-list:focus-within {
       display: block;
   }
 

--- a/frontend/scss/components/organisms/agenda.scss
+++ b/frontend/scss/components/organisms/agenda.scss
@@ -42,7 +42,6 @@
       padding: 10px 30px 15px;
       margin-bottom: 0;
       flex-grow: 1;
-      outline: none;
       color: fade_out(color('limed-spruce'), 0.57);
       background: color('athens-gray');
 
@@ -57,7 +56,6 @@
 
       &[option][selected] {
         @include agenda-button-shadow;
-        outline: none;
         border: none;
         color: color('white');
         background: color('carnation');

--- a/frontend/scss/components/organisms/burger-menu.scss
+++ b/frontend/scss/components/organisms/burger-menu.scss
@@ -15,6 +15,7 @@
 
 .#{organism('burger-menu')} {
 /* This is where the actual burger-menu starts */
+  display: none;
   position: fixed;
   top: 0;
   left: 0;
@@ -23,9 +24,6 @@
   padding: 110px 20px 80px;
   z-index: 16;
   background-color: color('white');
-  pointer-events: none;
-  opacity: 0;
-  transition: transform 0.2s ease, opacity 0.2s ease;
 
   /* The following elements are not inside the burger-menu itself */
   &-label {
@@ -34,9 +32,6 @@
     top: 12px;
     right: 20px;
     cursor: pointer;
-    &:focus {
-      outline: none;
-    }
     &.mainmenuopen {
       z-index: 1004;
     }
@@ -58,32 +53,22 @@
     height: 30px;
   }
 
-  &-input {
-    display: none;
-  }
-
   @media (min-width: 1024px) {
     display: none;
   }
 
-  /* Styles for the opened burger menu */
-  &-input:checked {
-    & + .#{organism('burger-menu')} {
-      pointer-events: auto;
-      opacity: 1;
 
-      &.mainmenuopen {
-        z-index: 1003;
-      }
+  &.mainmenuopen {
+    display: block;
+    z-index: 1003;
+  }
 
-      & ~ .ap--main {
-        max-height: calc(100vh - #{$mobileHeaderHeight} - #{$bannerHeight});
-      }
+  &.mainmenuopen ~ .ap--main {
+    max-height: calc(100vh - #{$mobileHeaderHeight} - #{$bannerHeight});
+  }
 
-      & ~ .ap--footer {
-        display: none;
-      }
-    }
+  &.mainmenuopen ~ .ap--footer {
+    display: none;
   }
 
   &-items {
@@ -126,9 +111,14 @@
         height: 36px;
         padding: 0;
         margin: 0;
-        opacity: 0;
         background: none transparent;
         cursor: pointer;
+        -webkit-appearance: none;
+
+        &:focus {
+          outline: -webkit-focus-ring-color auto 5px;
+        }
+
         &:checked {
           & ~ ul {
             display: block;

--- a/frontend/scss/components/organisms/format-explainer.scss
+++ b/frontend/scss/components/organisms/format-explainer.scss
@@ -45,7 +45,7 @@
       opacity: 0;
       visibility: hidden;
       transition: opacity 0.4s cubic-bezier(.55,0,.1,1), visibility 0.4s cubic-bezier(.55,0,.1,1), transform 0.4s cubic-bezier(.55,0,.1,1);
-      
+
       &.active {
         opacity: 1;
         visibility: visible;
@@ -144,10 +144,6 @@
     @media (min-width: 1024px) {
       margin: 0 0 1em 0;
       background: none transparent;
-    }
-
-    &:focus {
-      outline: none;
     }
 
     &.active {

--- a/frontend/scss/components/organisms/fragment-slider-controls.scss
+++ b/frontend/scss/components/organisms/fragment-slider-controls.scss
@@ -13,9 +13,6 @@
 
 
 .#{organism('fragment-slider')} {
-  input:focus {
-    outline: none;
-  }
   button {
     position: absolute;
     height: 50px;
@@ -50,9 +47,6 @@
       margin: 0;
       transform: rotate(180deg);
     }
-    &:focus {
-      outline: none;
-    }
     &.slide1 {
       display: none;
     }
@@ -62,9 +56,6 @@
     right: 10px;
     div {
       margin: 0;
-    }
-    &:focus {
-      outline: none;
     }
     &.slide3 {
       display: none;

--- a/frontend/scss/components/organisms/fragment-slider-texts.scss
+++ b/frontend/scss/components/organisms/fragment-slider-texts.scss
@@ -49,6 +49,12 @@
         div {
           opacity: 1;
         }
+
+        .#{organism('fragment-slider-component')},
+        .#{organism('fragment-slider-ctas')} a {
+          visibility: visible;
+          transition-delay: 0s;
+        }
       }
     }
 
@@ -86,21 +92,29 @@
     padding-bottom: 30px;
   }
 
-    &-component {
-      flex: 1 0 50%;
-      line-height: 1.8em;
-    }
+  &-component {
+    visibility: hidden;
+    flex: 1 0 50%;
+    line-height: 1.8em;
+    transition-delay: 400ms;
+  }
 
   &-preheadline {
     margin: 0;
   }
 
   &-ctas {
-      display: flex;
+    display: flex;
 
-      a {
-         padding: 0 1.5em 1.5em 0
+    a {
+      visibility: hidden;
+      padding: 0 1.5em 1.5em 0;
+      transition-delay: 400ms;
+
+      div {
+        transition-delay: 0s;
       }
+    }
   }
 
   &-headline {

--- a/frontend/scss/components/organisms/video-slider.scss
+++ b/frontend/scss/components/organisms/video-slider.scss
@@ -36,7 +36,6 @@
       box-shadow: 0 10px 15px 0 rgba(0,0,0,0.4);
       transition: 400ms;
       background-color: #F3F3F3;
-      outline: none;
 
       &-prev {
         background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' fill='%23005AF0'%3E%3Cpath d='M15 8.25H5.87l4.19-4.19L9 3 3 9l6 6 1.06-1.06-4.19-4.19H15v-1.5z'/%3E%3C/svg%3E");

--- a/frontend/scss/components/templates/roadmap.scss
+++ b/frontend/scss/components/templates/roadmap.scss
@@ -145,12 +145,6 @@
           opacity: 1;
         }
       }
-      &:focus {
-        outline: none;
-      }
-    }
-    &:focus {
-      outline: none;
     }
   }
 

--- a/frontend/scss/components/templates/tools.scss
+++ b/frontend/scss/components/templates/tools.scss
@@ -183,14 +183,6 @@ section.#{utility('tools')} {
           opacity: 1;
         }
       }
-
-      &:focus {
-        outline: none;
-      }
-    }
-
-    &:focus {
-      outline: none;
     }
   }
 

--- a/frontend/templates/views/partials/burger-menu.j2
+++ b/frontend/templates/views/partials/burger-menu.j2
@@ -11,7 +11,7 @@
     <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#menu"></use></svg>
   </div>
 </label>
-<input id="burger-menu" class="ap-o-burger-menu-input" type="checkbox" autocomplete="off"/>
+
 <nav class="ap-o-burger-menu" [class]="mainmenuopen ? 'ap-o-burger-menu mainmenuopen' : 'ap-o-burger-menu'">
   <ul class="ap-o-burger-menu-items">
     {# Sections #}

--- a/frontend/templates/views/partials/header.j2
+++ b/frontend/templates/views/partials/header.j2
@@ -88,13 +88,14 @@
 
     {% do doc.styles.addCssFile('/css/components/molecules/language-selector.css') %}
     <div class="ap-m-language-selector">
-      <button class="ap-m-language-selector-toggle" aria-label="{{ _('Select a language') }}">
+      <span class="ap-m-language-selector-label" aria-label="{{ _('Select a language') }}" tabindex="-1">
         <span class="ap-m-nav-link">{{ doc.locale.language|upper }}</span>
         {% do doc.icons.useIcon('/icons/angle-down-solid.svg') %}
         <div class="ap-a-ico ap-m-language-selector-icon">
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
         </div>
-      </button>
+      </span>
+      <input class="ap-m-language-selector-toggle" type="checkbox" name="language-selector">
       <div class="ap-m-language-selector-list" role="list">
         {% for locale in doc.locales if not locale == doc.locale  %}
         {% set localized_doc = doc.localize(locale) %}

--- a/pages/content/amp-dev/community/roadmap.html
+++ b/pages/content/amp-dev/community/roadmap.html
@@ -39,7 +39,7 @@ roadmap: !g.json /content/amp-dev/community/roadmap.json
           <button class="ap-m-filter-bubble {{ label | slug}} active" on="tap:AMP.setState({roadmapfilter: {activefilter: '{{ label | slug}}' } })"
           [class]="roadmapfilter.activefilter == 'all' || roadmapfilter.activefilter == '{{label|slug}}' ? 'ap-m-filter-bubble {{ label | slug}} active' : 'ap-m-filter-bubble {{ label | slug}}'">
             {{ label }}
-            <span tabindex=0 role="reset" class="ap-m-filter-bubble-reset" [class]="roadmapfilter.activefilter == '{{ label | slug}}' ? 'ap-m-filter-bubble-reset show': 'ap-m-filter-bubble-reset'" on="tap:AMP.setState({roadmapfilter: {activefilter: 'all' }})">
+            <span tabindex="-1" role="reset" class="ap-m-filter-bubble-reset" [class]="roadmapfilter.activefilter == '{{ label | slug}}' ? 'ap-m-filter-bubble-reset show': 'ap-m-filter-bubble-reset'" on="tap:AMP.setState({roadmapfilter: {activefilter: 'all' }})">
                 <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close"></use></svg>
             </span>
           </button>

--- a/pages/content/amp-dev/documentation/tools.html
+++ b/pages/content/amp-dev/documentation/tools.html
@@ -80,7 +80,7 @@ tools: !g.yaml /shared/data/tools.yaml
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#amp-{{link|lower}}"></use></svg>
           </div>
           {{ link }}
-          <div tabindex=0 role="reset"
+          <div tabindex="-1" role="reset"
             class="ap-m-filter-bubble-reset ap-a-ico"
             [class]="activeFilter.chosenFilter == '{{link|slug}}' ? 'ap-m-filter-bubble-reset ap-a-ico show': 'ap-m-filter-bubble-reset ap-a-ico'"
             on="tap:AMP.setState({activeFilter: {chosenFilter: 'none' }})">


### PR DESCRIPTION
These changes fixes most of the a11y issues from #2385 and #2587 

### Summary
- removed `outline: none;` anywhere it was possible.
- refactored **mobile-menu** and **language-selector** to be accessible by keyboard
- optimized filter bubbles to be more accessible by keyboard
- fixed fragmet-slider (use-cases page) focusing hidden slides content issue