### PR TITLE
🐛 Only try to access teaser if it exists

### DIFF
--- a/frontend/templates/views/partials/teaser.j2
+++ b/frontend/templates/views/partials/teaser.j2
@@ -91,7 +91,9 @@
       <div class="ap-m-teaser-content">
         <div class="ap-m-teaser-content-text">
           <code><span>{{ teaser_doc.title }}</span></code>
+          {% if teaser_doc.teaser %}
           <p>{{ teaser_doc.teaser.text }}</p>
+          {% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
/cc @dlemm: you can only access frontmatter keys that exist. In comparison to other template languages jinja2 doesn't fail silently 🙂 