### PR TITLE
Rewrite pod internal links in <a href to site links

### DIFF
--- a/pages/extensions/internal_links/__init__.py
+++ b/pages/extensions/internal_links/__init__.py
@@ -6,6 +6,10 @@ from pod_internal_link_rewriter import PodInternalLinkRewriter
 class PodInternalLinkPostRenderHook(hooks.PostRenderHook):
   """Handle the post-render hook."""
 
+  def __init__(self, extension):
+    super(PodInternalLinkPostRenderHook, self).__init__(extension)
+    self.link_cache = extension.pod.podcache.get_object_cache('pod_site_link_map')
+
   def should_trigger(self, previous_result, doc, original_body, *_args,
                      **_kwargs):
     content = previous_result if previous_result else original_body
@@ -21,7 +25,7 @@ class PodInternalLinkPostRenderHook(hooks.PostRenderHook):
   def trigger(self, previous_result, doc, raw_content, *_args, **_kwargs):
     content = previous_result if previous_result else raw_content
 
-    link_rewriter = PodInternalLinkRewriter(doc);
+    link_rewriter = PodInternalLinkRewriter(doc, self.link_cache);
     content = link_rewriter.rewrite_pod_internal_links(content)
 
     return content

--- a/pages/extensions/internal_links/__init__.py
+++ b/pages/extensions/internal_links/__init__.py
@@ -1,0 +1,40 @@
+from grow import extensions
+from grow.documents import static_document
+from grow.extensions import hooks
+from pod_internal_link_rewriter import PodInternalLinkRewriter
+
+class PodInternalLinkPostRenderHook(hooks.PostRenderHook):
+  """Handle the post-render hook."""
+
+  def should_trigger(self, previous_result, doc, original_body, *_args,
+                     **_kwargs):
+    content = previous_result if previous_result else original_body
+    if content is None:
+      return False
+
+    # Check that it's not a StaticDocument
+    if isinstance(doc, static_document.StaticDocument):
+      return False
+
+    return True
+
+  def trigger(self, previous_result, doc, raw_content, *_args, **_kwargs):
+    content = previous_result if previous_result else raw_content
+
+    link_rewriter = PodInternalLinkRewriter(doc);
+    content = link_rewriter.rewrite_pod_internal_links(content)
+
+    return content
+
+
+class PodInternalLinkExtension(extensions.BaseExtension):
+
+  def __init__(self, pod, config):
+    super(PodInternalLinkExtension, self).__init__(pod, config)
+
+  @property
+  def available_hooks(self):
+    """Returns the available hook classes."""
+    return [
+      PodInternalLinkPostRenderHook,
+    ]

--- a/pages/extensions/internal_links/pod_internal_link_rewriter.py
+++ b/pages/extensions/internal_links/pod_internal_link_rewriter.py
@@ -1,0 +1,87 @@
+import os
+import re
+import traceback
+from grow.pods.pods import Pod
+from grow.documents.document import Document
+
+# find all <a href without a : in the link and not ending with /
+LINK_PATTERN = re.compile(r'<a\s+(?:[^>]+\s)?href\s*=\s*"((?:[^"#?](?!:))*?[^"/])((?:\?[^"]*)?(?:#[^"]*)?)"',
+                          re.IGNORECASE)
+
+
+class PodInternalLinkRewriter(object):
+
+  pod = None  # type: Pod
+
+  def __init__(self, doc):
+    """
+    :type doc: Document
+    """
+    self.doc = doc
+    self.pod = doc.pod
+
+  def rewrite_pod_internal_links(self, content):
+    """
+    :type content: str
+    """
+    try:
+      pos = 0
+      result = ''
+
+      match = LINK_PATTERN.search(content)
+      while match:
+        result = result + content[pos: match.start(1)]
+
+        # group 1 is the link, group 2 is the optional query and anchor part
+        result = result + self.rewrite_link(match.group(1), match.group(2))
+        result = result + content[match.end(2):match.end(0)]
+
+        pos = match.end(0)
+        match = LINK_PATTERN.search(content, match.end(0))
+
+      result = result + content[pos: ]
+      return result
+
+    except Exception as err:
+      stack = traceback.format_exc()
+      self.pod.logger.error('Error while trying to rewrite internal links for doc {}: {}\n{}'
+                            .format(self.doc.pod_path, err, stack))
+      return content
+
+  def rewrite_link(self, internal_link, query_and_anchor):
+    """
+    :type query_and_anchor: str
+    :type internal_link: str
+    """
+    try:
+      internal_path = internal_link
+
+      if not internal_path.startswith('/'):
+        internal_path = os.path.abspath(os.path.join(
+          PodInternalLinkRewriter.get_folder(self.doc.pod_path), internal_path))
+
+      target_doc = self.pod.get_doc(internal_path, self.doc.locale)
+
+      if not target_doc.exists:
+        return internal_link
+
+      result = target_doc.url.path
+
+    except Exception as err:
+      self.pod.logger.warn('Unable to rewrite internal link {} in {}'.format(internal_link, self.doc.pod_path))
+      result = internal_link
+
+    if query_and_anchor:
+      result = result + query_and_anchor
+    return result
+
+
+  @staticmethod
+  def get_folder(path):
+    """
+    :type path: str
+    """
+    idx = path.rfind('/')
+    if idx < 0:
+      return path
+    return path[:idx]

--- a/pages/extensions/internal_links/pod_internal_link_rewriter.py
+++ b/pages/extensions/internal_links/pod_internal_link_rewriter.py
@@ -3,6 +3,7 @@ import re
 import traceback
 from grow.pods.pods import Pod
 from grow.documents.document import Document
+from grow.cache.object_cache import ObjectCache
 
 # find all <a href without a : in the link and not ending with /
 LINK_PATTERN = re.compile(r'<a\s+(?:[^>]+\s)?href\s*=\s*"((?:[^"#?](?!:))*?[^"/])((?:\?[^"]*)?(?:#[^"]*)?)"',
@@ -13,12 +14,14 @@ class PodInternalLinkRewriter(object):
 
   pod = None  # type: Pod
 
-  def __init__(self, doc):
+  def __init__(self, doc, link_cache):
     """
     :type doc: Document
+    :type link_cache: ObjectCache
     """
     self.doc = doc
     self.pod = doc.pod
+    self.link_cache = link_cache
 
   def rewrite_pod_internal_links(self, content):
     """
@@ -54,18 +57,7 @@ class PodInternalLinkRewriter(object):
     :type internal_link: str
     """
     try:
-      internal_path = internal_link
-
-      if not internal_path.startswith('/'):
-        internal_path = os.path.abspath(os.path.join(
-          PodInternalLinkRewriter.get_folder(self.doc.pod_path), internal_path))
-
-      target_doc = self.pod.get_doc(internal_path, self.doc.locale)
-
-      if not target_doc.exists:
-        return internal_link
-
-      result = target_doc.url.path
+      result = self.get_site_link(internal_link)
 
     except Exception as err:
       self.pod.logger.warn('Unable to rewrite internal link {} in {}'.format(internal_link, self.doc.pod_path))
@@ -75,6 +67,22 @@ class PodInternalLinkRewriter(object):
       result = result + query_and_anchor
     return result
 
+  def get_site_link(self, internal_link):
+    internal_path = internal_link
+    if not internal_path.startswith('/'):
+      internal_path = os.path.abspath(os.path.join(
+        PodInternalLinkRewriter.get_folder(self.doc.pod_path), internal_path))
+
+    result = self.link_cache.get(internal_path)
+    if not result:
+      target_doc = self.pod.get_doc(internal_path, self.doc.locale)
+      if not target_doc.exists:
+        result = internal_link
+      else:
+        result = target_doc.url.path
+      self.link_cache.add(internal_path, result)
+
+    return result
 
   @staticmethod
   def get_folder(path):

--- a/pages/extensions/internal_links/pod_internal_link_rewriter_test.py
+++ b/pages/extensions/internal_links/pod_internal_link_rewriter_test.py
@@ -1,0 +1,153 @@
+"""Tests for the source code exporter."""
+
+import unittest
+import sys
+import os
+from grow.common.urls import Url
+
+sys.path.extend([os.path.join(os.path.dirname(__file__), '.')])
+
+from pod_internal_link_rewriter import PodInternalLinkRewriter
+
+
+class PodInternalLinkRewriterTestCase(unittest.TestCase):
+
+  def test_a_href_relative(self):
+    link_map = {
+      '/content/test/folder1/page.md': '/test/folder_1/page1.html',
+      '/content/test/folder2/page2.md': '/test/folder_2/page2.html',
+    }
+    doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
+    content = '<a href="../folder2/page2.md">test</a>'
+
+    link_rewriter = PodInternalLinkRewriter(doc)
+    result = link_rewriter.rewrite_pod_internal_links(content)
+
+    self.assertEquals('<a href="/test/folder_2/page2.html">test</a>', result)
+
+  def test_a_href_pod_path(self):
+    link_map = {
+      '/content/test/folder1/page.md': '/test/folder_1/page1.html',
+      '/content/test/folder2/page2.md': '/test/folder_2/page2.html',
+    }
+    doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
+    content = '<a href="/content/test/folder2/page2.md">test</a>'
+
+    link_rewriter = PodInternalLinkRewriter(doc)
+    result = link_rewriter.rewrite_pod_internal_links(content)
+
+    self.assertEquals('<a href="/test/folder_2/page2.html">test</a>', result)
+
+
+  def test_a_href_none_existing(self):
+    link_map = {
+      '/content/test/folder1/page.md': '/test/folder_1/page1.html',
+    }
+    doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
+    content = '<a href="../folder2/page2.md">test</a>'
+
+    link_rewriter = PodInternalLinkRewriter(doc)
+    result = link_rewriter.rewrite_pod_internal_links(content)
+
+    self.assertEquals(content, result)
+
+  def test_a_href_with_protocol(self):
+    link_map = {
+      '/content/test/folder1/page.md': '/test/folder_1/page1.html',
+    }
+    doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
+    content = '<a href="http://amp.dev/test/folder2/page2.md">test</a>'
+
+    link_rewriter = PodInternalLinkRewriter(doc)
+    result = link_rewriter.rewrite_pod_internal_links(content)
+
+    self.assertEquals(content, result)
+
+  def test_a_href_relative_with_anchor(self):
+    link_map = {
+      '/content/test/folder1/page.md': '/test/folder_1/page1.html',
+      '/content/test/folder2/page2.md': '/test/folder_2/page2.html',
+    }
+    doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
+    content = '<a href="../folder2/page2.md#test">test</a>'
+
+    link_rewriter = PodInternalLinkRewriter(doc)
+    result = link_rewriter.rewrite_pod_internal_links(content)
+
+    self.assertEquals('<a href="/test/folder_2/page2.html#test">test</a>', result)
+
+  def test_a_href_relative_with_params(self):
+    link_map = {
+      '/content/test/folder1/page.md': '/test/folder_1/page1.html',
+      '/content/test/folder2/page2.md': '/test/folder_2/page2.html',
+    }
+    doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
+    content = '<a href="../folder2/page2.md?format=ads">test</a>'
+
+    link_rewriter = PodInternalLinkRewriter(doc)
+    result = link_rewriter.rewrite_pod_internal_links(content)
+
+    self.assertEquals('<a href="/test/folder_2/page2.html?format=ads">test</a>', result)
+
+  def test_a_href_relative_with_params_and_anchor(self):
+    link_map = {
+      '/content/test/folder1/page.md': '/test/folder_1/page1.html',
+      '/content/test/folder2/page2.md': '/test/folder_2/page2.html',
+    }
+    doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
+    content = '<a href="../folder2/page2.md?format=ads#test">test</a>'
+
+    link_rewriter = PodInternalLinkRewriter(doc)
+    result = link_rewriter.rewrite_pod_internal_links(content)
+
+    self.assertEquals('<a href="/test/folder_2/page2.html?format=ads#test">test</a>', result)
+
+  def test_multiple_relative_href(self):
+    link_map = {
+      '/content/test/test.md': '/test/test.html',
+      '/content/test/folder1/page.md': '/test/folder_1/page1.html',
+      '/content/test/folder2/page2.md': '/test/folder_2/page2.html',
+      '/content/test/page3.md': '/test/page3.html',
+      '/content/page4.md': '/page4.html',
+    }
+    doc = MockPod(link_map).get_doc('/content/test/test.md')
+    content = '<p><a  class="link" href="folder2/page2.md">test</a><br>' \
+              '<a href="./page3.md" class="link">page3</a><br>' \
+              '<a href="../page4.md">page4</a><br>' \
+              '<a href = "./folder1/page.md">page</a></p>'
+
+    link_rewriter = PodInternalLinkRewriter(doc)
+    result = link_rewriter.rewrite_pod_internal_links(content)
+
+    self.assertEquals('<p><a  class="link" href="/test/folder_2/page2.html">test</a><br>' \
+                      '<a href="/test/page3.html" class="link">page3</a><br>' \
+                      '<a href="/page4.html">page4</a><br>' \
+                      '<a href = "/test/folder_1/page1.html">page</a></p>', result)
+
+
+class MockPod:
+
+  def __init__(self, link_map):
+    self.link_map = link_map
+
+  def get_doc(self, path, locale=None):
+    site_path = self.link_map.get(path)
+    return MockDoc(self, path, site_path)
+
+
+class MockDoc:
+
+  def __init__(self, pod, pod_path, site_path):
+    self.pod = pod
+    self.pod_path = pod_path
+    self.url = None
+    if site_path:
+      self.url = Url(site_path)
+    self.locale = None
+
+  @property
+  def exists(self):
+    if self.url:
+      return True
+    return False
+

--- a/pages/extensions/internal_links/pod_internal_link_rewriter_test.py
+++ b/pages/extensions/internal_links/pod_internal_link_rewriter_test.py
@@ -4,6 +4,7 @@ import unittest
 import sys
 import os
 from grow.common.urls import Url
+from grow.cache.object_cache import ObjectCache
 
 sys.path.extend([os.path.join(os.path.dirname(__file__), '.')])
 
@@ -20,7 +21,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="../folder2/page2.md">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc)
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<a href="/test/folder_2/page2.html">test</a>', result)
@@ -33,7 +34,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="/content/test/folder2/page2.md">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc)
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<a href="/test/folder_2/page2.html">test</a>', result)
@@ -46,7 +47,21 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="../folder2/page2.md">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc)
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
+    result = link_rewriter.rewrite_pod_internal_links(content)
+
+    self.assertEquals(content, result)
+
+  def test_multiple_href_none_existing_with_anchors(self):
+    link_map = {
+      '/content/test/folder1/page.md': '/test/folder_1/page1.html',
+    }
+    doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
+    # two times the same url and different anchor to test possible cache problems
+    content = '<a href="../folder2/page2.md#test">test</a><br>' \
+              '<a href="../folder2/page2.md#other">test2</a>'
+
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals(content, result)
@@ -58,7 +73,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="http://amp.dev/test/folder2/page2.md">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc)
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals(content, result)
@@ -69,12 +84,15 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
       '/content/test/folder2/page2.md': '/test/folder_2/page2.html',
     }
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
-    content = '<a href="../folder2/page2.md#test">test</a>'
+    # two times the same url and different anchor to test possible cache problems
+    content = '<a href="../folder2/page2.md#test">test</a><br>' \
+              '<a href="../folder2/page2.md#other">test2</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc)
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
     result = link_rewriter.rewrite_pod_internal_links(content)
 
-    self.assertEquals('<a href="/test/folder_2/page2.html#test">test</a>', result)
+    self.assertEquals('<a href="/test/folder_2/page2.html#test">test</a><br>' \
+                      '<a href="/test/folder_2/page2.html#other">test2</a>', result)
 
   def test_a_href_relative_with_params(self):
     link_map = {
@@ -84,7 +102,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="../folder2/page2.md?format=ads">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc)
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<a href="/test/folder_2/page2.html?format=ads">test</a>', result)
@@ -97,7 +115,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="../folder2/page2.md?format=ads#test">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc)
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<a href="/test/folder_2/page2.html?format=ads#test">test</a>', result)
@@ -116,7 +134,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
               '<a href="../page4.md">page4</a><br>' \
               '<a href = "./folder1/page.md">page</a></p>'
 
-    link_rewriter = PodInternalLinkRewriter(doc)
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<p><a  class="link" href="/test/folder_2/page2.html">test</a><br>' \

--- a/pages/extensions/internal_links/readme.md
+++ b/pages/extensions/internal_links/readme.md
@@ -1,0 +1,29 @@
+# Linking extension
+
+Rewrite pod internal file links to site links.
+
+
+## Purpose
+
+The best way to link from one file to another is to simply use the paths in the pod, since markdown editors
+support those links and can follow them or even refactor them when a file changes.
+Unfortunately grow will not even change such links in markdown to make valid site links.
+
+This extension will search for all <a href tags in the result page and check if there are any internal paths
+that needs to be rewritten to be valid site links.
+
+Since this extension works with the html result this works for links in markdown as well as links in html code.
+
+The link in the href attribute can be a link relative to the current document as well as a full path inside the pod.
+
+You must point links to the file in the base language and not to translated files.
+
+
+## Activation
+
+This extension has to be activated in the podspec.yaml
+
+```yaml
+ext:
+- extensions.internal_links.PodInternalLinkExtension
+```

--- a/platform/config/podspec.yaml
+++ b/platform/config/podspec.yaml
@@ -30,6 +30,7 @@ ext:
 - extensions.amp_dependencies.AmpDependenciesExtension
 - extensions.amp_dev.AmpDevExtension
 - extensions.url_beautifier.UrlBeautifierExtension
+- extensions.internal_links.PodInternalLinkExtension
 - extensions.jinja2_optimized_codehilite.Jinja2OptimizedCodehiliteExtension
 - extensions.markdown_toc_patch.MarkdownTocPatchExtension
 - extensions.markdown_in_html.MarkdownInHtmlExtension:


### PR DESCRIPTION
A new grow extension will rewrite pod internal links to site links.
Currently only links in <a href tags are handled.

This is the first step for issue #2243.

The second step would be to change all the ugly links in the content like
`{{g.doc('/content/amp-dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate.md', locale=doc.locale).url.path}}` to relative links like `../learn/spec/amp-boilerplate.md` or pod links like `/content/amp-dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate.md`
The first would be the best, since those links would be valid in markdown.
But the second could be done with a simple search and replace over all documents.
I would leave the links in the templates using g.doc for now.

It looks to me that the growReferenceChecker does not check regular markdown links, but only the g.doc syntax although a comment in the checker states otherwise.
When we change all the links, this has to be investigated and fixed if needed.