### PR TITLE
Fix importing component docs where the name is not a tag

### DIFF
--- a/platform/lib/pipeline/componentReferenceImporter.js
+++ b/platform/lib/pipeline/componentReferenceImporter.js
@@ -210,6 +210,10 @@ class ComponentReferenceImporter {
     tags.delete('script');
     tags.delete('$reference-point');
 
+    // always add the extension name.
+    // It might not be a tag, but the documentation might have this name
+    tags.add(extension.name);
+
     return tags;
   }
 

--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -22,8 +22,8 @@ const utils = require('@lib/utils');
 
 // Prep version template
 const nunjucks = require('nunjucks');
-const VERSION_TOGGLE_TEMPLATE = nunjucks
-    .compile(fs.readFileSync('frontend/templates/views/partials/version-toggle.j2', 'utf8'));
+const VERSION_TOGGLE_TEMPLATE = nunjucks.compile(fs.readFileSync(
+  utils.project.absolute('frontend/templates/views/partials/version-toggle.j2'), 'utf8'));
 
 // Inline marker used by Grow to determine if there should be TOC
 const TOC_MARKER = '[TOC]';

--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -23,7 +23,7 @@ const utils = require('@lib/utils');
 // Prep version template
 const nunjucks = require('nunjucks');
 const VERSION_TOGGLE_TEMPLATE = nunjucks.compile(fs.readFileSync(
-  utils.project.absolute('frontend/templates/views/partials/version-toggle.j2'), 'utf8'));
+    utils.project.absolute('frontend/templates/views/partials/version-toggle.j2'), 'utf8'));
 
 // Inline marker used by Grow to determine if there should be TOC
 const TOC_MARKER = '[TOC]';


### PR DESCRIPTION
Fixes #2808

Also again allow to run the importer standalone.