### PR TITLE
Add automatic import of basic components to amp_dependencies hook

### DIFF
--- a/pages/extensions/amp_dependencies/__init__.py
+++ b/pages/extensions/amp_dependencies/__init__.py
@@ -1,72 +1,12 @@
 # -*- coding: utf-8 -*-
-import requests
-import json
-
 from grow import extensions
 from grow.documents import document, static_document
 from grow.extensions import hooks
-
-COMPONENT_VERSIONS_FILE = 'extensions/amp-component-versions.json'
-COMPONENT_VERSIONS = {}
-
-with open(COMPONENT_VERSIONS_FILE) as f:
-  # The latest component versions if no explicit version is set
-  COMPONENT_VERSIONS = json.load(f)
-
-# Default version to use if it is not in the set of known components
-DEFAULT_VERSION = '0.1'
+from amp_dependencies import AmpDependencies
+from auto_dependency_injector import AutoDependencyInjector
 
 # Used to determine where to print the script tags
 PLACEHOLDER = '__AMP__DEPENDENCIES__'
-
-
-class AmpDependencies(object):
-  def __init__(self, doc):
-    self._doc = doc
-    self._pod = doc.pod
-    # Stores registered dependencies
-    self._dependencies = {}
-    # Can be used to determine if the deps have already been injected
-    self.injected = False
-
-
-  def __repr__(self):
-    return '<AmpDependencies>'
-
-  def add(self, name, version=None, type='element'):
-    tag, _version = self._dependencies.get(name, (None, version))
-    if not _version == version:
-        raise RuntimeError('Using two versions ({}, {}) of the same dependency ({}) is not supported.'.format(version, _version, name))
-    elif version == version and tag:
-        # No need to construct the tag if is already saved
-        return ''
-
-    if version is None:
-      self._pod.logger.warning('Adding an AMP dependency ({}) without a specific version is not recommended.'.format(name))
-      version = COMPONENT_VERSIONS.get(name, DEFAULT_VERSION)
-
-    src = 'https://cdn.ampproject.org/v0/{name}-{version}.js'.format(name=name, version=version)
-    tag = '<script custom-{type}="{name}" src="{src}" async></script>'.format(type=type, name=name, src=src)
-
-    self._dependencies[name] = (tag, version)
-    return ''
-
-  def emit(self):
-    return PLACEHOLDER
-
-  def inject(self, content):
-    # Check wether the content has the placeholder
-    if PLACEHOLDER not in content or self.injected:
-      return content
-
-    self.injected = True
-
-    dependencies = ''
-    for name, details in self._dependencies.iteritems():
-      # details[0] holds the actual <script> tag
-      dependencies = dependencies + details[0]
-
-    return content.replace(PLACEHOLDER, dependencies)
 
 
 class AmpDependenciesPreRenderHook(hooks.PreRenderHook):
@@ -83,7 +23,7 @@ class AmpDependenciesPreRenderHook(hooks.PreRenderHook):
     return True
 
   def trigger(self, previous_result, doc, raw_content, *_args, **_kwargs):
-    amp_dependencies = AmpDependencies(doc)
+    amp_dependencies = AmpDependencies(doc.pod)
     setattr(doc, 'amp_dependencies', amp_dependencies)
 
     return previous_result if previous_result else raw_content
@@ -110,8 +50,11 @@ class AmpDependenciesPostRenderHook(hooks.PostRenderHook):
   def trigger(self, previous_result, doc, raw_content, *_args, **_kwargs):
     content = previous_result if previous_result else raw_content
 
-    amp_dependencies = getattr(doc, 'amp_dependencies')
-    content = amp_dependencies.inject(content)
+    amp_deps = getattr(doc, 'amp_dependencies')
+
+    AutoDependencyInjector.add_auto_imports(doc, content, amp_deps)
+
+    content = amp_deps.inject(content)
 
     return content
 

--- a/pages/extensions/amp_dependencies/amp_dependencies.py
+++ b/pages/extensions/amp_dependencies/amp_dependencies.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import os
+import json
+
+COMPONENT_VERSIONS_FILE = os.path.normpath(os.path.join(os.path.dirname(
+  os.path.abspath(__file__)), '../amp-component-versions.json'))
+COMPONENT_VERSIONS = {}
+
+with open(COMPONENT_VERSIONS_FILE) as f:
+  # The latest component versions if no explicit version is set
+  COMPONENT_VERSIONS = json.load(f)
+
+# Default version to use if it is not in the set of known components
+DEFAULT_VERSION = '0.1'
+
+# Used to determine where to print the script tags
+PLACEHOLDER = '__AMP__DEPENDENCIES__'
+
+
+class AmpDependencies(object):
+  def __init__(self, pod):
+    self._pod = pod
+    # Stores registered dependencies
+    self._dependencies = {}
+    # Can be used to determine if the deps have already been injected
+    self.injected = False
+
+  def __repr__(self):
+    return '<AmpDependencies>'
+
+  def add(self, name, version=None, type='element', no_version_warn=False):
+    _version, dep_type = self._dependencies.get(name, (version, None))
+    if not _version == version and _version is not None and version is not None:
+        raise RuntimeError('Using two versions ({}, {}) of the same dependency ({}) is not supported.'.format(version, _version, name))
+    elif _version is not None and dep_type:
+        # component is already known
+        return ''
+
+    if version is None and not no_version_warn:
+      self._pod.logger.warning('Adding an AMP dependency ({}) without a specific version is not recommended.'.format(name))
+
+    self._dependencies[name] = (version, type)
+    return ''
+
+  def emit(self):
+    return PLACEHOLDER
+
+  def inject(self, content):
+    # Check if the content has the placeholder
+    if PLACEHOLDER not in content or self.injected:
+      self._pod.logger.warning('Did not find placeholder for amp dependencies. '
+                               'Ensure you call emit() in your template head section.')
+      return content
+
+    self.injected = True
+
+    dependencies = ''
+    for name, details in self._dependencies.iteritems():
+      version = details[0]
+
+      if version is None:
+        version = COMPONENT_VERSIONS.get(name, DEFAULT_VERSION)
+
+      dep_type = details[1]
+
+      src = 'https://cdn.ampproject.org/v0/{name}-{version}.js'.format(name=name, version=version)
+      tag = '<script custom-{type}="{name}" src="{src}" async></script>'.format(type=dep_type, name=name, src=src)
+
+      dependencies = dependencies + tag
+
+    return content.replace(PLACEHOLDER, dependencies)

--- a/pages/extensions/amp_dependencies/amp_dependencies.py
+++ b/pages/extensions/amp_dependencies/amp_dependencies.py
@@ -29,15 +29,15 @@ class AmpDependencies(object):
     return '<AmpDependencies>'
 
   def add(self, name, version=None, type='element', no_version_warn=False):
+    if version is None and not no_version_warn:
+      self._pod.logger.warning('Adding an AMP dependency ({}) without a specific version is not recommended.'.format(name))
+
     _version, dep_type = self._dependencies.get(name, (version, None))
     if not _version == version and _version is not None and version is not None:
         raise RuntimeError('Using two versions ({}, {}) of the same dependency ({}) is not supported.'.format(version, _version, name))
     elif _version is not None and dep_type:
         # component is already known
         return ''
-
-    if version is None and not no_version_warn:
-      self._pod.logger.warning('Adding an AMP dependency ({}) without a specific version is not recommended.'.format(name))
 
     self._dependencies[name] = (version, type)
     return ''

--- a/pages/extensions/amp_dependencies/amp_dependencies_test.py
+++ b/pages/extensions/amp_dependencies/amp_dependencies_test.py
@@ -1,0 +1,97 @@
+"""Tests for the source code exporter."""
+
+import unittest
+import sys
+import os
+
+from grow.pods import pods
+
+sys.path.extend([os.path.join(os.path.dirname(__file__), '.')])
+
+from amp_dependencies import AmpDependencies
+
+test_dir = os.path.join(os.path.dirname(__file__), 'non_existing')
+test_pod = pods.Pod(test_dir)
+
+
+class AmpDependenciesTestCase(unittest.TestCase):
+
+  def test_add_new_component(self):
+    amp_deps = AmpDependencies(test_pod)
+    amp_deps.add('amp-anim', '0.1')
+    self.assertEquals(1, len(amp_deps._dependencies))
+    version, dep_type = amp_deps._dependencies.get('amp-anim')
+    self.assertEquals('0.1', version)
+    self.assertEquals('element' , dep_type)
+
+  def test_add_new_template(self):
+    amp_deps = AmpDependencies(test_pod)
+    amp_deps.add('amp-mustache', '0.2', 'template')
+    self.assertEquals(1, len(amp_deps._dependencies))
+    version, dep_type = amp_deps._dependencies.get('amp-mustache')
+    self.assertEquals('0.2', version)
+    self.assertEquals('template' , dep_type)
+
+  def test_add_same_twice(self):
+    amp_deps = AmpDependencies(test_pod)
+    amp_deps.add('amp-anim', '0.1')
+    amp_deps.add('amp-anim', '0.1')
+    self.assertEquals(1, len(amp_deps._dependencies))
+
+  def test_add_other_version(self):
+    amp_deps = AmpDependencies(test_pod)
+    amp_deps.add('amp-anim', '0.1')
+    try:
+      amp_deps.add('amp-anim', '0.2')
+    except RuntimeError:
+      # expected
+      return
+    self.fail('no exception')
+
+  def test_add_none_first(self):
+    amp_deps = AmpDependencies(test_pod)
+    amp_deps.add('amp-anim', None)
+    amp_deps.add('amp-anim', '99.9')
+    self.assertEquals(1, len(amp_deps._dependencies))
+    _version, dep_type = amp_deps._dependencies.get('amp-anim')
+    self.assertEquals('99.9', _version)
+
+  def test_add_none_second(self):
+    amp_deps = AmpDependencies(test_pod)
+    amp_deps.add('amp-anim', '99.9')
+    amp_deps.add('amp-anim', None)
+    self.assertEquals(1, len(amp_deps._dependencies))
+    _version, dep_type = amp_deps._dependencies.get('amp-anim')
+    self.assertEquals('99.9', _version)
+
+  def test_emit_and_inject(self):
+    amp_deps = AmpDependencies(test_pod)
+    amp_deps.add('amp-anim', '99.9')
+    amp_deps.add('amp-mustache', '77.7', 'template')
+
+    content = amp_deps.emit()
+    content = amp_deps.inject(content)
+    self.assertEquals('<script custom-element="amp-anim" '
+                      'src="https://cdn.ampproject.org/v0/amp-anim-99.9.js" async></script>'
+                      '<script custom-template="amp-mustache" '
+                      'src="https://cdn.ampproject.org/v0/amp-mustache-77.7.js" async></script>',
+                      content)
+
+  def test_emit_and_inject_with_default_version(self):
+    amp_deps = AmpDependencies(test_pod)
+    amp_deps.add('amp-anim')
+
+    content = amp_deps.emit()
+    content = amp_deps.inject(content)
+    self.assertEquals('<script custom-element="amp-anim" '
+                      'src="https://cdn.ampproject.org/v0/amp-anim-0.1.js" async></script>',
+                      content)
+
+  def test_inject_without_emit(self):
+    amp_deps = AmpDependencies(test_pod)
+    amp_deps.add('amp-anim', '0.1')
+    amp_deps.add('amp-mustache', '0.2', 'template')
+
+    content = amp_deps.inject('')
+    self.assertEquals('', content)
+

--- a/pages/extensions/amp_dependencies/auto_dependency_injector.py
+++ b/pages/extensions/amp_dependencies/auto_dependency_injector.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+import re
+
+from grow.documents import document, static_document
+from amp_dependencies import AmpDependencies
+
+# we only auto import amp-anim, amp-youtube and amp-iframe
+ELEMENT_REGEX = re.compile(r"<(amp-(?:anim|youtube|iframe)*?)(>|\s)")
+PRE_CODE_REGEX = re.compile(r"<pre(?:\s[^>]*)?>.+?</pre>|<code(?:\s[^>]*)?>.+?</code>")
+COMMENTS_REGEX = re.compile(r"<!--.*?-->", re.DOTALL | re.MULTILINE)
+
+
+class AutoDependencyInjector(object):
+
+  @staticmethod
+  def add_auto_imports(doc, content, amp_dependencies):
+    """
+    :type doc: document.Document
+    :type content: basestring
+    :type amp_dependencies: AmpDependencies
+    """
+
+    if not AutoDependencyInjector.should_do_auto_import(doc, content):
+      return
+
+    dependencies = AutoDependencyInjector.find_dependencies(content)
+
+    for dependency in dependencies:
+      # calling add without version will use an existing version, or the default version
+      # we explicitly disable any warning output for the missing version
+      amp_dependencies.add(dependency, no_version_warn=True)
+
+  @staticmethod
+  def should_do_auto_import(doc, content):
+    """
+    :type doc: document.Document
+    :type content: basestring
+    :rtype: bool
+    """
+    # Do not run for empty documents
+    if content is None:
+      return False
+
+    # Check that it's not a StaticDocument
+    if isinstance(doc, static_document.StaticDocument):
+      return False
+
+    # Check if the document opted out of injection
+    if not doc.fields.get('$$injectAmpDependencies', True):
+      return False
+
+    # Quick check if the page is really a AMP page
+    if not any(marker in content for marker in ['<html amp', '<html ⚡']):
+      return False
+
+    # And has a head element
+    if '</head>' not in content:
+      return False
+
+    return True
+
+  @staticmethod
+  def find_dependencies(content):
+    """Checks the generated output for possible AMP dependencies."""
+
+    # Remove code snippets from content before searching for deps
+    stripped_content = re.sub(PRE_CODE_REGEX, '', content)
+    # Remove html comments
+    stripped_content = re.sub(COMMENTS_REGEX, '', stripped_content)
+
+    dependencies = []
+
+    # Finds all allowed <amp-> component tags
+    for element in re.findall(ELEMENT_REGEX, stripped_content):
+      # The first capturing group will be the component name
+      component_name = element[0]
+      dependencies.append(component_name)
+
+    return dependencies
+

--- a/pages/extensions/amp_dependencies/readme.md
+++ b/pages/extensions/amp_dependencies/readme.md
@@ -1,0 +1,32 @@
+# amp.dev component dependency injection
+
+
+## Purpose
+
+This hook inserts the scripts for the used amp component dependencies.
+
+In you template head section call `{{ doc.amp_dependencies.emit() }}` 
+at the position where the dependency scripts shall be added.
+
+You need to add the component dependency explicit in the templates or the content with this code: 
+`{% do doc.amp_dependencies.add('amp-bind', '0.1') %}`
+
+For template dependencies you have to call:
+`{% do doc.amp_dependencies.add('amp-mustache', '0.2', 'template') %}`
+
+When different versions are added for the same component in the context of a page there will be an error.
+Otherwise the hook ensures that each component is only imported once.
+
+For the basic components `amp-anim`, `amp-iframe` and `amp-youtube` no explicit dependency declaration is needed
+to make writing documentation with videos and animation more easy.
+But if you use those components in templates you should still explicitly add the dependency.
+
+
+## Activation
+
+This extension has to be activated in the podspec.yaml
+
+```yaml
+ext:
+  - extensions.amp_dependencies.AmpDependenciesExtension
+```


### PR DESCRIPTION
Fix https://github.com/ampproject/amp.dev/issues/2644

The amp-dependencies plugin now automatically imports the basic components `amp-anim`, `amp-iframe` and `amp-youtube`

The logic was also improved so that you now can add a dependency without a version and afterwards add a dependency with a version which will be used