### PR TITLE
Remove binding from email sample

### DIFF
--- a/examples/source/interactivity-dynamic-content/Advanced_Server_Request.html
+++ b/examples/source/interactivity-dynamic-content/Advanced_Server_Request.html
@@ -61,7 +61,7 @@ When the form is submitted for the first time, the `amp-list` is hidden and the 
       <div submitting>Loading ...</div>
       <div submit-success template="animal-template"></div>
     </form>
-    <amp-list id="animal-list" items="." single-item template="animal-template" src="/documentation/examples/api/echo" binding="no" layout="fixed-height" height="50">
+    <amp-list id="animal-list" items="." single-item template="animal-template" src="/documentation/examples/api/echo" layout="fixed-height" height="50">
       <div placeholder>Loading ...</div>
     </amp-list>
   </div>


### PR DESCRIPTION
`binding` was removed from email spec so removing it from sample.