### PR TITLE
🎨 Improve new overview pages

### DIFF
--- a/frontend/templates/views/partials/card-grid.j2
+++ b/frontend/templates/views/partials/card-grid.j2
@@ -40,6 +40,7 @@
     {% endif %}
     {% for link in item.links %}
     {% set link = g.doc(link, locale=doc.locale) %}
+    {% if link.exists %}
     <a href="{{ link.url.path }}"
       class="ap-m-lnk">
       <div class="ap-a-ico ap-m-lnk-icon">
@@ -48,6 +49,7 @@
       </div>
       <span class="ap-m-lnk-text">{{ link.title }}</span>
     </a>
+    {% endif %}
     {% endfor %}
   </div>
   {% endfor %}

--- a/frontend/templates/views/partials/teaser-tags.j2
+++ b/frontend/templates/views/partials/teaser-tags.j2
@@ -1,0 +1,16 @@
+{% do doc.styles.addCssFile('/css/components/molecules/tag.css') %}
+
+<div class="ap-m-teaser-tags">
+  {% if 'websites' in formats %}
+  <div class="ap-m-tag ap-m-tag-websites"></div>
+  {% endif %}
+  {% if 'stories' in formats %}
+  <div class="ap-m-tag ap-m-tag-stories"></div>
+  {% endif %}
+  {% if 'ads' in formats %}
+  <div class="ap-m-tag ap-m-tag-ads"></div>
+  {% endif %}
+  {% if 'email' in formats or 'emails' in formats %}
+  <div class="ap-m-tag ap-m-tag-email"></div>
+  {% endif %}
+</div>

--- a/frontend/templates/views/partials/teaser.j2
+++ b/frontend/templates/views/partials/teaser.j2
@@ -82,11 +82,10 @@
 <div class="ap-m-teaser ap-m-teaser-code">
   <a href="{{ teaser_doc.url.path }}">
     <div class="ap-m-teaser-card">
-      <div class="ap-m-teaser-tags">
-        {% for tag in teaser_doc.formats %}
-        <div class="ap-m-tag ap-m-tag-{{ tag }}"></div>
-        {% endfor %}
-      </div>
+      {% with %}
+      {% set formats = teaser_doc.formats %}
+      {% include 'views/partials/teaser-tags.j2' %}
+      {% endwith %}
       <div class="ap-m-teaser-content">
         <div class="ap-m-teaser-content-text">
           <code><span>{{ teaser_doc.title }}</span></code>
@@ -138,12 +137,10 @@
 
       {% if teaser_doc.formats %}
       <div class="ap-m-teaser-placeholder">
-        {% do doc.styles.addCssFile('/css/components/molecules/tag.css') %}
-        <div class="ap-m-teaser-tags">
-          {% for format in teaser_doc.formats %}
-          <div class="ap-m-tag ap-m-tag-{{ format }} ap-m-teaser-tag"></div>
-          {% endfor %}
-        </div>
+        {% with %}
+        {% set formats = teaser_doc.formats %}
+        {% include 'views/partials/teaser-tags.j2' %}
+        {% endwith %}
       </div>
       {% endif %}
 
@@ -184,11 +181,10 @@
 {# guides and tutorials #}
 <div class="ap-m-teaser ap-m-teaser-highlighted">
   <div class="ap-m-teaser-double-teaser">
-    <div class="ap-m-teaser-tags">
-      {% for tag in teaser_doc.formats %}
-      <div class="ap-m-tag ap-m-tag-{{ tag }}"></div>
-      {% endfor %}
-    </div>
+    {% with %}
+    {% set formats = teaser_doc.formats %}
+    {% include 'views/partials/teaser-tags.j2' %}
+    {% endwith %}
     {% if teaser_doc.image %}
     <div class="ap-a-img ap-m-teaser-image">
       <amp-img class="ap--media" src="{{ teaser_doc.image.src }}" layout="responsive" width="2.3" height="1" alt="{{ teaser_doc.image.alt }}"></amp-img>
@@ -240,12 +236,10 @@
   <a href="{{ teaser_doc.url.path }}">
 
     {# tags #}
-    {% do doc.styles.addCssFile('/css/components/molecules/tag.css') %}
-    <div class="ap-m-teaser-tags">
-      {% for format in formats %}
-      <div class="ap-m-tag ap-m-tag-{{ format }} ap-m-teaser-tag"></div>
-      {% endfor %}
-    </div>
+    {% with %}
+    {% set formats = teaser_doc.formats %}
+    {% include 'views/partials/teaser-tags.j2' %}
+    {% endwith %}
 
     {# image #}
     {% if teaser.image %}

--- a/pages/content/amp-dev/documentation/components/index.html
+++ b/pages/content/amp-dev/documentation/components/index.html
@@ -113,9 +113,8 @@ highlighted_components:
         {% do doc.styles.addCssFile('/css/components/molecules/table-component.css') %}
 
 
-        <h2>Categories</h2>
+        <h2>Filter by category</h2>
         {% include 'views/partials/category-filter.j2'%}
-
 
         {% for category, docs in categories %}
         {% set scope = namespace(categoryFormats = []) %}

--- a/pages/content/amp-dev/documentation/components/index.html
+++ b/pages/content/amp-dev/documentation/components/index.html
@@ -136,9 +136,18 @@ highlighted_components:
                 {% if component.formats %}
                 {% do doc.styles.addCssFile('/css/components/molecules/tag.css') %}
                 <div class="ap-m-table-component-tags">
-                  {% for format in component.formats %}
-                  <div class="ap-m-tag ap-m-tag-{{ format }} ap-m-table-component-tag"></div>
-                  {% endfor %}
+                  {% if 'websites' in component.formats %}
+                  <div class="ap-m-tag ap-m-tag-websites ap-m-table-component-tag"></div>
+                  {% endif %}
+                  {% if 'stories' in component.formats %}
+                  <div class="ap-m-tag ap-m-tag-stories ap-m-table-component-tag"></div>
+                  {% endif %}
+                  {% if 'ads' in component.formats %}
+                  <div class="ap-m-tag ap-m-tag-ads ap-m-table-component-tag"></div>
+                  {% endif %}
+                  {% if 'email' in component.formats or 'emails' in component.formats %}
+                  <div class="ap-m-tag ap-m-tag-email ap-m-table-component-tag"></div>
+                  {% endif %}
                 </div>
                 {% else %}
                 <p></p>

--- a/pages/content/amp-dev/documentation/examples/index.html
+++ b/pages/content/amp-dev/documentation/examples/index.html
@@ -1,5 +1,5 @@
 ---
-$title: Examples
+$title: AMP [= format|capitalize =] Examples
 $titles:
   teaser: Examples.
 $view: /views/custom.j2
@@ -173,7 +173,7 @@ recent_examples:
       {% include '/views/partials/sidebar-toggle-button.j2' %}
       {% include '/views/partials/breadcrumbs.j2' %}
 
-      <h1>Learn AMP By Example</h1>
+      <h1>{{ doc.title }}</h1>
 
       {% do doc.styles.addCssFile('/css/components/organisms/card-grid.css') %}
       <section class="ap--card-grid">

--- a/pages/content/amp-dev/documentation/examples/index.html
+++ b/pages/content/amp-dev/documentation/examples/index.html
@@ -263,9 +263,18 @@ recent_examples:
                 {% if document.formats %}
                 {% do doc.styles.addCssFile('/css/components/molecules/tag.css') %}
                 <div class="ap-m-table-component-tags">
-                  {% for format in document.formats %}
-                  <div class="ap-m-tag ap-m-tag-{{ format }} ap-m-table-component-tag"></div>
-                  {% endfor %}
+                  {% if 'websites' in document.formats %}
+                  <div class="ap-m-tag ap-m-tag-websites ap-m-table-component-tag"></div>
+                  {% endif %}
+                  {% if 'stories' in document.formats %}
+                  <div class="ap-m-tag ap-m-tag-stories ap-m-table-component-tag"></div>
+                  {% endif %}
+                  {% if 'ads' in document.formats %}
+                  <div class="ap-m-tag ap-m-tag-ads ap-m-table-component-tag"></div>
+                  {% endif %}
+                  {% if 'email' in document.formats or 'emails' in document.formats %}
+                  <div class="ap-m-tag ap-m-tag-email ap-m-table-component-tag"></div>
+                  {% endif %}
                 </div>
                 {% endif %}
                 <div class="ap-m-table-component-name ap-m-table-component-name-example">

--- a/pages/content/amp-dev/documentation/examples/index.html
+++ b/pages/content/amp-dev/documentation/examples/index.html
@@ -177,6 +177,7 @@ recent_examples:
 
       {% do doc.styles.addCssFile('/css/components/organisms/card-grid.css') %}
       <section class="ap--card-grid">
+        <h2 class="ap-o-card-grid-text">Featured examples</h2>
         {% for format in doc.examples %}
         [% if format == '{{ format }}' %]
           {% for item in doc.examples[format] %}

--- a/pages/content/amp-dev/documentation/examples/index.html
+++ b/pages/content/amp-dev/documentation/examples/index.html
@@ -210,8 +210,8 @@ recent_examples:
                    src="/static/img/playground-teaser@3x.png"
                    class="ap--media"
                    layout="responsive"
-                   width="1668px"
-                   height="1236px"
+                   width="1668"
+                   height="1236"
                    srcset="/static/img/playground-teaser@3x.png 1600w,
                            /static/img/playground-teaser@2x.png 1100w,
                            /static/img/playground-teaser.png 500w">
@@ -224,7 +224,7 @@ recent_examples:
         {% do doc.styles.addCssFile('css/components/organisms/teaser-grid.css') %}
         {% do doc.styles.addCssFile('/css/components/molecules/table-component.css') %}
 
-        <h2>Categories</h2>
+        <h2>Filter by category</h2>
         {% include '/views/partials/category-filter.j2'%}
 
         {% for category, documents in categories %}

--- a/pages/content/amp-dev/documentation/examples/index.html
+++ b/pages/content/amp-dev/documentation/examples/index.html
@@ -120,7 +120,7 @@ examples:
       links:
         - /content/amp-dev/documentation/examples/previews/Advanced_Server_Request.html
         - /content/amp-dev/documentation/examples/previews/Article_Bookmark_Email.html
-        - /content/amp-dev/documentation/examples/previews/Conference_Service_Email.html
+        - /content/amp-dev/documentation/examples/previews/Conference_Survey_Email.html
         - /content/amp-dev/documentation/examples/previews/Dynamically_updating_items_in_a_feed.html
 
 highlight_examples:

--- a/pages/content/amp-dev/documentation/examples/index.html
+++ b/pages/content/amp-dev/documentation/examples/index.html
@@ -197,7 +197,17 @@ recent_examples:
           <p>
             Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback.
           </p>
-          <a class="ap-m-lnk ap-m-lnk-square" href="https://playground.amp.dev/">
+          <a class="ap-m-lnk ap-m-lnk-square"
+             [% if format == 'websites' %]
+             href="https://playground.amp.dev/"
+             [% elif format == 'stories' %]
+             href="https://playground.amp.dev/?runtime=amp4stories"
+             [% elif format == 'ads' %]
+             href="https://playground.amp.dev/?runtime=amp4ads"
+             [% elif format == 'email' %]
+             href="https://playground.amp.dev/?runtime=amp4email"
+             [% endif %]
+             >
             <div class="ap-a-ico ap-m-lnk-icon">
               {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>

--- a/pages/translations/en/LC_MESSAGES/messages.po
+++ b/pages/translations/en/LC_MESSAGES/messages.po
@@ -995,3 +995,38 @@ msgstr "Presentation"
 msgid "social"
 msgstr "Social"
 
+msgid "advertising-analytics"
+msgstr "Advertising & Analytics"
+
+msgid "introduction"
+msgstr "Introduction"
+
+msgid "components"
+msgstr "Components"
+
+msgid "guides"
+msgstr "Guides"
+
+msgid "e-commerce"
+msgstr "E-Commerce"
+
+msgid "interactivity-dynamic-content"
+msgstr "Interactivity & Dynamic Content"
+
+msgid "multimedia-animations"
+msgstr "Multimedia & Animations"
+
+msgid "news-publishing"
+msgstr "News & Publishing"
+
+msgid "personalization"
+msgstr "Personalization"
+
+msgid "style-layout"
+msgstr "Style & Layout"
+
+msgid "user-consent"
+msgstr "User consent"
+
+msgid "visual-effects"
+msgstr "Visual effects"


### PR DESCRIPTION
This addresses some of the comments in #2756.

- Non-existing linked documents don't show up as `None` anymore
- Example categories are now properly cased and divided
- Featured examples got a headline
- "Categories" has been rephrased to "Filter by category" on example and guides overview
- Playground teaser on filtered example overview opens the playground in matching format
- Format tags are shown in consistent order (websites, stories, ads, email) now. A wrong format key of `emails` so far causing a blank tag is additionally catched gracefully now
- Page title of filtered examples overview shares its format now