### PR TITLE
Clarify Grow installation instructions on Linux, fix broken links, typos, and grammatical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,61 +8,69 @@ The official homepage of the AMP Project.
 
 We welcome contributions to amp.dev.
 
-* **Bug reports and feature requests:** something missing or not working on https://amp.dev? Please file an issue [here](https://github.com/ampproject/docs/issues/new).
+* **Bug reports and feature requests:** something missing or not working on [amp.dev](https://amp.dev)? Please file an issue [here](https://github.com/ampproject/docs/issues/new).
 * **Documentation & Guides:** see [this guide](./contributing/documentation.md) for more information on how to contribute documentation to amp.dev.
 * **Code samples & demos:** see [this guide](./contributing/samples.md) for more information on how to contribute sample code to amp.dev.
 
-**Note:** fixing spelling mistakes and other small changes are often easiest by directly editing a file on Github.
+**Note:** fixing spelling mistakes and other small changes are often easiest by directly editing the file on Github.
 
 <img width="669" alt="Inline editing on Github" src="https://user-images.githubusercontent.com/380472/59018008-2d8f5580-8845-11e9-8160-e2890e2c7944.png">
-
-**Note:** Windows is not a currently supported OS for those intending to conduct development on this repository.
 
 ## Setup
 
 ### Requirements
 
-1.  Install the LTS version of [NodeJS](https://nodejs.org). An easy way to do so is with `nvm`. (Mac and Linux: [here](https://github.com/creationix/nvm)).
+**Note:** For those intending to conduct development on this repository beyond fixing typos, Linux and macOS are the only currently supported operating systems. Windows is not supported at this time.
+
+1. Install the LTS version of [Node.js](https://nodejs.org). An easy way to do so is by using [nvm](https://github.com/nvm-sh/nvm).
+
     ```sh
     $ nvm install --lts
     ```
 
-1.  Install [Grow](http://grow.io) the static site generator used to build amp.dev. Do so by using `pip` instead of the installer. This allows importing from the `grow` package in Python later on:
+1. Install [Grow](http://grow.io), the static site generator used to build amp.dev. Do so by using `pip` instead of its installer. Using `pip` will enable importing from the `grow` package in Python later on.
+
+     **Note**: Be sure to use the `pip` command associated with Python 2.7 as Grow depends on Python 2.7.
+
     ```sh
     $ pip install grow
     ```
-     Note: If using MacOS, here are the simplest steps to install a reliable version of `pip`:
-      1. Install [Homebrew](https://brew.sh/).
-      1. Run `brew doctor` to ensure everything is up to date. Xcode version 10.3 or the the most recent stable version is required. 
-      1. Run `brew install python@2`. Python 2.7 is required. 
-      1. Pip should now be installed! 
 
-1.  Install the dependencies for the project:
+     **Note**: If using Linux, refer to the section of pip's official documentation titled [Ensure you can run pip from the command line](https://packaging.python.org/tutorials/installing-packages/#ensure-you-can-run-pip-from-the-command-line) for pip installation troubleshooting.
+
+     **Note**: If using macOS, the simplest steps to install a reliable version of pip are as follow:
+      1. Install [Homebrew](https://brew.sh/).
+      1. Run `brew doctor` to ensure everything is up to date. Xcode version 10.3 or the most recent stable version is required.
+      1. Run `brew install python@2`. Python 2.7 is required.
+      1. Pip should now be installed!
+
+1. Install the dependencies for the project:
+
     ```sh
     $ npm install
     ```
 
 ### Develop
 
-If it's your first time working on amp.dev it is recommended to bootstrap your local environment. To do so make sure you have setup a valid [GitHub access token](https://github.com/settings/tokens) in an environment variable named `AMP_DOC_TOKEN` like:
+If it's your first time working on amp.dev, it is recommended to bootstrap your local environment. To do so, make sure you have set up a valid [GitHub access token](https://github.com/settings/tokens) in an environment variable named `AMP_DOC_TOKEN` like so:
 
 ```sh
 $ export AMP_DOC_TOKEN="c59f6..."
 ```
 
-This enables the import from GitHub to run flawlessly which can be started by the following command which additionally will build the Playground and Boilerplate Generator once:
+This command enables the import from GitHub to run flawlessly. The actual import occurs by running the following command, which will also build the Playground and Boilerplate Generator once.
 
 ```sh
 $ gulp bootstrap
 ```
 
-You can then start developing in your local environment with the command below. The task will take care of building and copying all files, watching them for changes and rebuild them when needed. Beware that changes to the [express.js](https://expressjs.com/) backend require to restart the task.
+You can then start developing in your local environment with the command below. The task will take care of building and copying all files, watching them for changes, and rebuilding them when needed. Beware that changes to the [Express](https://expressjs.com/) backend requires the Gulp task to be restarted.
 
 ```sh
 $ gulp develop
 ```
 
-This command prints a lot to the shell and will most probably end on `Server ready. Press ctrl-c to quit.`. This means everything went fine so far but other than stated in the logs the site is then available at [http://localhost:8080/](http://localhost:8080/). The service running on 8081 is only Grow rendering the pages.
+This command prints a lot to the shell and will most likely end on `Server ready. Press ctrl-c to quit.`. Seeing this line means everything went fine so far unless otherwise stated in the logs; the site should be available at [http://localhost:8080/](http://localhost:8080/). The service running on port `8081` is only Grow rendering the pages.
 
 ### Maintenance
 
@@ -70,11 +78,11 @@ This command prints a lot to the shell and will most probably end on `Server rea
 Made changes to a lot of Grow documents at once and not quite sure if all references are still valid? You can run `npm run lint:grow` to pick up broken ones.
 
 #### Samples
-Building the samples creates a lot of individual files per sample. In order to still have a quick startup time for development only changed samples are rebuilt. To freshly build *all* samples you can run `gulp develop --clean-samples`.
+Building the samples creates a lot of individual files per sample. In order to still have a quick startup time for development, only changed samples are rebuilt. To freshly build *all* samples you can run `gulp develop --clean-samples`.
 
 ### Run a test build
 To run a local test build that does all the minifying and vends the static pages instead of
-proxying them through to Grow you can run
+proxying them through to Grow you can run:
 
 ```sh
 $ gulp build --env local
@@ -82,7 +90,7 @@ $ npm run start:local
 ```
 
 ## Build
-Caution: starting a build automatically cleans all locations of possible remainings from previous builds. Make sure you don't have anything there that you want to keep - additionally check your working copy for eventual unintended local changes.
+**Caution**: starting a build will automatically clean all locations of possible remainings from previous builds. Make sure you don't have anything there that you want to keep - additionally check your working copy for eventual unintended local changes.
 
 To perform a build run the following command with `--env` being one of the following valid environments: `development`, `local`, `staging` or `production`:
 
@@ -90,7 +98,7 @@ To perform a build run the following command with `--env` being one of the follo
 $ gulp build --env <environment>
 ```
 
-This builds all parts of the project and might take a while. Usually all builds on amp-dev-staging.appspot.com and amp.dev are built using [Travis CI](https://travis-ci.org/ampproject/docs). In case you want to reproduce one of those remote builds in your local environment you can fetch the build artifacts by running:
+This command builds all parts of the project and might take a while. Usually, all builds on [amp-dev-staging.appspot.com](https://amp-dev-staging.appspot.com/) and [amp.dev](https://amp.dev/) are built using [Travis CI](https://travis-ci.org/ampproject/amp.dev). In case you want to reproduce one of those remote builds in your local environment, you can fetch the build artifacts by running:
 
 ```sh
 $ gulp fetchArtifacts --travis-build <build_number>

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/custom-javascript-tutorial.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/custom-javascript-tutorial.md
@@ -1,11 +1,11 @@
 ---
-$title: Add custom JavaScript to AMP pages with amp-script
+$title: Build custom UI with amp-script
 $order: 101
 formats:
   - websites
 tutorial: true
 author: CrystalOnScript
-description: For web experiences requiring a high amount of customization AMP has created amp-script, a component that allows the use of arbitrary JavaScript on your AMP page without affecting the page's overall performance.
+description: For web experiences requiring a high amount of customization AMP has created amp-script, a component that allows the use of arbitrary JavaScript on your AMP page without affecting the page's performance.
 ---
 
 AMP strives to provide solutions that get developers where they want to be quickly and hassle free. However, some types of functionality are too tailored to individual use cases or require custom JavaScript. The AMP framework is expanding to accommodate these needs with [`<amp-script>`](../../../documentation/components/reference/amp-script.md?format=websites). The `amp-script` component allows AMP developers to introduce custom JavaScript that expand page features and render as valid AMP.
@@ -23,7 +23,7 @@ Prerequisites:
 Use the following commands to download and install the starter code: 
 
 ```
-$ git clone git@github.com:CrystalOnScript/vanilla-js-amp-script.git
+$ git clone https://github.com/CrystalOnScript/vanilla-js-amp-script.git
 $ cd vanilla-js-amp-script/starter_code
 $ npm install
 ```
@@ -72,20 +72,12 @@ Our functionality relays and changes the DOM of our `form`. Place the `<form>` e
 </amp-script>
 ```
 
-[tip type="note"]
-**Note**: Currently, the `src` attribute must point to an absolute URL.
-[/tip]
-
 The `src` attribute points to the filepath `http://localhost:8080/js/script.js`. Create a directory titled `js` in the `public` directory and add the `script.js` file. 
 
 
 # Inject custom script
 
 Open the newly created `script.js` file and add `console.log("amp-script here")`. Reload the page and open the [DevTools console](https://developers.google.com/web/tools/chrome-devtools/) to verify it successfully logged "amp-script here". 
-
-[tip type="important"]
-**Important**: amp-script is still in experimental mode. You will need to enable it inside the console by running `AMP.toggleExperiment('amp-script')` and confirming that it returns `true`. Read more about experimental components [here](../../../documentation/guides-and-tutorials/learn/experimental.md?format=websites). 
-[/tip]
 
 Imported script logic from the `amp-script` `src` attribute is debugged in the console, same as JavaScript inside non-AMP pages.
 
@@ -218,6 +210,13 @@ For this to work, we will need to add a `check` class to all the items and defin
 } 
 ```
 
+Ensure you call to `initCheckPassword` in `script.js` and pass it `passwordBox` as an argument to setup the event handlers.
+Our logic is now complete!
+
+```js
+initCheckPassword(passwordBox);
+```
+
 Refresh the page and type into the password input. The elements corresponding to whether the check passed or failed should turn red or green accordingly!
 
 <figure class="alignment-wrapper margin-">
@@ -225,13 +224,6 @@ Refresh the page and type into the password input. The elements corresponding to
     <source src="/static/img/docs/tutorials/custom-javascript-tutorial/checkpassfail.mp4" type="video/mp4" />
   </amp-video>
 </figure>
-
-Ensure you call to `initCheckPassword` in `script.js` and pass it `passwordBox` as an argument to setup the event handlers.
-Our logic is now complete!
-
-```js
-initCheckPassword(passwordBox);
-```
 
 # Congratulations! 
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/custom-javascript-tutorial.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/custom-javascript-tutorial.md
@@ -146,6 +146,7 @@ function initCheckPassword(element) {
       let passed = item.test(element.value);
        // passed/fail logic 
     });
+  };  
 };
 ```
 


### PR DESCRIPTION
This PR resolves #2888, along with several other problems that I discovered.

Corrections include:

- fixing links broken due to repository renaming
- correcting various typos and grammatical errors
- using accurate and consistent speech
- clarifying OS support & Grow installation instructions

A couple of notes:

- It seems like this repository would benefit greatly by defining voice & tone guidelines. Check out [this link](https://lightningdesignsystem.com/guidelines/voice-and-tone/) for an example. I've wanted to learn more about this myself and I think having them would facilitate collaboration on a repository like this.
- Implementating a [Markdown Linter](https://github.com/DavidAnson/markdownlint) would likely assist in maintaining the quality of a substantially Markdown-based site like this.

/to @CrystalOnScript Apologies in advance for the number of changes! I think you'll find that most of them are critical.