### PR TITLE
Allow markdown in all html tables

### DIFF
--- a/pages/extensions/markdown_in_html/__init__.py
+++ b/pages/extensions/markdown_in_html/__init__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from grow import extensions
+from grow.documents import document_format
+from grow.extensions import hooks
+from markdown.extensions import extra
+from html_block_processor import HtmlBlockProcessor
+
+CLEAR_EXTRA_EXTENSIONS_FLAG = 'prevent_markdown_extra_auto_loading_other'
+
+
+class AddMarkdownAttributePreRenderHook(hooks.PreRenderHook):
+  """Handle the pre-render hook."""
+
+  def should_trigger(self, previous_result, doc, original_body, *_args,
+                       **_kwargs):
+    # Only trigger for non-empty documents
+    content = previous_result if previous_result else original_body
+    if content is None:
+      return False
+
+    # Only trigger for MarkdownDocuments
+    if not isinstance(doc.format, document_format.MarkdownDocumentFormat):
+      return False
+
+    return True
+
+  def trigger(self, previous_result, doc, raw_content, *_args, **_kwargs):
+    content = previous_result if previous_result else raw_content
+    return HtmlBlockProcessor().addMarkdownAttributes(content)
+
+
+class MarkdownInHtmlExtension(extensions.BaseExtension):
+  """Markdown in HTML Extension."""
+
+  def __init__(self, pod, config):
+    super(MarkdownInHtmlExtension, self).__init__(pod, config)
+
+    if config.has_key(CLEAR_EXTRA_EXTENSIONS_FLAG) and config.get(CLEAR_EXTRA_EXTENSIONS_FLAG):
+      # Clear the markdown extra extensions to prevent auto loading unwanted extensions
+      extra.extensions = []
+
+  @property
+  def available_hooks(self):
+    """Returns the available hook classes."""
+    return [
+      AddMarkdownAttributePreRenderHook,
+    ]

--- a/pages/extensions/markdown_in_html/html_block_processor.py
+++ b/pages/extensions/markdown_in_html/html_block_processor.py
@@ -1,0 +1,45 @@
+import re
+
+SOURCECODE_BLOCK = r'\[\s*sourcecode[^\]]*\][\s\S]*?\[\s*/\s*sourcecode\s*\]'
+CODE_BLOCK = r'^```[^\n][\s\S]*?^```'
+INLINE_CODE_BLOCK = r'`[^`]*`'
+TABLE_WITHOUT_MARKDOWN_BLOCK = r'(<\s*table)((?:[^>](?!markdown))*>)'
+
+TABLE_MARKDOWN_ATTRIB_PATTERN = re.compile(
+  SOURCECODE_BLOCK + '|' + CODE_BLOCK + '|' + INLINE_CODE_BLOCK + '|' + TABLE_WITHOUT_MARKDOWN_BLOCK,
+  re.IGNORECASE | re.MULTILINE)
+
+
+class HtmlBlockProcessor(object):
+  """
+    This class searches for html tags and adds the markdown="span" attribute
+    To support markdown in html block element when the markdown extra extension is active.
+    Currently only table tags are supported, but idea is that the tag names can easily be
+    specified in the configuration.
+  """
+
+  def addMarkdownAttributes(self, content):
+    """
+      Add the markdown attribute to all table tags without this attribute
+      @type content: str
+    """
+    output = ''
+    pos = 0
+    match = TABLE_MARKDOWN_ATTRIB_PATTERN.search(content)
+    while match:
+
+      output = output + content[pos:match.start(0)]
+
+      # Our expression also matches blocks that we want to skip
+      # The tag block we are interested in is marked with brackets:
+      if match.group(1):
+        output = output + match.group(1) + ' markdown="span"' + match.group(2)
+      else:
+        # no changes for blocks where we do not want to search inside
+        output = output + match.group(0)
+
+      pos = match.end(0)
+      match = TABLE_MARKDOWN_ATTRIB_PATTERN.search(content, pos)
+
+    output = output + content[pos:]
+    return output

--- a/pages/extensions/markdown_in_html/html_block_processor_test.py
+++ b/pages/extensions/markdown_in_html/html_block_processor_test.py
@@ -1,0 +1,48 @@
+"""Tests for the html block processor."""
+
+import unittest
+import sys
+import os
+
+sys.path.extend([os.path.join(os.path.dirname(__file__), '.')])
+
+from html_block_processor import HtmlBlockProcessor
+
+processor = HtmlBlockProcessor()
+
+class SourceCodeExtractorTestCase(unittest.TestCase):
+
+  def test_simple_table_block(self):
+    html = '<table>'
+    result = processor.addMarkdownAttributes(html)
+    self.assertEqual('<table markdown="span">', result)
+
+  def test_table_attributes_block(self):
+    html = '<table colspan="0">'
+    result = processor.addMarkdownAttributes(html)
+    self.assertEqual('<table markdown="span" colspan="0">', result)
+
+  def test_table_with_markdown_block(self):
+    html = '<table markdown>'
+    result = processor.addMarkdownAttributes(html)
+    self.assertEqual(html, result)
+
+  def test_table_in_inline_code_block(self):
+    html = '`<table>`'
+    result = processor.addMarkdownAttributes(html)
+    self.assertEqual(html, result)
+
+  def test_table_in_sourcecode_block(self):
+    html = '[sourcecode]<table>[/sourcecode]'
+    result = processor.addMarkdownAttributes(html)
+    self.assertEqual(html, result)
+
+  def test_table_in_code_block(self):
+    html = 'test\n' \
+           '```html\n' \
+           '<!-- ` -->\n' \
+           '<table><tr><td>block</td></tr></table>\n' \
+           '```\n' \
+           'end\n'
+    result = processor.addMarkdownAttributes(html)
+    self.assertEqual(html, result)

--- a/pages/extensions/markdown_in_html/readme.md
+++ b/pages/extensions/markdown_in_html/readme.md
@@ -1,0 +1,40 @@
+# Support markdown in html content
+
+## Purpose
+
+Python markdown supports markdown inside html block elements only when the extra extension is activated
+and the attribute "markdown" is set.
+https://python-markdown.github.io/extensions/extra/
+
+This extension automatically sets the attribute markdown="span" to all `table` tags
+when no markdown attribute is present. 
+
+Unfortunately the extra extension automatically activates quite a few other extensions.
+So this grow extension can set the list of automatically activated extension to an empty list
+when the option `prevent_markdown_extra_auto_loading_other` is set to true.
+There is an issue for python markdown: https://github.com/Python-Markdown/markdown/issues/849
+If this issue is resolved and we use a grow version that uses the new python markdown version 
+this logic can be removed. 
+
+
+## Activation
+
+First you have to enable python markdown extra extension in the podspec.yaml
+
+```yaml
+markdown:
+  extensions:
+  - kind: markdown.extensions.extra
+```
+
+The extension itself also has to be activated in the podspec.yaml.
+The following example configures this plugin to prevent the auto loading of the other extensions
+by the markdown extra extension
+
+```yaml
+ext:
+  - extensions.markdown_in_html.MarkdownInHtmlExtension:
+      prevent_markdown_extra_auto_loading_other: true
+```
+
+

--- a/platform/config/podspec.yaml
+++ b/platform/config/podspec.yaml
@@ -17,6 +17,7 @@ markdown:
   - kind: markdown.extensions.codehilite
     classes: True
     class_name: ap-m-code-snippet
+  - kind: markdown.extensions.extra
 
 ext:
 - extensions.inline_text_assets.InlineTextAssetsExtension:
@@ -31,3 +32,5 @@ ext:
 - extensions.url_beautifier.UrlBeautifierExtension
 - extensions.jinja2_optimized_codehilite.Jinja2OptimizedCodehiliteExtension
 - extensions.markdown_toc_patch.MarkdownTocPatchExtension
+- extensions.markdown_in_html.MarkdownInHtmlExtension:
+    prevent_markdown_extra_auto_loading_other: true


### PR DESCRIPTION
Fixes 1809

* Activates the markdown extra extension
* Prevent automatically loading more extensions by the extra extension
* automatically add `markdown="span"` to all html table tags in markdown docs (unless found in source code blocks)