### PR TITLE
Grow link extension should work with grow 0.7.4

### DIFF
--- a/pages/extensions/internal_links/component_version_resolver.py
+++ b/pages/extensions/internal_links/component_version_resolver.py
@@ -1,7 +1,7 @@
 import re
 from grow.pods.pods import Pod
 
-COMPONENT_VERSION_PATTERN = re.compile('(amp-.+)-v(\d+)\.(\d+)', re.IGNORECASE)
+COMPONENT_VERSION_PATTERN = re.compile('.*/(amp-.+)-v(\d+)\.(\d+)', re.IGNORECASE)
 
 
 class ComponentDocInfo(object):
@@ -52,7 +52,7 @@ class ComponentVersionResolver(object):
     result = {}
     component_docs = self.pod.get_collection(components_path)
     for item in component_docs.list_docs():
-      match = COMPONENT_VERSION_PATTERN.match(item.collection_sub_path)
+      match = COMPONENT_VERSION_PATTERN.match(item.pod_path)
       if match:
         component = match.group(1)
         major_version = match.group(2)

--- a/pages/extensions/internal_links/component_version_resolver_test.py
+++ b/pages/extensions/internal_links/component_version_resolver_test.py
@@ -54,4 +54,3 @@ class MockDoc:
     :type pod_path: str
     """
     self.pod_path = pod_path
-    self.collection_sub_path = pod_path[pod_path.rindex('/') + 1:]


### PR DESCRIPTION
Fix the problem that PR #2851 did not work with older grow versions