### PR TITLE
🐛 Escape SSR tags when importing documents

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state.md
@@ -490,7 +490,7 @@ We recommend validating the authenticity of query parameter values by using the 
 </ul>
 <p>To do this on your non-AMP page, include the following JavaScript, which will remove all query parameters from the URL:</p>
 <pre>
-var href = location.href.replace(/\?[^#]+/, '');
+var href = location.href.replace(/\?[^{{'[% raw %]'}}#]{{'{% endraw %}'}}+/, '');
 history.replaceState(null, null, href);
 </pre>
 <p>Adapt this as needed to remove fewer query parameters.</p>

--- a/platform/lib/pipeline/markdownDocument.test.js
+++ b/platform/lib/pipeline/markdownDocument.test.js
@@ -1,5 +1,20 @@
 const MarkdownDocument = require('./markdownDocument.js');
 
+test('Test escape nunjucks tags', async (done) => {
+  const result = MarkdownDocument.escapeNunjucksTags(
+      '<pre>\n' +
+      'var href = location.href.replace(/\?[^#]+/, \'\');\n' +
+      'history.replaceState(null, null, href);\n' +
+      '</pre>\n');
+
+  expect(result).toBe(
+      '<pre>\n' +
+      'var href = location.href.replace(/\?[^{{\'[% raw %]\'}}#]{{\'{% endraw %}\'}}+/, \'\');\n' +
+      'history.replaceState(null, null, href);\n' +
+      '</pre>\n');
+  done();
+});
+
 test('Test escape mustache tags', async (done) => {
   const result = MarkdownDocument.escapeMustacheTags(
       'The [`link`]({{notincode}}) test `code`.\n' +


### PR DESCRIPTION
Fixes #2865 and makes `/documentation/guides-and-tutorials/optimize-and-measure/amp-managing-user-state/?format=websites` available again.