### PR TITLE
🎨 Unwrap code snippets in sample sections

### DIFF
--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -268,6 +268,9 @@ class SamplesBuilder {
 
     // Rewrite some markdown to be consumable by Grow
     for (const section of parsedSample.document.sections) {
+      // Unwrap code snippet from wrapping divs and remove trailing whitespace
+      section.code = section.codeSnippet();
+
       // Replace GitHub sourcecode syntax by python-markdown
       let markdown = section.doc_;
       markdown = MarkdownDocument.rewriteCodeBlocks(markdown);


### PR DESCRIPTION
Fixes #2928.

This is needed as we are currently simply serializing the parsedSample with `JSON.stringify`. An alternative would be to implement something like `toString()` on `abe.ExampleFile` which takes care of recursively calling available methods on child objects instead of explicitly calling the ones we need like in this PR.