### PR TITLE
♻️ Use RCS string replace over DOM method

### DIFF
--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -387,7 +387,7 @@ function minifyPages() {
           try {
             // Shorten selectors
             rcs.fillLibraries(minifiedCss, {prefix: '-'});
-            html = rcs.replace.html(html);
+            html = rcs.replace.string(html);
             console.log(`[MINIFY_PAGES]: Minified ${page.relative}`);
           } catch (e) {
             console.error('[MINIFY_PAGES]:', page.relative, e);


### PR DESCRIPTION
Finally *really* unblocks #2594 and #2593.

Rewriting the CSS selectors was still using a DOM implementation and therefore broke SSR tags. As all our selectors are prefixed with `ap--` using the in addition faster string based method should be fine, as a quick check showed.