### PR TITLE
🎨 Fix search priority of sidebar markup

### DIFF
--- a/frontend/templates/views/detail/component-detail.j2
+++ b/frontend/templates/views/detail/component-detail.j2
@@ -17,7 +17,6 @@
 {% endblock %}
 
 {% block main %}
-{% include 'views/partials/component-sidebar.j2' %}
 {% include 'views/partials/sidebar-toggle-observer.j2' %}
 <main class="ap--main ap-t-component-detail">
   <div class="ap--container">
@@ -48,4 +47,5 @@
     </section>
   </div>
 </main>
+{% include 'views/partials/component-sidebar.j2' %}
 {% endblock %}

--- a/frontend/templates/views/detail/docs-detail.j2
+++ b/frontend/templates/views/detail/docs-detail.j2
@@ -17,7 +17,6 @@
 {% endblock %}
 
 {% block main %}
-{% include 'views/partials/sidebar.j2' %}
 {% include 'views/partials/sidebar-toggle-observer.j2' %}
 <main class="ap--main ap-t-docs-detail">
   <div class="ap--container">
@@ -67,4 +66,5 @@
 
   </div>
 </main>
+{% include 'views/partials/sidebar.j2' %}
 {% endblock %}

--- a/frontend/templates/views/detail/guide-detail.j2
+++ b/frontend/templates/views/detail/guide-detail.j2
@@ -10,7 +10,6 @@
 {% endblock %}
 
 {% block main %}
-{% include 'views/partials/sidebar.j2' %}
 {% include 'views/partials/sidebar-toggle-observer.j2' %}
 <main class="ap--main ap-t-guide">
   <div class="ap--container">
@@ -18,4 +17,5 @@
     {% include 'views/partials/content.j2' %}
   </div>
 </main>
+{% include 'views/partials/sidebar.j2' %}
 {% endblock %}

--- a/frontend/templates/views/detail/template-detail.j2
+++ b/frontend/templates/views/detail/template-detail.j2
@@ -10,7 +10,6 @@
 {% endblock %}
 
 {% block main %}
-{% include 'views/partials/sidebar.j2' %}
 {% include 'views/partials/sidebar-toggle-observer.j2' %}
 <main class="ap--main ap-t-template">
   <div class="ap--container">
@@ -18,4 +17,5 @@
     {% include 'views/partials/content.j2' %}
   </div>
 </main>
+{% include 'views/partials/sidebar.j2' %}
 {% endblock %}

--- a/frontend/templates/views/detail/use-cases-detail.j2
+++ b/frontend/templates/views/detail/use-cases-detail.j2
@@ -10,7 +10,6 @@
 {% endblock %}
 
 {% block main %}
-{% include 'views/partials/sidebar.j2' %}
 {% include 'views/partials/sidebar-toggle-observer.j2' %}
 <main class="ap--main ap-t-use-cases">
   <div class="ap--container">
@@ -18,4 +17,5 @@
     {% include 'views/partials/content.j2' %}
   </div>
 </main>
+{% include 'views/partials/sidebar.j2' %}
 {% endblock %}

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -69,7 +69,6 @@
 {% endblock %}
 
 {% block main %}
-{% include 'views/partials/example-sidebar.j2' %}
 {% include 'views/partials/sidebar-toggle-observer.j2' %}
 <main class="ap--main ap-t-examples-manual">
   <div class="ap--container">
@@ -239,6 +238,7 @@
     {% include 'views/partials/author.j2' %}
   </div>
 </main>
+{% include 'views/partials/example-sidebar.j2' %}
 
 {% if doc.example.document.metadata.experiments %}
 {% set experiments = doc.example.document.metadata.experiments %}

--- a/frontend/templates/views/overview/courses.j2
+++ b/frontend/templates/views/overview/courses.j2
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block main %}
-{% include 'views/partials/sidebar.j2' %}
 {% include 'views/partials/sidebar-toggle-observer.j2' %}
 <main class="ap--main ap-t-courses-overview">
   <div class="ap--container">
@@ -16,4 +15,5 @@
     {% include 'views/partials/content.j2' %}
   </div>
 </main>
+{% include 'views/partials/sidebar.j2' %}
 {% endblock %}

--- a/frontend/templates/views/overview/guides.j2
+++ b/frontend/templates/views/overview/guides.j2
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block main %}
-{% include 'views/partials/sidebar.j2' %}
 {% include 'views/partials/sidebar-toggle-observer.j2' %}
 <main class="ap--main ap-t-docs-guides-overview">
   <div class="ap--container">
@@ -16,4 +15,5 @@
     {% include 'views/partials/content.j2' %}
   </div>
 </main>
+{% include 'views/partials/sidebar.j2' %}
 {% endblock %}

--- a/frontend/templates/views/partials/component-sidebar.j2
+++ b/frontend/templates/views/partials/component-sidebar.j2
@@ -10,7 +10,7 @@
     toolbar-target="ap--sidebar-content">
     <ul>
       {% include '/views/partials/format-toggle.j2' %}
-      <section class="ap-o-sidebar-section">
+      <div class="ap-o-sidebar-section">
         <div class="ap-o-component-sidebar">
           <div class="nav">
             {% set components = g.collection('/content/amp-dev/documentation/components/reference').list_docs(locale=doc.locale) %}
@@ -42,7 +42,7 @@
             </ul>
           </div>
         </div>
-      </section>
+      </div>
     </ul>
   </nav>
 </amp-sidebar>

--- a/frontend/templates/views/partials/example-sidebar.j2
+++ b/frontend/templates/views/partials/example-sidebar.j2
@@ -11,7 +11,7 @@
     toolbar-target="ap--sidebar-content">
     <ul>
       {% include '/views/partials/format-toggle.j2' %}
-      <section>
+      <div>
         <div class="ap-o-sidebar">
           <div class="nav">
             {% set categories = g.categories('/content/amp-dev/documentation/examples/documentation', locale=doc.locale) %}
@@ -48,7 +48,7 @@
           </div>
 
         </div>
-      </section>
+      </div>
     </ul>
   </nav>
 </amp-sidebar>

--- a/frontend/templates/views/partials/sidebar.j2
+++ b/frontend/templates/views/partials/sidebar.j2
@@ -7,7 +7,7 @@
     toolbar-target="ap--sidebar-content">
     <ul>
       {% include '/views/partials/format-toggle.j2' %}
-      <section class="ap-o-sidebar-section">
+      <div class="ap-o-sidebar-section">
         {% do doc.styles.addCssFile('css/components/organisms/sidebar.css') %}
         <div class="ap-o-sidebar">
           <div class="nav">
@@ -115,7 +115,7 @@
             {{ nav_tree(root=g.collection(current_path)) }}
           </div>
         </div>
-      </section>
+      </div>
     </ul>
   </nav>
 </amp-sidebar>

--- a/pages/content/amp-dev/documentation/components/index.html
+++ b/pages/content/amp-dev/documentation/components/index.html
@@ -33,7 +33,6 @@ highlighted_components:
 {% do doc.styles.addCssFile('/css/components/templates/component-overview.css') %}
 
 {% block main %}
-{% include 'views/partials/component-sidebar.j2' %}
 {% include 'views/partials/sidebar-toggle-observer.j2' %}
 <main class="ap--main ap-t-component-overview">
   <div class="ap--container">
@@ -160,4 +159,5 @@ highlighted_components:
     </section>
   </div>
 </main>
+{% include 'views/partials/component-sidebar.j2' %}
 {% endblock %}

--- a/pages/content/amp-dev/documentation/examples/index.html
+++ b/pages/content/amp-dev/documentation/examples/index.html
@@ -163,7 +163,6 @@ recent_examples:
 {% do doc.styles.addCssFile('/css/components/templates/component-overview.css') %}
 
 {% block main %}
-{% include 'views/partials/example-sidebar.j2' %}
 {% include 'views/partials/sidebar-toggle-observer.j2' %}
 <main class="ap--main ap-t-component-overview">
   <div class="ap--container">
@@ -283,4 +282,5 @@ recent_examples:
     </section>
   </div>
 </main>
+{% include 'views/partials/example-sidebar.j2' %}
 {% endblock %}


### PR DESCRIPTION
We've tried to move the sidebar below the main area and prevent using `<section>` tags inside the sidebar to keep the indexing priority of the search low.

We can't see if those changes take a positive effect to our custom search, until they're not live.

@sebastianbenz could you please take a quick look at this?