### PR TITLE
Revert New meta tags (locale, format) that can be used for filtering in Google CSE

### DIFF
--- a/frontend/templates/views/partials/structured-data.j2
+++ b/frontend/templates/views/partials/structured-data.j2
@@ -113,8 +113,3 @@
 <meta property="og:image" content="{{ base_url }}{{ sharing_images.wide }}">
 <meta property="og:image:width" content="600">
 <meta property="og:image:height" content="314">
-
-{# meta tags for amp.dev search filtering #}
-{% set supported_formats = ','.join(doc.formats or doc.collection.formats or ['websites', 'stories', 'ads', 'email']) %}
-<meta name="amp-supported-formats" content="{{supported_formats}}">
-<meta name="amp-dev-locale" content="{{doc.locale}}">


### PR DESCRIPTION
Reverts ampproject/amp.dev#2721. It seems as if the [validator](https://travis-ci.org/ampproject/amp.dev/jobs/568902483#L870) doesn't like them 😅 