### PR TITLE
Small search improvements

### DIFF
--- a/frontend/scss/components/organisms/search.scss
+++ b/frontend/scss/components/organisms/search.scss
@@ -207,7 +207,7 @@
   &-result {
     overflow-x: hidden;
     overflow-y: auto;
-    min-height: 500px;
+    min-height: 60vh;
     max-height: calc(100vh - 88px);
     padding: 0 0 30px;
 
@@ -236,7 +236,7 @@
     }
 
     .amp-active {
-      transform: translate(-50%, 206px);
+      transform: translate(-50%, 25vh);
     }
 
     &-list:last-child &-item:last-child {

--- a/pages/content/amp-dev/search.html
+++ b/pages/content/amp-dev/search.html
@@ -1,8 +1,0 @@
----
-$title: Search
-$order: 1
-description: Search amp.dev.
-$view: /views/overview/custom-content.j2
----
-
-{% include 'views/partials/search.j2' %}


### PR DESCRIPTION
The search.html is no longer in use and can be deleted.
The `min-height` for the result container should be `vh` to prevent issues on smaller devices.