### PR TITLE
Internal component links without version resolve to the latest

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting.md
@@ -103,7 +103,7 @@ description: For web experiences requiring a high amount of customization AMP ha
 For a list of shortcodes and their uses, please view [documentation.md on GitHub](https://github.com/ampproject/amp.dev/blob/future/contributing/documentation.md#shortcodes).
 
 ## Images
-amp.dev is built with AMP! Therefore our images must match the [`amp-img`](../../../../documentation/components/reference/amp-img.md?format=websites) criteria. The build process uses the following syntact to convert images to proper `amp-img` format. 
+amp.dev is built with AMP! Therefore our images must match the [`amp-img`](../../../../documentation/components/reference/amp-img.md) criteria. The build process uses the following syntact to convert images to proper `amp-img` format. 
 
 <div class="ap-m-code-snippet">
 <pre>
@@ -235,8 +235,10 @@ Use the `preview` attribute to define how the preview is generated:
 
 - **orientation**: `default: landscape|portrait`
 
-If custom elements are needed, specify them in the imports attribute as a comma separated list
+If custom elements are needed, specify them in the `imports` attribute as a comma separated list
 with the name of the component followed by a colon and the version.
+If your code uses [`amp-mustache`](../../../../documentation/components/reference/amp-mustache.md?format=websites)
+specify the dependency in the `template` attribute instead.
 
 For email content with resource links use the placeholder <code>&#123;&#123;server_for_email}}</code> in the source.
 
@@ -261,46 +263,38 @@ For email content with resource links use the placeholder <code>&#123;&#123;serv
 </div>
 
 ## Links
-Guides and tutorials are filterable by AMP format, such as AMP websites or AMP stories. Readers who filter their content often want to keep it this way. When linking out to a different guide or tutorial, use the following structure:
 
-<div class="ap-m-code-snippet">
-<pre>
- &lsqb;link](&#123;&#123;g.doc('/content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md', locale=doc.locale).url.path&#125;&#125;?format=websites)
-</pre>
-</div>
+You can link to other pages with standard markdown link syntax:
+```md
+ [link](../../../courses/beginning-course/index.md)
+```
 
-The structure can be broken down into:
-
-<div class="ap-m-code-snippet">
-<pre>
-//Explains it is a page that exists in the docs repository. 
-
-(&#123;&#123;g.doc
-
-// When linking to another guide and tutorial this will be the filepath, 
-// fill in the rest with the proper document route. 
-
-&#47;content&#47;amp-dev&#47;documentation&#47;guides-and-tutorials
-
-//If linking to an example.
-
-&#47;content&#47;amp-dev&#47;documentation&#47;examples&#47;
-
-//Keeps the document on the chosen language, if available. 
-
-locale=doc.locale
-
-//Explains the page exists in the docs repository.
-
-)url.path&#125;&#125;
+When linking to another page on amp.dev the reference will be a relative filepath to the target file.
 
 
-//Define the filtered format. 
-//Default to websites if your document is relevant to websites and another format. 
+### AMP format filter
+Component documentation, guides and tutorials and examples are filterable by AMP format,
+such as AMP websites or AMP stories.
+When linking out to such a page you should explicitly specify a format, which is supported by the target,
+by appending the format parameter to the link: 
 
-?format=websites
-</pre>
-</div>
+```md
+ [link](../../learn/amp-actions-and-events.md?format=websites)
+```
+
+Only when you are sure the target supports **all** the formats that your page does you can omit the parameter.
+
+
+### Component references
+A link to a component reference documentation will automatically point to the latest version
+if your link omits the version part.
+When you explicitly want to point to a version specify the full name:
+
+```md
+ [latest version](../../../components/reference/amp-carousel.md?format=websites)
+ [explicit version](../../../components/reference/amp-carousel-v0.2.md?format=websites)
+``` 
+
 
 ## Document Structure 
 ### Titles, headings and subheadings

--- a/pages/extensions/internal_links/__init__.py
+++ b/pages/extensions/internal_links/__init__.py
@@ -2,6 +2,7 @@ from grow import extensions
 from grow.documents import static_document
 from grow.extensions import hooks
 from pod_internal_link_rewriter import PodInternalLinkRewriter
+from component_version_resolver import ComponentVersionResolver
 
 class PodInternalLinkPostRenderHook(hooks.PostRenderHook):
   """Handle the post-render hook."""
@@ -25,7 +26,7 @@ class PodInternalLinkPostRenderHook(hooks.PostRenderHook):
   def trigger(self, previous_result, doc, raw_content, *_args, **_kwargs):
     content = previous_result if previous_result else raw_content
 
-    link_rewriter = PodInternalLinkRewriter(doc, self.link_cache);
+    link_rewriter = PodInternalLinkRewriter(doc, self.link_cache, self.extension.component_version_resolver);
     content = link_rewriter.rewrite_pod_internal_links(content)
 
     return content
@@ -35,6 +36,10 @@ class PodInternalLinkExtension(extensions.BaseExtension):
 
   def __init__(self, pod, config):
     super(PodInternalLinkExtension, self).__init__(pod, config)
+    if 'component_path' in config:
+      self.component_version_resolver = ComponentVersionResolver(pod, config['component_path'])
+    else:
+      self.component_version_resolver = None
 
   @property
   def available_hooks(self):

--- a/pages/extensions/internal_links/component_version_resolver.py
+++ b/pages/extensions/internal_links/component_version_resolver.py
@@ -1,0 +1,74 @@
+import re
+from grow.pods.pods import Pod
+
+COMPONENT_VERSION_PATTERN = re.compile('(amp-.+)-v(\d+)\.(\d+)', re.IGNORECASE)
+
+
+class ComponentDocInfo(object):
+
+  def __init__(self, doc, major_version, minor_version):
+    self.doc = doc
+    self.major_version = int(major_version)
+    self.minor_version = int(minor_version)
+
+  def is_older(self, other_major, other_minor):
+    other_major = int(other_major)
+    other_minor = int(other_minor)
+    if self.major_version < other_major:
+      return True
+    if self.major_version == other_major and self.minor_version < other_minor:
+      return True
+    return False
+
+  def update_if_older(self, doc, other_major, other_minor):
+    if self.is_older(other_major, other_minor):
+      self.doc = doc
+      self.major_version = int(other_major)
+      self.minor_version = int(other_minor)
+
+
+class ComponentVersionResolver(object):
+
+  def __init__(self, pod, components_path):
+    """
+    :type pod: Pod
+    :type components_path: str
+    """
+    self.pod = pod
+    self.latest_components = self.init_latest_versions(components_path)
+    self.no_version_component_pattern = self.init_no_version_pattern(components_path)
+
+  def init_no_version_pattern(self, components_path):
+    if not components_path.endswith('/'):
+      components_path = components_path + '/'
+    # for components matching this pattern we add the latest version number to the link
+    return re.compile(
+      r'^.*' + components_path + r'((?:.(?!-v\d[\d\.]+))+).md$')
+
+  def init_latest_versions(self, components_path):
+    """
+    :type components_path: str
+    """
+    result = {}
+    component_docs = self.pod.get_collection(components_path)
+    for item in component_docs.list_docs():
+      match = COMPONENT_VERSION_PATTERN.match(item.collection_sub_path)
+      if match:
+        component = match.group(1)
+        major_version = match.group(2)
+        minor_version = match.group(3)
+        if component in result:
+          doc_info = result[component]
+          doc_info.update_if_older(item, major_version, minor_version)
+        else:
+          doc_info = ComponentDocInfo(item, major_version, minor_version)
+          result[component] = doc_info
+    return result
+
+  def find_latest_for_component_with_no_version(self, pod_path):
+    match = self.no_version_component_pattern.match(pod_path)
+    if match:
+      component = match.group(1)
+      if component in self.latest_components:
+        return self.latest_components[component].doc
+    return None

--- a/pages/extensions/internal_links/component_version_resolver_test.py
+++ b/pages/extensions/internal_links/component_version_resolver_test.py
@@ -1,0 +1,57 @@
+import unittest
+import sys
+import os
+
+sys.path.extend([os.path.join(os.path.dirname(__file__), '.')])
+
+from component_version_resolver import ComponentVersionResolver
+
+
+class PodInternalLinkRewriterTestCase(unittest.TestCase):
+
+  def test_all(self):
+    docs = [
+      MockDoc('pages/documents/components/amp-list-v0.5.md'),
+      MockDoc('pages/documents/components/amp-list-v1.1.md'),
+      MockDoc('pages/documents/components/amp-list-v1.3.md'),
+      MockDoc('pages/documents/components/amp-list-v1.2.md'),
+      MockDoc('pages/documents/components/amp-amp-list-v2.4.md'),
+      MockDoc('pages/documents/components/amp-img-v2.11.md'),
+      MockDoc('pages/documents/components/amp-img-v11.2.md'),
+    ]
+    pod = MockPod(docs)
+    version_resolver = ComponentVersionResolver(pod, 'pages/documents/components/')
+    doc = version_resolver.find_latest_for_component_with_no_version('pages/documents/components/amp-list.md')
+    self.assertEquals(doc.pod_path, 'pages/documents/components/amp-list-v1.3.md')
+    doc = version_resolver.find_latest_for_component_with_no_version('pages/documents/components/amp-img.md')
+    self.assertEquals(doc.pod_path, 'pages/documents/components/amp-img-v11.2.md')
+    doc = version_resolver.find_latest_for_component_with_no_version('pages/documents/components/amp-unknown.md')
+    self.assertEquals(doc, None)
+
+
+class MockPod:
+
+  def __init__(self, doc_list):
+    self.mock_collection = MockCollection(doc_list)
+
+  def get_collection(self, path):
+    return self.mock_collection
+
+
+class MockCollection:
+
+  def __init__(self, docs):
+    self.docs = docs
+
+  def list_docs(self):
+    return self.docs
+
+
+class MockDoc:
+
+  def __init__(self, pod_path):
+    """
+    :type pod_path: str
+    """
+    self.pod_path = pod_path
+    self.collection_sub_path = pod_path[pod_path.rindex('/') + 1:]

--- a/pages/extensions/internal_links/pod_internal_link_rewriter.py
+++ b/pages/extensions/internal_links/pod_internal_link_rewriter.py
@@ -1,6 +1,7 @@
 import os
 import re
 import traceback
+from component_version_resolver import ComponentVersionResolver
 from grow.pods.pods import Pod
 from grow.documents.document import Document
 from grow.cache.object_cache import ObjectCache
@@ -9,19 +10,21 @@ from grow.cache.object_cache import ObjectCache
 LINK_PATTERN = re.compile(r'<a\s+(?:[^>]+\s)?href\s*=\s*"((?:[^"#?](?!:))*?[^"/])((?:\?[^"]*)?(?:#[^"]*)?)"',
                           re.IGNORECASE)
 
-
 class PodInternalLinkRewriter(object):
 
   pod = None  # type: Pod
 
-  def __init__(self, doc, link_cache):
+  def __init__(self, doc, link_cache, component_version_resolver):
     """
     :type doc: Document
+    :type pod: Pod
     :type link_cache: ObjectCache
+    :type component_version_resolver: ComponentVersionResolver
     """
     self.doc = doc
     self.pod = doc.pod
     self.link_cache = link_cache
+    self.component_version_resolver = component_version_resolver
 
   def rewrite_pod_internal_links(self, content):
     """
@@ -77,12 +80,26 @@ class PodInternalLinkRewriter(object):
     if not result:
       target_doc = self.pod.get_doc(internal_path, self.doc.locale)
       if not target_doc.exists:
-        result = internal_link
+        result = self.get_latest_component_doc_link(internal_path)
+        if not result:
+          result = internal_link
       else:
         result = target_doc.url.path
       self.link_cache.add(internal_path, result)
 
     return result
+
+  def get_latest_component_doc_link(self, absolute_component_path):
+    """
+    :param absolute_component_path:
+    :return: The link for the latest version if the path is a component doc
+    """
+    if self.component_version_resolver:
+      version_doc = self.component_version_resolver.\
+        find_latest_for_component_with_no_version(absolute_component_path)
+      if version_doc:
+        return version_doc.url.path
+    return None
 
   @staticmethod
   def get_folder(path):

--- a/pages/extensions/internal_links/pod_internal_link_rewriter_test.py
+++ b/pages/extensions/internal_links/pod_internal_link_rewriter_test.py
@@ -21,7 +21,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="../folder2/page2.md">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache(), None)
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<a href="/test/folder_2/page2.html">test</a>', result)
@@ -34,7 +34,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="/content/test/folder2/page2.md">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache(), None)
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<a href="/test/folder_2/page2.html">test</a>', result)
@@ -47,7 +47,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="../folder2/page2.md">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache(), None)
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals(content, result)
@@ -61,7 +61,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     content = '<a href="../folder2/page2.md#test">test</a><br>' \
               '<a href="../folder2/page2.md#other">test2</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache(), None)
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals(content, result)
@@ -73,7 +73,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="http://amp.dev/test/folder2/page2.md">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache(), None)
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals(content, result)
@@ -88,7 +88,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     content = '<a href="../folder2/page2.md#test">test</a><br>' \
               '<a href="../folder2/page2.md#other">test2</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache(), None)
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<a href="/test/folder_2/page2.html#test">test</a><br>' \
@@ -102,7 +102,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="../folder2/page2.md?format=ads">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache(), None)
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<a href="/test/folder_2/page2.html?format=ads">test</a>', result)
@@ -115,7 +115,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
     doc = MockPod(link_map).get_doc('/content/test/folder1/page.md')
     content = '<a href="../folder2/page2.md?format=ads#test">test</a>'
 
-    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache(), None)
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<a href="/test/folder_2/page2.html?format=ads#test">test</a>', result)
@@ -134,7 +134,7 @@ class PodInternalLinkRewriterTestCase(unittest.TestCase):
               '<a href="../page4.md">page4</a><br>' \
               '<a href = "./folder1/page.md">page</a></p>'
 
-    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache())
+    link_rewriter = PodInternalLinkRewriter(doc, ObjectCache(), None)
     result = link_rewriter.rewrite_pod_internal_links(content)
 
     self.assertEquals('<p><a  class="link" href="/test/folder_2/page2.html">test</a><br>' \

--- a/platform/config/podspec.yaml
+++ b/platform/config/podspec.yaml
@@ -29,7 +29,8 @@ ext:
 - extensions.amp_dependencies.AmpDependenciesExtension
 - extensions.amp_dev.AmpDevExtension
 - extensions.url_beautifier.UrlBeautifierExtension
-- extensions.internal_links.PodInternalLinkExtension
+- extensions.internal_links.PodInternalLinkExtension:
+    component_path: '/content/amp-dev/documentation/components/reference/'
 - extensions.jinja2_optimized_codehilite.Jinja2OptimizedCodehiliteExtension
 - extensions.markdown_toc_patch.MarkdownTocPatchExtension
 - extensions.markdown_in_html.MarkdownInHtmlExtension:


### PR DESCRIPTION
Currently a lot of documentation links to component docs without a version.
Those links are broken since the component docs now have the version in the name.
You can see lots of broken links here: https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout/?format=websites

This PR extends the grow extension that handles relative links to lookup the latest version of a component documentation.

Information about this was added to the contribution formatting documentation.
Also some other missing and misleading parts about links and templates in examples where changed in this file.