### PR TITLE
Removes Contributor Summit 2019 application & promo banner

### DIFF
--- a/frontend/templates/views/partials/header.j2
+++ b/frontend/templates/views/partials/header.j2
@@ -9,7 +9,7 @@
 {%- endmacro %}
 
 {# Simply set to False to disable banner #}
-{% set show_banner = True %}
+{% set show_banner = False %}
 {% if show_banner %}
   {% set banner %}
   {% include '/views/partials/banner.j2' %}

--- a/pages/content/amp-dev/events/amp-cs-2019.html
+++ b/pages/content/amp-dev/events/amp-cs-2019.html
@@ -55,9 +55,6 @@ section_links:
   <p class="ap--content-default">
     The AMP Contributor Summit is our annual opportunity for the AMP open source community to meet face-to-face to discuss the latest in AMP and where AMP is going.  This technical summit consists of a mix of different formats, including talks, breakout sessions and many opportunities for informal conversations.
   </p>
-  <p class="ap--content-default">
-    Please <a href="https://events.withgoogle.com/ampcs2019/registrations/new/">apply to attend the AMP Contributor Summit</a> by July 22, 2019! 
-  </p>
 </section>
 
 <section class="ap--container" id="Schedule">
@@ -314,6 +311,8 @@ section_links:
     <div class="ap-m-faq ampconf">
       <h2>Frequently Asked Questions</h2>
       <div class="ap-m-faq-content">
+        <p class="ap-m-faq-content-question">How do I register to attend?</p>
+        <p class="ap-m-faq-content-answer">Due to the limited amount of space, we use an application process for attendees.  The application period for this summit has now closed.</p>
         <p class="ap-m-faq-content-question">Does it cost anything?</p>
         <p class="ap-m-faq-content-answer">No - tickets are free of charge.</p>
         <p class="ap-m-faq-content-question">Who is the event for?</p>
@@ -323,7 +322,7 @@ section_links:
         <p class="ap-m-faq-content-question">Does applying mean I am all set to attend?</p>
         <p class="ap-m-faq-content-answer">Unfortunately, we have a limited number of spaces available for the summit, so not everyone who applies will be able to attend.</p>
         <p class="ap-m-faq-content-question">When will I hear back if I have a spot?</p>
-        <p class="ap-m-faq-content-answer">Our goal is to confirm within a couple of weeks from the application deadline.</p>
+        <p class="ap-m-faq-content-answer">We have let everyone who applied know whether their application was accepted.  If you have questions please reach out to ampcs2019-support at amp.dev.</p>
 </p>
       </div>
     </div>


### PR DESCRIPTION
Applications for the Contributor Summit 2019 have closed, so this updates the Contributor Summit page to reflect that and turns off the banner for it.

/cc @vishaldodiya @matthiasrohmer @mattludwig