### PR TITLE
🚸 Make Get Started links on home point to Docs/Get Started

### DIFF
--- a/pages/content/amp-dev/index.html
+++ b/pages/content/amp-dev/index.html
@@ -63,7 +63,7 @@ success_stories:
       <div class="ap--container-fluid">
         <div class="ap-o-stage-content">
             <h1 class="ap-o-stage-content-headline">AMP is a web component framework to easily create <span style="white-space: nowrap;">user-first</span><br> {% include 'views/partials/rolling-formats.j2' %}</h1>
-            <a href="documentation/guides-and-tutorials/index.html" class="ap-o-stage-content-button ap-a-btn">Get started</a>
+            <a href="documentation/index.html" class="ap-o-stage-content-button ap-a-btn">Get started</a>
         </div>
       </div>
     </div>
@@ -386,7 +386,7 @@ success_stories:
       </div>
 
       <div class="ap-o-benefits-overview-link">
-        <a href="documentation/guides-and-tutorials/index.html" class="ap-m-lnk ap-m-lnk-square">
+        <a href="documentation/index.html" class="ap-m-lnk ap-m-lnk-square">
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>


### PR DESCRIPTION
Not a fix for a specific issue but something I felt to be better UX: the two Get Started links on the homepage point to the Guides & Tutorials overview page while we introduced the new Get Started page for the documentation which might be a better fit for those links.