### PR TITLE
Update signed-exchange.md

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/signed-exchange.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/signed-exchange.md
@@ -130,7 +130,11 @@ content-type: application/signed-exchange;v=b3
 ```
 
 [tip type="important"]
-The `v=b3` version string is the current version. This version will change. 
+The `v="1..100"` in the request will change. Do not match on this exact string; instead split on `;` and look for `google`.
+[/tip]
+
+[tip type="important"]
+The `v=b3` version string in the response is the current version as of August 2019. This version will change. 
 [/tip]
 
 The bulk of the response should be your AMP page (in plaintext). There's a small binary header, and, if the page is >16kb, a few binary bytes sprinkled throughout.

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/signed-exchange.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/signed-exchange.md
@@ -117,10 +117,10 @@ See [`packager.js`](https://github.com/ampproject/docs/blob/future/platform/lib/
 
 ### Testing
 
-Verify that your staging site returns the content with the added MIME type `application/signed-exchange` when provided with the correct request headers. In the below example, replace `staging.example.com` with your staging server.
+Verify that your staging site responds with content of MIME type `application/signed-exchange` when specified by the HTTP request. In the below example, replace `staging.example.com` with your staging server.
 
 ```sh
-$ curl -si -H 'amp-cache-transform: google' -H 'accept: application/signed-exchange;v=b3;q=0.9,*/*;q=0.8' https://staging.example.com/ | less
+$ curl -si -H 'amp-cache-transform: google;v="1..100"' -H 'accept: application/signed-exchange;v=b3;q=0.9,*/*;q=0.8' https://staging.example.com/ | less
 ```
 
 This command should return this line (amongst others):
@@ -135,21 +135,27 @@ The `v=b3` version string is the current version. This version will change.
 
 The bulk of the response should be your AMP page (in plaintext). There's a small binary header, and, if the page is >16kb, a few binary bytes sprinkled throughout.
 
-You can also test with the more complete accept header sent by Chrome:
-
-```sh
-$ curl -si -H 'amp-cache-transform: google' -H 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3' https://staging.example.com/ | less
-```
-
 The [`dump-signedexchange` tool](https://github.com/WICG/webpackage/blob/master/go/signedexchange/README.md#installation) can be used to inspect the response:
 
 ```sh
-$ curl -s --output - -H 'amp-cache-transform: google' -H 'accept: application/signed-exchange;v=b3;q=0.9,*/*;q=0.8' https://staging.example.com/ > example.sxg
+$ curl -s --output - -H 'amp-cache-transform: google;v="1..100"' -H 'accept: application/signed-exchange;v=b3;q=0.9,*/*;q=0.8' https://staging.example.com/ > example.sxg
 $ dump-signedexchange -i example.sxg
 format version: 1b3
 ```
 
 (Note that the `-verify` switch will not work at this point because the required certificates are not on the `https://example.com/` server.)
+
+Verify that the response *always* include the `Vary` header with the value `Accept,AMP-Cache-Transform` (irrespective of whether the MIME type is `text/html`, `application/signed-exchange`, or something else:
+
+```sh
+$ curl -si https://staging.example.com/ | less
+```
+
+This command should return this line (amongst others):
+
+```txt
+Vary: Accept,AMP-Cache-Transform
+```
 
 ## Deploy packager to production
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/signed-exchange.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/signed-exchange.md
@@ -117,24 +117,24 @@ See [`packager.js`](https://github.com/ampproject/docs/blob/future/platform/lib/
 
 ### Testing
 
-Verify that your staging site responds with content of MIME type `application/signed-exchange` when specified by the HTTP request. In the below example, replace `staging.example.com` with your staging server.
+Verify that your staging site responds with content of MIME type `application/signed-exchange` when specified by the HTTP request. For example (replace `staging.example.com` with your staging server):
 
 ```sh
 $ curl -si -H 'amp-cache-transform: google;v="1..100"' -H 'accept: application/signed-exchange;v=b3;q=0.9,*/*;q=0.8' https://staging.example.com/ | less
 ```
 
-This command should return this line (amongst others):
+The output must include this line:
 
 ```txt
 content-type: application/signed-exchange;v=b3
 ```
 
 [tip type="important"]
-The `v="1..100"` in the request will change. Do not match on this exact string; instead split on `;` and look for `google`.
+The `v="1..100"` in the request is a placeholder. Do not match on this exact value; instead, as [described in the amppackager installation instructions](https://github.com/ampproject/amppackager/blob/master/README.md#productionizing), check for the existence of the `amp-cache-transform` header only, and ignore the value.
 [/tip]
 
 [tip type="important"]
-The `v=b3` version string in the response is the current version as of August 2019. This version will change. 
+The `v=b3` version string in the response is the version as of August 2019. This version will change. 
 [/tip]
 
 The bulk of the response should be your AMP page (in plaintext). There's a small binary header, and, if the page is >16kb, a few binary bytes sprinkled throughout.
@@ -155,10 +155,10 @@ Verify that the response *always* include the `Vary` header with the value `Acce
 $ curl -si https://staging.example.com/ | less
 ```
 
-This command should return this line (amongst others):
+This output must include this line:
 
 ```txt
-Vary: Accept,AMP-Cache-Transform
+vary: Accept,AMP-Cache-Transform
 ```
 
 ## Deploy packager to production


### PR DESCRIPTION
Two substantive changes + wording cleanup. The substantive changes:

1. Change the `amp-cache-transform` header to include the version parameter `v`. This is always issued, and some developers thought it was sufficient to do a strict string match on `google`, which is not sufficient. A "large" version range is used in an attempt to ensure the doc remains accurate for as long as possible. It's still possible for this test to succeed but for indexing to fail if the version of the response isn't acceptable to the indexing system, but I'm not sure how to fix this without some laborious explanation. (Also, I'm not sure where the currently acceptable versions are documented.)
2. Add the test that `vary: accept,amp-cache-transform` should always be returned. This is mentioned in e.g. https://github.com/ampproject/amppackager/blob/releases/README.md but didn't make it to this doc.

Also some separate wording changes to the first paragraph that I think are improvements, but happy to drop if you disagree.

/cc @sebastianbenz @twifkak 