### PR TITLE
♻️ Migrate geolocation example backend to amp.dev

### DIFF
--- a/examples/source/personalization/Geolocation_with_amp-list/api.js
+++ b/examples/source/personalization/Geolocation_with_amp-list/api.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const express = require('express');
+const fetch = require('node-fetch');
+const credentials = require('@lib/utils/credentials');
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+
+const IPSTACK_API_KEY = 'ipstack_api_key';
+const GEONAMES_USERNAME = 'geonames_username';
+const IPSTACK_API_URL = 'http://api.ipstack.com/';
+const GEONAMES_API_URL = 'http://api.geonames.org/findNearbyPostalCodesJSON';
+
+examples.get('/location-specific-results.json', async (request, response) => {
+  const ipstackCredential = await credentials.get(IPSTACK_API_KEY);
+  let ip = request.headers['x-forwarded-for'] || request.connection.remoteAddress;
+  ip = ip.split(',')[0];
+
+  let ipstackResponse;
+  let geonamesResponse;
+
+  try {
+    ipstackResponse = await fetch(IPSTACK_API_URL + ip + '?access_key=' + ipstackCredential);
+    ipstackResponse = await ipstackResponse.json();
+  } catch (err) {
+    response.status(500).send('Error fetching ipstack data.');
+  }
+
+  const geonamesCredential = await credentials.get(GEONAMES_USERNAME);
+  const geoNamesSearchParams = new URLSearchParams({
+    maxRows: 150,
+    lat: ipstackResponse.latitude,
+    lng: ipstackResponse.longitude,
+    username: geonamesCredential,
+  }).toString();
+
+  try {
+    geonamesResponse = await fetch(GEONAMES_API_URL + '?' + geoNamesSearchParams);
+    geonamesResponse = await geonamesResponse.json();
+  } catch (err) {
+    response.status(500).send('Error fetching geonames data.');
+  }
+
+  const existingPlaceNames = {};
+  const places = geonamesResponse.postalCodes.filter((place) => {
+    if (!(place.placeName in existingPlaceNames) && Object.keys(existingPlaceNames).length < 5) {
+      existingPlaceNames[place.placeName] = true;
+      return true;
+    }
+  });
+
+  // ipstack is supposed to return data.city, but sometimes doesn't
+  const location = ipstackResponse.city || places[0].placeName;
+
+  response.json({
+    location,
+    results: places,
+  });
+});
+
+module.exports = examples;

--- a/examples/source/personalization/Geolocation_with_amp-list/index.html
+++ b/examples/source/personalization/Geolocation_with_amp-list/index.html
@@ -111,7 +111,7 @@ author: jamesshannon
   -->
   <amp-list class="geolist-preview" width="auto" height="640" layout="fixed-height"
             noloading
-            src="https://caramel-wolf.glitch.me//location-specific-results.json"
+            src="/documentation/examples/personalization/geolocation_with_amp-list/location-specific-results.json"
             binding="no"
             single-item items=".">
     <template type="amp-mustache" id="amp-template-id">
@@ -122,7 +122,7 @@ author: jamesshannon
             <amp-img
               alt="{{placeName}} Map" noloading
               layout="fixed" width="150" height="100"
-              src="https://maps.googleapis.com/maps/api/staticmap?markers={{lat}},{{lng}}&zoom=9&size=150x100&maptype=roadmap&key=AIzaSyByT-0aYa-nEF0gGqJHNpEEK1bus00losI">
+              src="https://maps.googleapis.com/maps/api/staticmap?markers={{lat}},{{lng}}&zoom=9&size=150x100&maptype=roadmap&key=AIzaSyAyAS599A2GGPKTmtNr9CptD61LE4gN6oQ">
             </amp-img>
             <p>
               <strong>{{placeName}}</strong><br>


### PR DESCRIPTION
Migrated the geolocation example backend from [glitch.com](https://glitch.com/~caramel-wolf) to amp.dev.

It updates the example [here](https://amp.dev/documentation/examples/personalization/geolocation_with_amp-list/?format=websites).

Part of the migration/improvements in #2054.

This is a draft PR until all credentials have been made available in the datastore.