### PR TITLE
Adds a go.amp.dev link for the AMPCS2019 schedule

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -2,6 +2,7 @@
 # Add new entries in alphabetical order
 /ads: /about/ads
 /amp-pwa-amp: https://blog.amp.dev/2018/06/19/the-shadow-reader-improved/
+/ampcs: /events/amp-cs-2019/#Schedule
 /auto-sw: https://github.com/ampproject/amp-sw/
 /camp-code: https://github.com/ampproject/samples/tree/master/amp-camp
 /cors: /documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests


### PR DESCRIPTION
We want a short link to put on AMPCS2019 badges so people can quickly get to the agenda.

I optimistically used the #Schedule anchor; will this actually work?

/cc @alankent @nainar @mattludwig @sebastianbenz 