### PR TITLE
Fix a bunch of broken samples

### DIFF
--- a/examples/api/amp-access/index.js
+++ b/examples/api/amp-access/index.js
@@ -42,6 +42,9 @@ const LOGIN_FILE_PATH = path.join(__dirname, 'login.html');
 examples.get('/authorization', handleAuthorization);
 examples.get('/login', handleLogin);
 examples.get('/logout', handleLogout);
+examples.post('/pingback', (req, res) => {
+  res.status(200);
+});
 examples.post('/submit', handleSubmit);
 
 function handleAuthorization(request, response) {

--- a/examples/source/1.components/amp-access.html
+++ b/examples/source/1.components/amp-access.html
@@ -30,7 +30,7 @@ author: andreban
   <script id="amp-access" type="application/json">
     {
         "authorization": "/documentation/examples/api/amp-access/authorization?rid=READER_ID&url=CANONICAL_URL&ref=DOCUMENT_REFERRER&_=RANDOM",
-        "pingback": "/documentation/examples/api/amp-access/authorization?rid=READER_ID&url=CANONICAL_URL&ref=DOCUMENT_REFERRER&_=RANDOM",
+        "pingback": "/documentation/examples/api/amp-access/pingback?rid=READER_ID&url=CANONICAL_URL&ref=DOCUMENT_REFERRER&_=RANDOM",
         "login": {
           "sign-in": "/documentation/examples/api/amp-access/login?rid=READER_ID&url=CANONICAL_URL",
           "sign-out": "/documentation/examples/api/amp-access/logout"

--- a/examples/source/1.components/amp-analytics/api.js
+++ b/examples/source/1.components/amp-analytics/api.js
@@ -105,6 +105,7 @@ function embedListenHandler(request, response) {
   const onNewAnalyticsData = function(userData) {
     const content = analyticsTemplate.render({data: userData});
     response.write('data: ' + content + '\n\n');
+    response.flush();
   };
 
   const userData = forUser(account, user);
@@ -186,7 +187,7 @@ function inc(data, event) {
   if (!eventCount) {
     eventCount = 0;
   }
-  return data[event] = eventCount + 1;
+  data[event] = eventCount + 1;
 }
 
 function notifyListeners(user, data) {

--- a/examples/source/1.components/amp-analytics/embed.html
+++ b/examples/source/1.components/amp-analytics/embed.html
@@ -48,8 +48,7 @@
         var query = getQueryParams(document.location.search);
         var account = query.account;
         var user = query.user;
-        var source = new EventSource('/documentation/examples/components/amp-analytics/embed/listen?account=' + account + '&user=' + user);
-        console.log('adding event listener for ' + account + ' and ' + user);
+        var source = new EventSource('https://amp.dev/documentation/examples/components/amp-analytics/embed/listen?account=' + account + '&user=' + user);
         source.onmessage = function(e) {
           updateAnalyticsData(e.data);
           updateTimestamp();

--- a/examples/source/1.components/amp-analytics/index.html
+++ b/examples/source/1.components/amp-analytics/index.html
@@ -65,11 +65,11 @@ This sample demonstrates which events can be measured and how they can be config
 <body>
     <!-- &nbsp; -->
     <amp-iframe class="fixed-dashboard"
-        width="180"
-        height="180" layout="fixed"
-        sandbox="allow-scripts allow-same-origin"
+        width="200"
+        height="240" layout="fixed"
+        sandbox="allow-scripts"
         frameborder="0"
-        src="<% hosts.preview %>/documentation/examples/components/amp-analytics/embed?user=[= user =]&account=ampdev">
+        src="<% base_path %>/embed?test=1&user=[= user =]&account=ampdev">
       <amp-img src="/static/samples/img/pixel-white.png"
           layout="fixed-height"
           height="350"

--- a/examples/source/1.components/amp-recaptcha-input/index.html
+++ b/examples/source/1.components/amp-recaptcha-input/index.html
@@ -71,14 +71,17 @@
 
   <!-- ## Basic usage -->
     <!-- POST Form request, that responds with the resolved recaptcha items. See the [reference documentation](https://amp.dev/documentation/components/amp-recaptcha-input.html) for a walkthrough on the corresponding `grecaptcha` calls. -->
-  <form id="amp-recaptcha-input-form" method="POST" action-xhr="/documentation/examples/components/amp-recaptcha-input/api/recaptcha" target="_top">
+    <form id="amp-recaptcha-input-form" method="POST" action-xhr="<% base_path %>/api/recaptcha" target="_top">
     <fieldset>
       <label>
         <span>Search for</span>
         <input type="search" name="term" required>
       </label>
       <input name="submit-button" type="submit" value="Search">
-      <amp-recaptcha-input layout="nodisplay" name="recaptcha_token" data-sitekey="6LfcQ7IUAAAAAIv1KcgqyExGK0v8dLJtvV_Q6xD-" data-action="recaptcha_example">
+      <amp-recaptcha-input layout="nodisplay" 
+                           name="recaptcha_token" 
+                           data-sitekey="6LfcQ7IUAAAAAIv1KcgqyExGK0v8dLJtvV_Q6xD-" 
+                           data-action="recaptcha_example">
       </amp-recaptcha-input>
     </fieldset>
 

--- a/examples/source/1.components/amp-web-push/index.html
+++ b/examples/source/1.components/amp-web-push/index.html
@@ -40,10 +40,10 @@ preview: default
     <amp-web-push 
         id="amp-web-push"
         layout="nodisplay"
-        helper-iframe-url="<% hosts.preview %>/documentation/examples/components/amp-web-push/amp-web-push-helper-frame.html"
-        permission-dialog-url="<% hosts.preview %>/documentation/examples/components/amp-web-push/amp-web-push-permission-dialog.html"
-        service-worker-url="<% hosts.preview %>/documentation/examples/components/amp-web-push/sw.js"
-        service-worker-scope="<% hosts.preview %>/documentation/examples/components/amp-web-push/">
+        helper-iframe-url="<% base_path %>/amp-web-push-helper-frame.html"
+        permission-dialog-url="<% base_path %>/amp-web-push-permission-dialog.html"
+        service-worker-url="<% base_path %>/sw.js"
+        service-worker-scope="<% base_path %>/">
     </amp-web-push>
 
     <!-- Clicking the subscription widget pops up a page prompting the user for notification permissions and signals the service worker (configured below) to subscribe the user to push in the background. On this example, we are intercepting the call to `onMessageReceivedSubscribe`, and storing the subscription object on IndexedDB.
@@ -56,7 +56,7 @@ preview: default
     -->
     <amp-web-push-widget visibility="subscribed" layout="fixed" width="500" height="180">
         <button on="tap:amp-web-push.unsubscribe">Unsubscribe from Notifications</button>
-        <form method="post" action-xhr="<% hosts.preview %>/documentation/examples/components/amp-web-push/send-push" target="_top">
+        <form method="post" action-xhr="<% base_path %>/send-push" target="_top">
             <input type="submit" value="Send Web Push">
             <div submitting>
                 Sending Push message...

--- a/examples/source/e-commerce/Checkout_Flow/index.html
+++ b/examples/source/e-commerce/Checkout_Flow/index.html
@@ -83,6 +83,7 @@ author: sebastianbenz
               width: 100vw;
               max-width: 700px;
               padding: var(--space-2);
+              box-sizing: border-box;
             }
             .checkout-flow-sample > * + *,
             #checkout-form > * + * {
@@ -178,7 +179,7 @@ author: sebastianbenz
                   single-item
                   layout="fixed-height"
                   credentials="include"
-                  src="shoppingcart?clientId=CLIENT_ID(cart)"
+                  src="<% base_path %>/shoppingcart?clientId=CLIENT_ID(cart)"
                   [src]="shoppingCart.src"
                   binding="no">
           <template type="amp-mustache">
@@ -220,8 +221,12 @@ author: sebastianbenz
         <section [class]="checkoutSuccess ? 'hide' : 'checkout-section'" class="checkout-section">
           <h3> Add a promotional code </h3>
           <form  method="post"
-                 action-xhr="apply-code"
-                 on="submit-success:AMP.setState({shoppingCart: {src: 'shoppingcart?clientId=CLIENT_ID(cart)&' + random()}})"
+                 action-xhr="<% base_path %>/apply-code"
+                 on="submit-success:AMP.setState({
+                        shoppingCart: {
+                          src: '<% base_path %>/shoppingcart?clientId=CLIENT_ID(cart)&' + random()
+                        }
+                     })"
                  target="_top">
             <input name="clientId"
                    type="hidden"
@@ -239,7 +244,7 @@ author: sebastianbenz
           <form  id="checkout-form"
                  method="post"
                  [hidden]="checkoutSuccess"
-                 action-xhr="apply-code"
+                 action-xhr="<% base_path %>/apply-code"
                  on="submit-success:AMP.setState({checkoutSuccess: true})"
                  target="_top">
 

--- a/examples/source/e-commerce/Shopping_Cart/index.html
+++ b/examples/source/e-commerce/Shopping_Cart/index.html
@@ -59,7 +59,7 @@ author: demianrenzulli
         2. Clicking on the "remove" button, updates an state object (`cartItem`), which, in turn, update two hidden fields on the form `form-cart-delete`, and also triggers a form submission. This form will call the server to update the cart, and update the `cartItemsList` object with the response.
         2. The `amp-list` component contains the expression `[src]="cartItemsList.items"`, so that, when the `cartItemsList` object changes, as a result of the previous action, the list gets refreshed with the content of the updated cart.
         -->
-        <amp-list credentials="include" layout="responsive" height="100px" width="500px" src="<% hosts.platform %>/documentation/examples/e-commerce/shopping_cart/cart-items" [src]="cartItemsList.items" binding="no">
+        <amp-list credentials="include" layout="responsive" height="100px" width="500px" src="<% base_path %>/cart-items" [src]="cartItemsList.items" binding="no">
             <template type="amp-mustache" id="cart-items">
                 {{#isEmpty}}
                 <h3>Your Basket is Empty. </h3>
@@ -90,7 +90,7 @@ author: demianrenzulli
     1. The form contains two hidden input fields, bound to the `cartItem` object's variables. When the remove button is clicked, this object gets updated with the details of the item to remove from cart, so the form can send them on the call to the server.
     2. The form updates the `cartItemsList` with the response from the server, so that  `amp-list` can be refreshed with the contents of the updated cart.
     -->
-    <form id="form-cart-delete" method="POST" target="_top" action-xhr="<% hosts.platform %>/documentation/examples/e-commerce/shopping_cart/delete-cart-item" on="submit-success: AMP.setState({
+    <form id="form-cart-delete" method="POST" target="_top" action-xhr="<% base_path %>/delete-cart-item" on="submit-success: AMP.setState({
                 cartItemsList: event.response
             })" novalidate="">
         <input type="hidden" name="id" value="" [value]="cartItem.id">

--- a/examples/source/interactivity-dynamic-content/Comment_Section/index.html
+++ b/examples/source/interactivity-dynamic-content/Comment_Section/index.html
@@ -123,6 +123,7 @@ This sample showcases how to build a comment section in AMP HTML using the [amp-
       width: 100vw;
       max-width: 700px;
       min-height: 500px;
+      box-sizing: border-box;
     }
     .comment-sample > button {
       margin: var(--space-2) 0;
@@ -166,7 +167,7 @@ This sample showcases how to build a comment section in AMP HTML using the [amp-
         -->
         <amp-list id="comments"
                   class="comments"
-                  src="comments"
+                  src="<% base_path %>/comments"
                   layout="fixed-height"
                   height="200"
                   items="."
@@ -206,7 +207,7 @@ This sample showcases how to build a comment section in AMP HTML using the [amp-
               amp-access="loggedIn"
               amp-access-hide
               method="post"
-              action-xhr="comments/new"
+              action-xhr="<% base_path %>/comments/new"
               target="_top"
               on="submit-success:
                     comments.changeToLayoutContainer,

--- a/examples/source/interactivity-dynamic-content/Favorite_Button/index.html
+++ b/examples/source/interactivity-dynamic-content/Favorite_Button/index.html
@@ -137,7 +137,7 @@ author: sebastianbenz
     -->
     <amp-state id="favorite"
                credentials="include"
-               src="favorite">
+               src="<% base_path %>/favorite">
     </amp-state>
 
     <!--
@@ -160,7 +160,7 @@ author: sebastianbenz
     -->
     <form class="favorite-button"
           method="post"
-          action-xhr="favorite"
+          action-xhr="<% base_path %>/favorite"
           target="_top"
           on="submit:AMP.setState({
                         favorite: !favorite
@@ -175,7 +175,7 @@ author: sebastianbenz
                 credentials="include"
                 items="."
                 single-item
-                src="favorite"
+                src="<% base_path %>/favorite"
                 binding="always">
         <template type="amp-mustache">
           <input type="submit"
@@ -204,7 +204,7 @@ author: sebastianbenz
     -->
     <amp-state id="favoriteWithCount"
                credentials="include"
-               src="favorite-with-count">
+               src="<% base_path %>/favorite-with-count">
     </amp-state>
     <!--
     The implementation is similar to the previous sample, but also updates the count when the button is clicked
@@ -221,7 +221,7 @@ author: sebastianbenz
     -->
     <form class="favorite-button"
           method="post"
-          action-xhr="favorite-with-count"
+          action-xhr="<% base_path %>/favorite-with-count"
           target="_top"
           on="submit:AMP.setState({
                    previousFavoriteWithCount: favoriteWithCount,
@@ -242,7 +242,7 @@ author: sebastianbenz
                 items="."
                 single-item
                 noloading
-                src="favorite-with-count"
+                src="<% base_path %>/favorite-with-count"
                 binding="always">
         <template type="amp-mustache">
           <div class="favorite-container">

--- a/examples/source/interactivity-dynamic-content/Poll/index.html
+++ b/examples/source/interactivity-dynamic-content/Poll/index.html
@@ -80,7 +80,7 @@ Read more about [variable substitution](/content/amp-dev/documentation/component
       -->
       <form id="sample-poll"
             method="post"
-            action-xhr="/documentation/examples/interactivity-dynamic-content/poll/submit-poll"
+            action-xhr="<% base_path %>/submit-poll"
             target="_blank">
             <input name="clientId" type="hidden" value="CLIENT_ID(POLL_USER_ID)" data-amp-replace="CLIENT_ID">
             <h3>What is your favorite flightless bird?</h3>
@@ -93,25 +93,25 @@ Read more about [variable substitution](/content/amp-dev/documentation/component
             <div submit-success>
               <script type="text/plain" template="amp-mustache">
                 <p>{{Message}}</p>
-          <p>Here are the results:</p>
-          <table>
-            {{#PollEntryResults}}
-            <tr>
-              <td>
-                {{Answer}}
-              </td>
-              <td>
-                {{Percentage.length}}%
-              </td>
-              <td>
-                {{Votes}}
-              </td>
-              <td>
-                {{#Percentage}}<span class="one-pc-fixed"></span>{{/Percentage}}
-              </td>
-            </tr>
-            {{/PollEntryResults}}
-          </table>
+                <p>Here are the results:</p>
+                <table>
+                  {{#PollEntryResults}}
+                  <tr>
+                    <td>
+                      {{Answer}}
+                    </td>
+                    <td>
+                      {{Percentage.length}}%
+                    </td>
+                    <td>
+                      {{Votes}}
+                    </td>
+                    <td>
+                      {{#Percentage}}<span class="one-pc-fixed"></span>{{/Percentage}}
+                    </td>
+                  </tr>
+                  {{/PollEntryResults}}
+                </table>
               </script>
             </div>
             <div submit-error>

--- a/examples/source/interactivity-dynamic-content/Star_Rating/index.html
+++ b/examples/source/interactivity-dynamic-content/Star_Rating/index.html
@@ -130,7 +130,7 @@ author: sebastianbenz
   We want the form to submit as soon as the user makes a selection, without a Submit button. To do that, we'll set the [`on` attribute](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md#on) of the `input`s to submit the form on [`change`](/content/amp-dev/documentation/components/reference/amp-form.md#input-events).
 
   The initial rating is determined by which radio button has the `checked` attribute set. This is optional. -->
-  <form id="rating" method="post" action-xhr="set" target="_blank">
+  <form id="rating" method="post" action-xhr="<% base_path %>/set" target="_blank">
     <fieldset class="rating">
       <input name="rating" type="radio" id="rating5" value="5" on="change:rating.submit"/>
       <label for="rating5" title="5 stars">☆</label>

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -4,7 +4,9 @@
 {% block head %}
 {{ super() }}
 
+{% if not doc.example.document.metadata.hidePreview %}
 {{ doc.example.document.head|safe }}
+{% endif %}
 
 {# Always include amp-bind for the header and TOC if the sample doesn't include it #}
 {% if 'amp-bind' not in doc.used_components or not inline_preview %}

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -4,6 +4,8 @@
 {% block head %}
 {{ super() }}
 
+{{ doc.example.document.head|safe }}
+
 {# Always include amp-bind for the header and TOC if the sample doesn't include it #}
 {% if 'amp-bind' not in doc.used_components or not inline_preview %}
 {% do doc.amp_dependencies.add('amp-bind', '0.1') %}


### PR DESCRIPTION
The first commit addressed the problem that post requests didn't work in the playground. Unfortunately, there's no way to solve this without re-writing the source files so we'll have to use `<% base_path %>` for these cases. 

The other commits fix the amp-analytics and the amp-access samples which never worked on amp.dev.