### PR TITLE
🔧 Add datastore scope to GCE instance templates

### DIFF
--- a/gulpfile.js/deploy.js
+++ b/gulpfile.js/deploy.js
@@ -126,7 +126,8 @@ function instanceTemplateCreate() {
   return sh(`gcloud compute instance-templates create-with-container ${config.instance.template} \
                  --container-image ${config.image.current} \
                  --machine-type ${config.instance.machine} \
-                 --tags http-server,https-server`);
+                 --tags http-server,https-server \
+                 --scopes default,datastore`);
 }
 
 /**


### PR DESCRIPTION
Second try after #2719. This time with `default` scope explicitly assigned additionally to `datastore` according to the [gcloud docs](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--scopes).