### PR TITLE
♻️ Migrate amp-user-notification example backend to amp.dev

### DIFF
--- a/examples/source/1.components/amp-user-notification/api.js
+++ b/examples/source/1.components/amp-user-notification/api.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+examples.use(express.json());
+const DISMISSED_NOTIFICATIONS = {};
+
+/**
+ * AMP will make a CORS GET request to this URL to determine whether
+ * the notification should be shown. The AMP runtime will append the elementId and
+ * ampUserId query string fields to the href provided on the data-show-if-href
+ * attribute.
+ */
+examples.get('/show', (req, res) => {
+  const userId = req.query.ampUserId;
+  const notificationId = req.query.elementId;
+  const showNotification = shouldShowNotification(notificationId, userId);
+  res.json({
+    'showNotification': showNotification,
+  });
+});
+
+/**
+ * AMP will make a CORS POST request to this URL transmitting the elementId
+ * and ampUserId only when the user dismisses the notification.
+ */
+examples.post('/dismiss', (req, res) => {
+  const userId = req.body.ampUserId;
+  const notificationId = req.body.elementId;
+  dismissNotification(notificationId, userId);
+  res.json({});
+});
+
+/**
+ * Returns true if the notification should be shown for the user
+ * and notificationId
+ */
+function shouldShowNotification(notificationId, userId) {
+  const user = DISMISSED_NOTIFICATIONS[userId];
+  if (!user) {
+    return true;
+  }
+  return !user[notificationId];
+}
+
+/**
+ * Dismisses further notifications for the user and notificationId
+ */
+function dismissNotification(notificationId, userId) {
+  let user = DISMISSED_NOTIFICATIONS[userId];
+  if (!user) {
+    user = {};
+    DISMISSED_NOTIFICATIONS[userId] = user;
+  }
+  user[notificationId] = true;
+};
+
+module.exports = examples;

--- a/examples/source/1.components/amp-user-notification/index.html
+++ b/examples/source/1.components/amp-user-notification/index.html
@@ -72,8 +72,8 @@ author: sebastianbenz
       id="my-notification-with-server-endpoint"
       class="sample-notification"
       layout="nodisplay"
-      data-show-if-href="https://rocky-sierra-1919.herokuapp.com/amp-user-notification/api/show?timestamp=TIMESTAMP"
-      data-dismiss-href="https://rocky-sierra-1919.herokuapp.com/amp-user-notification/api/echo/post">
+      data-show-if-href="<% base_path %>/show?timestamp=TIMESTAMP"
+      data-dismiss-href="<% base_path %>/echo/post">
       This is an amp-user-notification. It uses a backend service to verify if the notification has to be shown.
       <button on="tap:my-notification.dismiss">I accept</button>
   </amp-user-notification>


### PR DESCRIPTION
Migrated the amp-user-notification example backend from herokuapp.com to amp.dev.
It updates the example [here](https://amp.dev/documentation/examples/components/amp-user-notification/).

Part of the migration/improvements in #2054.