### PR TITLE
🐛 Run smoke-tests before running deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,8 @@ jobs:
     script: scripts/unbuffer.sh gulp buildPages --locales zh_CN
   - stage: deploy
     env: APP_ENV=staging
-    script:
+    before_script:
     - scripts/unbuffer.sh gulp buildFinalize
     - scripts/unbuffer.sh npm run smoke-test
+    script:
     - gcloud app deploy --project=amp-dev-staging --quiet --version=1


### PR DESCRIPTION
Moves smoke-tests to `before_script` phase as any command exiting with 0 there will immediately exit the build. 

All commands in `script` still run if a preceeding command failed which trigger a deployment even if the tests failed currently.