### PR TITLE
Further search improvements

### DIFF
--- a/frontend/scss/components/organisms/search.scss
+++ b/frontend/scss/components/organisms/search.scss
@@ -395,12 +395,11 @@
     }
 
     &-notfound {
-      padding: 0 15px;
+      padding: 14vh 15px 0;
       text-align: center;
 
       &-smiley {
         @include hl;
-        font-family: 'Noto Sans';
         font-size: 100px;
         margin: 0 0 -4rem;
         color: color('athens-gray');

--- a/frontend/scss/components/organisms/search.scss
+++ b/frontend/scss/components/organisms/search.scss
@@ -379,6 +379,10 @@
           opacity: 1;
         }
       }
+
+      .amp-notsupported & {
+        display: none;
+      }
     }
 
     &-hint {

--- a/frontend/scss/components/organisms/search.scss
+++ b/frontend/scss/components/organisms/search.scss
@@ -390,6 +390,31 @@
       }
     }
 
+    &-notfound {
+      padding: 0 15px;
+      text-align: center;
+
+      &-smiley {
+        @include hl;
+        font-family: 'Noto Sans';
+        font-size: 100px;
+        margin: 0 0 -4rem;
+        color: color('athens-gray');
+
+        @media (min-width: 1280px) {
+          font-size: 140px;
+        }
+      }
+
+      &-headline {
+        margin: 0 0 .5rem;
+      }
+
+      &-copy {
+        margin: 0 0 2em;
+      }
+    }
+
     // Hack to prevent showing load-more button and loading-indicator at the same time
     // Related issue: https://github.com/ampproject/amphtml/issues/24034
     div[class*="loading-container"]:not(.amp-hidden) ~ [load-more-button] {

--- a/frontend/scss/components/organisms/search.scss
+++ b/frontend/scss/components/organisms/search.scss
@@ -394,23 +394,28 @@
       }
     }
 
-    &-notfound {
+    &-error {
       padding: 14vh 15px 0;
       text-align: center;
 
-      &-smiley {
+      &-smiley,
+      &-shruggie {
         @include hl;
-        font-size: 100px;
-        margin: 0 0 -4rem;
+        font-size: 16vw;
+        margin: 0;
         color: color('athens-gray');
 
-        @media (min-width: 1280px) {
-          font-size: 140px;
+        @media (min-width: 768px) {
+          font-size: 13vw;
+        }
+
+        @media (min-width: 1024px) {
+          font-size: 100px;
         }
       }
 
-      &-headline {
-        margin: 0 0 .5rem;
+      &-shruggie {
+        font-family: 'Noto Sans', sans-serif;
       }
 
       &-copy {

--- a/frontend/templates/views/partials/search.j2
+++ b/frontend/templates/views/partials/search.j2
@@ -146,22 +146,26 @@
             </amp-list-load-more>
 
             <amp-list-load-more class="ap-o-search-result-hint" load-more-failed>
-              {{_('An internal server error occurred while trying to load more search results.')}}<br>
+              {{_('Something went wrong while trying to load more search results.')}}<br>
               {{_('We apologize for the inconvenience caused.')}}<br>
               {{_('Please try again later.')}}
             </amp-list-load-more>
 
-            <div class="ap-o-search-result-hint" fallback>
-              {{_('An internal server error occurred while trying to load the search results.')}}<br>
-              {{_('We apologize for the inconvenience caused.')}}<br>
-              {{_('Please try again later.')}}
+            <div class="ap-o-search-result-error" fallback>
+              <h2 class="ap-o-search-result-error-smiley">{{';('}}</h2>
+              <h3 class="ap-o-search-result-error-headline">{{ _('Something went wrong…') }}</h3>
+              <p class="ap-o-search-result-error-copy">
+                {{ _('…while trying to load the search results.') }}<br>
+                {{ _('We apologize for the inconvenience caused.') }}<br>
+                {{_('Please try again later.')}}
+              </p>
             </div>
           </amp-list>
 
-          <div class="ap-o-search-result-notfound" [hidden]="search.result.totalResults != 0" hidden>
-            <h2 class="ap-o-search-result-notfound-smiley">{{';('}}</h2>
-            <h3 class="ap-o-search-result-notfound-headline">{{ _('No results found.') }}</h3>
-            <p class="ap-o-search-result-notfound-copy">{{ _('We could not find any results for your search query.') }}</p>
+          <div class="ap-o-search-result-error" [hidden]="search.result.totalResults != 0" hidden>
+            <h2 class="ap-o-search-result-error-shruggie">{{'¯\_(ツ)_/¯'}}</h2>
+            <h3 class="ap-o-search-result-error-headline">{{ _('No results found.') }}</h3>
+            <p class="ap-o-search-result-error-copy">{{ _('We could not find any results matching your search query.') }}</p>
           </div>
 
         </div>

--- a/frontend/templates/views/partials/search.j2
+++ b/frontend/templates/views/partials/search.j2
@@ -156,8 +156,10 @@
             </amp-list-load-more>
           </amp-list>
 
-          <div class="ap-o-search-result-hint" [hidden]="search.result.totalResults != 0" hidden>
-            {{_('We could not find any results for your search query.')}}
+          <div class="ap-o-search-result-notfound" [hidden]="search.result.totalResults != 0" hidden>
+            <h2 class="ap-o-search-result-notfound-smiley">{{';('}}</h2>
+            <h3 class="ap-o-search-result-notfound-headline">{{ _('No results found.') }}</h3>
+            <p class="ap-o-search-result-notfound-copy">{{ _('We could not find any results for your search query.') }}</p>
           </div>
 
         </div>

--- a/frontend/templates/views/partials/search.j2
+++ b/frontend/templates/views/partials/search.j2
@@ -154,6 +154,12 @@
               {{_('We apologize for the inconvenience caused.')}}<br>
               {{_('Please try again later.')}}
             </amp-list-load-more>
+
+            <div class="ap-o-search-result-hint" fallback>
+              {{_('An internal server error occurred while trying to load the search results.')}}<br>
+              {{_('We apologize for the inconvenience caused.')}}<br>
+              {{_('Please try again later.')}}
+            </div>
           </amp-list>
 
           <div class="ap-o-search-result-notfound" [hidden]="search.result.totalResults != 0" hidden>

--- a/frontend/templates/views/partials/search.j2
+++ b/frontend/templates/views/partials/search.j2
@@ -63,9 +63,6 @@
                  required
           >
         </amp-autocomplete>
-
-        <input name="locale" type="hidden" value="{{ doc.locale }}">
-
       </form>
 
       <div class="empty" [class]="query ? '' : 'empty'">
@@ -75,7 +72,6 @@
                     [src]="query == undefined ? null : '/search/do?q=' + encodeURIComponent(query) + '&locale={{ doc.locale }}'"></amp-state>
           <amp-list [src]="query == undefined ? null : '/search/do?q=' + encodeURIComponent(query) + '&locale={{ doc.locale }}'"
                     binding="no"
-                    class="paged-amp-list"
                     items="."
                     height="10"
                     layout="fixed-height"
@@ -176,7 +172,6 @@
 
       <amp-list src="/search/highlights?locale={{ doc.locale }}"
                 binding="no"
-                class="paged-amp-list"
                 items="."
                 height="100vh"
                 layout="fixed-height"


### PR DESCRIPTION
This PR fixes: #2829 and #2817

- We've changed the 'no-results' message accordingly to the 404 page.
Right now the version with the sad looking smiley face `;(` is commited, but I've attached a screenshot with the alternative schruggie `¯\_(ツ)_/¯`. Closes: #2829
- There is now a fallback element for `<amp-list>` which has the same error message like on `load-more-failed`. Closes: #2817
- Additionally we've removed some unused markup

---

**current**
![Screenshot 1](https://user-images.githubusercontent.com/22053023/63684278-c9a17b00-c7fc-11e9-9dc4-6b2bb851580e.png)

**alternative**
![Screenshot 2](https://user-images.githubusercontent.com/22053023/63684276-c9a17b00-c7fc-11e9-9d97-21c05c1826b6.png)
