### PR TITLE
New meta tags (locale, format) that can be used for filtering in Google CSE

### DIFF
--- a/frontend/templates/views/partials/structured-data.j2
+++ b/frontend/templates/views/partials/structured-data.j2
@@ -113,3 +113,8 @@
 <meta property="og:image" content="{{ base_url }}{{ sharing_images.wide }}">
 <meta property="og:image:width" content="600">
 <meta property="og:image:height" content="314">
+
+{# meta tags for amp.dev search filtering #}
+{% set supported_formats = ','.join(doc.formats or doc.collection.formats or ['websites', 'stories', 'ads', 'email']) %}
+<meta name="amp-supported-formats" content="{{supported_formats}}">
+<meta name="amp-dev-locale" content="{{doc.locale}}">


### PR DESCRIPTION
Once the new meta tags are inside the Google index for all pages, those tags can be used to filter search results in Google Custom Search (`more:pagemap:metatags-xxx:yyyy`)
This will help to implement a better search (#2705).
This change can and should be launched before the search functionality, as long as we will be using Google Custom Search. For other search solutions this change might not be needed.