### PR TITLE
🐛 Fix tool screenshots covering header on latest macos safari

### DIFF
--- a/frontend/scss/components/molecules/tools-visual.scss
+++ b/frontend/scss/components/molecules/tools-visual.scss
@@ -22,7 +22,7 @@
   max-width: 17em;
   padding: 1.5em 0;
   margin: 0;
-  transform: rotate3d(-50, 25, 5, 25deg);
+  transform: skewX(-4.5deg) scale(.98, .92);
 
   @media (min-width: 768px) {
     grid-column: 12 / -1;


### PR DESCRIPTION
Closes: #2626

<img width="897" alt="Screenshot" src="https://user-images.githubusercontent.com/22053023/61977444-c729e680-afee-11e9-8124-e495b55d21aa.png">
