### PR TITLE
Fixes cheerio output for transformation

### DIFF
--- a/platform/lib/format-transform/index.js
+++ b/platform/lib/format-transform/index.js
@@ -49,7 +49,7 @@ class FormatTransform {
       throw new Error(`Unsupported transform format: ${target}`);
     }
     const {transforms, validatorRuntime} = this.formats[target];
-    const $ = cheerio.load(input);
+    const $ = cheerio.load(input, {decodeEntities: false});
     this.applyCommentFormatFilters_($, target);
     for (const selector of Object.keys(transforms)) {
       const elements = $(selector);

--- a/platform/lib/format-transform/index.test.js
+++ b/platform/lib/format-transform/index.test.js
@@ -29,7 +29,9 @@ describe('formatTransform', () => {
   });
 
   it('makes no changes when target is websites', () => {
-    const input = '<html ⚡><head></head><body></body></html>';
+    const input = `<html ⚡>
+<head>
+<link rel="canonical" href="<% canonical %>"></head><body></body></html>`;
     expect(formatTransform.transform(input, 'websites')).toEqual({
       transformedContent: input,
     });
@@ -83,12 +85,12 @@ describe('formatTransform', () => {
   });
 
   it('removes @formats', () => {
-    const input = s(`<html ⚡><head></head>
+    const input = s(`<html ⚡><head><style amp-custom>body{color:red}</style></head>
 <!-- comment @formats(websites) -->
 <body>
 </body>
 </html>`);
-    const want = s(`<html ⚡><head></head>
+    const want = s(`<html ⚡><head><style amp-custom>body{color:red}</style></head>
 <!-- comment  -->
 <body>
 </body>

--- a/platform/lib/utils/cheerioHelper.js
+++ b/platform/lib/utils/cheerioHelper.js
@@ -33,7 +33,9 @@ function htmlContent(dom) {
   );
 
   // Ensure doctype has a line break before and after
-  html = html.replace(/<!doctype([^>]+)>/i, '\n<!doctype$1>\n');
+  html = html.replace(/\s*<!doctype([^>]+)>\s*/i, '\n<!doctype$1>\n');
+  // Ensure <head> has a line break before and after
+  html = html.replace(/\s*<(\/?head)>\s*/i, '\n<$1>\n');
   // Remove empty lines
   html = html.replace(/\n\s+\n/g, '\n');
   return html;


### PR DESCRIPTION
-   Makes cheerio not encode HTML entities (required for `<% ... %>` to work).
-   Adds newline before and after `<head>` tag to ensure the parser properly catches it.

Fixes #2901