### PR TITLE
♻️ Migrate amp-recaptcha-input example backend to amp.dev

### DIFF
--- a/examples/source/1.components/amp-recaptcha-input/api.js
+++ b/examples/source/1.components/amp-recaptcha-input/api.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+const fetch = require('node-fetch');
+const multer = require('multer');
+const upload = multer();
+const credentials = require('@lib/utils/credentials');
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+examples.use(express.json());
+examples.use(express.urlencoded({
+  extended: true,
+}));
+
+const RECAPTCHA_SECRET = 'recaptcha_secret';
+
+examples.post('/api/recaptcha', upload.array(), async (req, res) => {
+  if (!req.body || !req.body.recaptcha_token) {
+    res.status(400).json({
+      message: 'You must provide a recaptcha token.',
+    });
+    return;
+  }
+
+  // get key from gcloud datastore
+  let secret;
+  try {
+    secret = await credentials.get(RECAPTCHA_SECRET);
+  } catch (error) {
+    res.status(500).json({
+      message: 'Error looking up recaptcha secret.',
+    });
+    return;
+  }
+
+  const recaptchaTask = async () => {
+    const params = new URLSearchParams();
+    params.append('secret', secret);
+    params.append('response', req.body.recaptcha_token);
+    params.append('remoteip', req.ip);
+
+    const response = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+      method: 'POST',
+      body: params,
+    }).then((response) => response.json());
+
+    if (!response.success) {
+      res.status(500).json({
+        message: 'Error on recaptcha server verification. Uncessful response from recaptcha.',
+      });
+      return;
+    }
+
+    // Add some of the parameters from the form submission
+    response.term = req.body.term;
+    response.recaptcha_token = req.body.recaptcha_token;
+
+    res.status(200).json(response);
+  };
+  recaptchaTask().catch(() => {
+    res.status(500).json({
+      message: 'Error on recaptcha server verification',
+    });
+  });
+});
+
+module.exports = examples;

--- a/examples/source/1.components/amp-recaptcha-input/index.html
+++ b/examples/source/1.components/amp-recaptcha-input/index.html
@@ -71,14 +71,14 @@
 
   <!-- ## Basic usage -->
     <!-- POST Form request, that responds with the resolved recaptcha items. See the [reference documentation](https://amp.dev/documentation/components/amp-recaptcha-input.html) for a walkthrough on the corresponding `grecaptcha` calls. -->
-  <form id="amp-recaptcha-input-form" method="POST" action-xhr="https://torch2424-amp-glitch-express.glitch.me/api/recaptcha" target="_top">
+  <form id="amp-recaptcha-input-form" method="POST" action-xhr="/documentation/examples/components/amp-recaptcha-input/api/recaptcha" target="_top">
     <fieldset>
       <label>
         <span>Search for</span>
         <input type="search" name="term" required>
       </label>
       <input name="submit-button" type="submit" value="Search">
-      <amp-recaptcha-input layout="nodisplay" name="recaptcha_token" data-sitekey="6LebBGoUAAAAAHbj1oeZMBU_rze_CutlbyzpH8VE" data-action="recaptcha_example">
+      <amp-recaptcha-input layout="nodisplay" name="recaptcha_token" data-sitekey="6LfcQ7IUAAAAAIv1KcgqyExGK0v8dLJtvV_Q6xD-" data-action="recaptcha_example">
       </amp-recaptcha-input>
     </fieldset>
 


### PR DESCRIPTION
Migrated the amp-recaptcha-input example backend from glitch.com to amp.dev.
It updates the example [here](https://amp.dev/documentation/examples/components/amp-recaptcha-input/).

Part of the migration/improvements in #2054.

Fixes #1601.