### PR TITLE
♻️ Migrate live-blog to amp.dev

### DIFF
--- a/examples/source/news-publishing/Live_Blog/api.js
+++ b/examples/source/news-publishing/Live_Blog/api.js
@@ -1,0 +1,217 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const {setMaxAge} = require('@lib/utils/cacheHelpers');
+const SampleRenderer = require('@examples/lib/SampleRenderer');
+const {createRequestContext} = require('@lib/templates/');
+
+// eslint-disable-next-line new-cap
+const router = express.Router();
+router.use(cookieParser());
+
+const MAX_BLOG_ITEMS_NUMBER_PER_PAGE = 5;
+const BLOG_ID_PREFIX = 'post';
+const IMG_PATH = '/static/samples/img/';
+const AMP_LIVE_LIST_COOKIE_NAME = 'ABE_AMP_LIVE_LIST_STATUS';
+const EXPIRATION_DATE = 24*60*60*1000; // 1 day in ms
+const blogs = [
+  newPost('Green landscape', 'A green landscape with trees.', 'landscape_green_1280x853.jpg', 1),
+  newPost('Mountains', 'Mountains reflecting on a lake.', 'landscape_mountains_1280x657.jpg', 2),
+  newPost('Road leading to a lake', 'A road leading to a lake with mountains on the back.',
+      'landscape_lake_1280x857.jpg', 3),
+  newPost('Forested hills', 'Forested hills with a grey sky in the background.',
+      'landscape_trees_1280x960.jpg', 4),
+  newPost('Scattered houses', 'Scattered houses in a mountain village.',
+      'landscape_village_1280x853.jpg', 5),
+  newPost('Canyon', 'A deep canyon.', 'landscape_canyon_1280x1700.jpg', 6),
+  newPost('Desert', 'A desert with mountains in the background.',
+      'landscape_desert_1280x853.jpg', 7),
+  newPost('Houses', 'Colorful houses on a street.', 'landscape_houses_1280x803.jpg', 8),
+  newPost('Blue sea', 'Blue sea surrounding a cave.', 'landscape_sea_1280x848.jpg', 9),
+  newPost('Sailing ship', 'A ship sailing the sea at sunset.', 'landscape_ship_1280x853.jpg', 10),
+];
+
+SampleRenderer.use(router, async (request, response, template) => {
+  // set max-age to 15 s - the minimum refresh time for an amp-live-list
+  setMaxAge(response, 15);
+  const newStatus = await updateStatus(request, response);
+  response.send(template.render(createRequestContext(
+      request,
+      await createLiveBlogSample(request, newStatus)
+  )));
+});
+
+async function createLiveBlogSample(request, newStatus = 0) {
+  if (newStatus > blogs.length) {
+    newStatus = blogs.length;
+  }
+  const origin = request.protocol + '://' + request.get('host');
+  // generate random number of 1 to 10 new blog items
+  const blogItems = await getBlogEntries(newStatus);
+  const firstBlogId = await getFirstBlogId(request);
+  const firstItemIndex = await getBlogEntryIndexFromID(firstBlogId, blogItems);
+  const lengthCurrentPageBlog = Math.min(blogItems.length,
+      firstItemIndex+MAX_BLOG_ITEMS_NUMBER_PER_PAGE);
+  const nextPageId = await getNextPageId(firstItemIndex+MAX_BLOG_ITEMS_NUMBER_PER_PAGE, blogItems);
+  const prevPageId = await getPrevPageId(firstItemIndex);
+  const prefix = await buildPrefixPaginationUrl(origin, request.baseUrl);
+  const nextPageUrl = await buildPaginationURL(prefix, nextPageId);
+  const prevPageUrl = await buildPaginationURL(prefix, prevPageId);
+  const blogMetaData = await createMetaData(origin, request.baseUrl);
+  const disabled = prevPageUrl !== '' ? 'disabled' : '';
+
+  return {
+    timestamp: Number(new Date()),
+    // send a list of blog items
+    blogItems: blogItems.slice(firstItemIndex, lengthCurrentPageBlog),
+    pageNumber: await getPageNumberFromProductIndex(firstItemIndex),
+    prevPageUrl,
+    nextPageUrl,
+    blogMetaData,
+    disabled,
+  };
+}
+
+function updateStatus(request, response) {
+  const newStatus = readStatus(request) + 1;
+  writeStatus(response, newStatus);
+  return newStatus;
+}
+
+function readStatus(request) {
+  const cookie = request.cookies[AMP_LIVE_LIST_COOKIE_NAME];
+  if (!cookie) {
+    return 0;
+  }
+  return Number(cookie.value);
+}
+
+function writeStatus(response, newValue) {
+  response.cookie(
+      AMP_LIVE_LIST_COOKIE_NAME,
+      {value: newValue},
+      {expires: new Date(Date.now() + EXPIRATION_DATE)}
+  );
+}
+
+function getBlogEntries(size) {
+  const returnArray = [];
+  for (let i = 0; i < size; i++) {
+    returnArray.push(
+        newPost(
+            blogs[i].heading,
+            blogs[i].text,
+            blogs[i].img.split(IMG_PATH)[1],
+            i + 1
+        )
+    );
+  }
+  return returnArray;
+}
+
+function buildPrefixPaginationUrl(origin, path) {
+  return origin + path + '?from=';
+}
+
+function buildPaginationURL(urlPrefix, pageId) {
+  if (pageId !== '') {
+    return urlPrefix + pageId;
+  }
+  return '';
+}
+
+function getPageNumberFromProductIndex(index) {
+  return (index / MAX_BLOG_ITEMS_NUMBER_PER_PAGE) + 1;
+}
+
+function getBlogEntryIndexFromID(id, blogItems = []) {
+  if (id > blogItems.length) {
+    return 0;
+  }
+  return id - 1;
+}
+
+function getNextPageId(nextPageFirstItemIndex, blogItems = []) {
+  if (nextPageFirstItemIndex < blogItems.length) {
+    return `${BLOG_ID_PREFIX}${nextPageFirstItemIndex + 1}`;
+  }
+  return '';
+}
+
+function getPrevPageId(firstItemIndex) {
+  if (firstItemIndex >= MAX_BLOG_ITEMS_NUMBER_PER_PAGE) {
+    return `${BLOG_ID_PREFIX}${firstItemIndex-MAX_BLOG_ITEMS_NUMBER_PER_PAGE+1}`;
+  }
+  return '';
+}
+
+function getFirstBlogId(request) {
+  const firstItemIndex = !!request.query.from ? request.query.from : `${BLOG_ID_PREFIX}1`;
+  return Number(firstItemIndex.split(BLOG_ID_PREFIX)[1]);
+};
+
+function newPost(heading, text, img, id) {
+  return {
+    heading: heading,
+    id: id,
+    date: new Date().toLocaleDateString(),
+    text: text,
+    img: IMG_PATH + img,
+    timestamp: Number(new Date()),
+  };
+}
+
+function createMetaData(origin, baseUrl) {
+  const result = [];
+  const urlPrefix = origin + baseUrl + '/#';
+  for (let i = 0; i < blogs.length; i++) {
+    result.push({
+      '@type': 'BlogPosting',
+      'headline': blogs[i].heading,
+      'url': urlPrefix + BLOG_ID_PREFIX + (i+1),
+      'datePublished': blogs[i].timestamp,
+      'author': {
+        '@type': 'Person',
+        'sameAs': 'https://github.com/kul3r4',
+        'name': 'Chiara Chiappini',
+      },
+      'articleBody': 'Text',
+      'publisher': {
+        '@type': 'Organization',
+        'name': 'amp.dev',
+        'logo': {
+          '@type': 'ImageObject',
+          'url': origin + '/img/favicon.png',
+          'width': '512',
+          'height': '512',
+        },
+      },
+      'image': {
+        '@type': 'ImageObject',
+        'url': origin + blogs[i].img,
+        'width': '853',
+        'height': '1280',
+      },
+    });
+  }
+  return result;
+}
+
+module.exports = router;

--- a/examples/source/news-publishing/Live_Blog/index.html
+++ b/examples/source/news-publishing/Live_Blog/index.html
@@ -81,7 +81,7 @@ This is a sample template for implementing live blogs in AMP.
           "coverageEndTime": "2016-07-23T16:00:00-07:00",
           "headline": "An AMP Live Blog",
           "description": "A Live Blog implementation with AMP",
-          "liveBlogUpdate": "[% for blogItem in blogMetaData %][= blogItem | dump =][% endfor %]"
+          "liveBlogUpdate": "[% for blogItem in blogMetaData %][= blogItem | dump(2) =][% endfor %]"
         }
       </script>
       <style amp-custom>

--- a/examples/source/news-publishing/Live_Blog/index.html
+++ b/examples/source/news-publishing/Live_Blog/index.html
@@ -33,7 +33,7 @@ This is a sample template for implementing live blogs in AMP.
         {
           "@context": "http://schema.org",
           "@type": "LiveBlogPosting",
-          "url": "<% hosts.backend %>/samples_templates/live_blog/",
+          "url": "<% hosts.platform %>/documentation/examples/news-publishing/live_blog/",
           "articleBody": "This is the initial text in the blog post",
           "datePublished": "2016-09-08T23:04:28.24337",
           "about": {
@@ -42,7 +42,7 @@ This is a sample template for implementing live blogs in AMP.
             "startDate": "2016-07-23T13:00:00-07:00",
             "endDate": "2016-07-23T15:00:00-07:00",
             "name": "An AMP Live Blog",
-            "url": "<% hosts.backend %>/samples_templates/live_blog/",
+            "url": "<% hosts.platform %>/documentation/examples/news-publishing/live_blog/",
             "location": {
               "@type": "EventVenue",
               "name": "The Venue Name",
@@ -81,7 +81,7 @@ This is a sample template for implementing live blogs in AMP.
           "coverageEndTime": "2016-07-23T16:00:00-07:00",
           "headline": "An AMP Live Blog",
           "description": "A Live Blog implementation with AMP",
-          "liveBlogUpdate": [[.BlogMetadata]]
+          "liveBlogUpdate": "[% for blogItem in blogMetaData %][= blogItem | dump =][% endfor %]"
         }
       </script>
       <style amp-custom>
@@ -176,7 +176,7 @@ This is a sample template for implementing live blogs in AMP.
     <!-- Use amp-live-list to implement a live blog. The amp-live-list component regularly polls the host document for updated content and updates the end user's browser as new items become available. This means that every time a new post needs to be added, the host document should be updated by the CMS to include the update both the body and the metadata section. Find an amp-live-list example [here](/documentation/examples/components/amp-live-list/).
 
     Long blogs could use pagination to improve performance by limiting the number of blog items to be displayed on a page. To implement pagination, amp-live-list allows to add the `<div pagination></div>` element, to then insert any markup needed for pagination, for example the page number, a link to the next and previous page. -->
-    <amp-live-list [[.Disabled]]
+    <amp-live-list
     class="live-list"
     layout="container"
     data-poll-interval="15000"
@@ -185,36 +185,36 @@ This is a sample template for implementing live blogs in AMP.
 
       <button id ="live-list-update-button" update on="tap:amp-live-list-insert-blog.update">You have updates</button>
       <div items>
-        [[range .BlogItems]]
-            <div id="[[.ID]]" data-sort-time="[[.Timestamp]]">
+        [% for item in blogItems %]
+            <div id="[= item.id =]" data-sort-time="[= item.timestamp =]">
               <div class="blog">
-                <amp-img src="[[.Image]]"
+                <amp-img src="[= item.img =]"
                     layout="responsive" width="1280" height="853">
                 </amp-img>
-                <h4 class="title">[[.Heading]]</h4>
-                <p class="date">[[.Date]]</p>
-                <p class="text">[[.Text]]</p>
+                <h4 class="title">[= item.heading =]</h4>
+                <p class="date">[= item.date =]</p>
+                <p class="text">[= item.text =]</p>
                 <p class="social-share">
-                  <amp-social-share type="twitter" width="45" height="33" data-param-url="AMPDOC_URL#[[.ID]]"></amp-social-share>
-                  <amp-social-share type="facebook" width="45" height="33" data-attribution="254325784911610" data-param-url="AMPDOC_URL#[[.ID]]"></amp-social-share>
-                  <amp-social-share type="gplus" width="45" height="33" data-param-url="AMPDOC_URL#[[.ID]]"></amp-social-share>
-                  <amp-social-share type="email" width="45" height="33" data-param-url="AMPDOC_URL#[[.ID]]"></amp-social-share>
-                  <amp-social-share type="pinterest" width="45" height="33" data-param-url="AMPDOC_URL#[[.ID]]"></amp-social-share>
+                  <amp-social-share type="twitter" width="45" height="33" data-param-url="AMPDOC_URL#[= item.id =]"></amp-social-share>
+                  <amp-social-share type="facebook" width="45" height="33" data-attribution="254325784911610" data-param-url="AMPDOC_URL#[= item.id =]"></amp-social-share>
+                  <amp-social-share type="gplus" width="45" height="33" data-param-url="AMPDOC_URL#[= item.id =]"></amp-social-share>
+                  <amp-social-share type="email" width="45" height="33" data-param-url="AMPDOC_URL#[= item.id =]"></amp-social-share>
+                  <amp-social-share type="pinterest" width="45" height="33" data-param-url="AMPDOC_URL#[= item.id =]"></amp-social-share>
                 </p>
               </div>
             </div>
-          [[end]]
+          [% endfor %]
       </div>
       <div pagination>
         <nav aria-label="amp live list pagination">
           <ul class="pagination">
-            [[if .PrevPageURL]]
-              <li><a href="[[.PrevPageURL]]">Prev</a></li>
-            [[end]]
-            <li>[[.PageNumber]]</li>
-            [[if .NextPageURL]]
-              <li><a href="[[.NextPageURL]]">Next</a></li>
-            [[end]]
+            [% if prevPageUrl %]
+              <li><a href="[= prevPageUrl =]">Prev</a></li>
+            [% endif %]
+            <li>[= pageNumber =]</li>
+            [% if nextPageUrl %]
+              <li><a href="[= nextPageUrl =]">Next</a></li>
+            [% endif %]
           </ul>
         </nav>
       </div>


### PR DESCRIPTION
Migrated the backend/live-list.go from ampbyexample.com to amp.dev.
It updates the example [here](https://amp.dev/documentation/examples/news-publishing/live_blog/?format=websites).

Part of the migration/improvements in #2054.
Fixes #2609.

