### PR TITLE
Describes trust levels for actions and events

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md
@@ -120,7 +120,7 @@ For example, the following is possible in AMP:
 
 ## Event/Action trust compatibility
 
-Similar to native web events and actions, AMP follows a trust model that insures that critical actions are only triggered by highly trusted events, (usually meaning that the event resulted directly from a user interaction such as a tap or click). Currently AMP supports two levels of trust as defined by `ActionTrust` which are `ActionTrust.HIGH` and `ActionTrust.LOW`. An action can only be triggered by an event of equal or higher trust level than required by the action. Refer to the tables below to compare event and action trust levels.
+Similar to Javascript's native `event.isTrusted` distinction between user generated and script-generated events, AMP follows a trust model that insures that critical actions can only be triggered by highly trusted events. High trust events are usually triggered by a user interaction such as a tap or click. Currently AMP supports two levels of trust as defined by `ActionTrust` which are `ActionTrust.HIGH` and `ActionTrust.LOW`. An action can only be triggered by an event of equal or higher trust level than required by the action. Refer to the tables below to compare event and action trust levels.
 
 ## Element-specific events
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md
@@ -118,6 +118,10 @@ For example, the following is possible in AMP:
 
 [/tip]
 
+## Event/Action trust compatibility
+
+Similar to native web events and actions, AMP follows a trust model that insures that critical actions are only triggered by highly trusted events, (usually meaning that the event resulted directly from a user interaction such as a tap or click). Currently AMP supports two levels of trust as defined by `ActionTrust` which are `ActionTrust.HIGH` and `ActionTrust.LOW`. An action can only be triggered by an event of equal or higher trust level than required by the action. Refer to the tables below to compare event and action trust levels.
+
 ## Element-specific events
 
 ### * - all elements
@@ -343,30 +347,37 @@ event.response</pre></td>
 ## Element-specific actions
 
 ### * (all elements)
+Note: All standard actions require a high trust event
+
 <table>
   <tr>
     <th width="40%">Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>hide</code></td>
     <td>Hides the target element.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>show</code></td>
     <td>Shows the target element. If an
     <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#autofocus"><code>autofocus</code> element</a> becomes visible as a
     result, it gains focus.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>toggleVisibility</code></td>
     <td>Toggles the visibility of the target element. If an
     <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#autofocus"><code>autofocus</code> element</a> becomes visible as a
     result, it gains focus.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>toggleClass(class=STRING, force=BOOLEAN)</code></td>
     <td>Toggles class of the target element. <code>force</code> is optional, and if defined, it ensures that class would only be added but not removed if set to <code>true</code>, and only removed but not added if set to <code>false</code>.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>scrollTo(duration=INTEGER, position=STRING)</code></td>
@@ -377,6 +388,7 @@ event.response</pre></td>
     or <code>bottom</code> (default <code>top</code>).
     Specifies the position of the element relative to the viewport after
     scrolling.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>focus</code></td>
@@ -384,6 +396,7 @@ event.response</pre></td>
     on another element (usually parent element). We strongly advise against
     losing focus by focusing on <code>body</code>/<code>documentElement</code>
     for accessibility reasons.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
@@ -392,14 +405,17 @@ event.response</pre></td>
   <tr>
     <th width="20%">Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>play</code></td>
     <td>Plays the audio. Is a no-op if the <code>&lt;amp-audio></code> element is a descendant of <code>&lt;amp-story></code>.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>pause</code></td>
     <td>Pauses the audio. Is a no-op if the <code>&lt;amp-audio></code> element is a descendant of <code>&lt;amp-story></code>.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
@@ -436,14 +452,17 @@ event.response</pre></td>
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>goToSlide(index=INTEGER)</code></td>
     <td>Advances the carousel to a specified slide index.</td>
+    <td>LOW</td>
   </tr>
   <tr>
     <td><code>toggleAutoplay(toggleOn=true|false)</code></td>
     <td>Toggle the carousel's autoplay status. <code>toggleOn</code> is optional.</td>
+    <td>LOW</td>
   </tr>
 </table>
 
@@ -452,10 +471,12 @@ event.response</pre></td>
   <tr>
     <th width="40%">Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>open (default)</code></td>
     <td>Opens the image lightbox with the source image being the one that triggered the action.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
@@ -464,14 +485,17 @@ event.response</pre></td>
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>open (default)</code></td>
     <td>Opens the lightbox.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>close</code></td>
     <td>Closes the lightbox.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
@@ -480,10 +504,12 @@ event.response</pre></td>
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>refresh</code></td>
     <td>Refreshes data from the <code>src</code> and re-renders the list.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
@@ -492,10 +518,12 @@ event.response</pre></td>
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>update (default)</code></td>
     <td>Updates the DOM items to show updated content.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
@@ -504,18 +532,22 @@ event.response</pre></td>
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>selectUp(delta=INTEGER)</code></td>
     <td>Moves the selection up by the value of `delta`. The default `delta` is set to 1.</td>
+    <td>LOW</td>
   </tr>
   <tr>
     <td><code>selectDown(delta=INTEGER)</code></td>
     <td>Moves the selection down by the value of `delta`. The default `delta` is set to -1.</td>
+    <td>LOW</td>
   </tr>
   <tr>
     <td><code>toggle(index=INTEGER, value=BOOLEAN)</code></td>
     <td>Sets the selected element's `selected` attribute if value is 'true', otherwise removes the attribute</td>
+    <td>LOW</td>
   </tr>
 </table>
 
@@ -524,18 +556,22 @@ event.response</pre></td>
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>open (default)</code></td>
     <td>Opens the sidebar.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>close</code></td>
     <td>Closes the sidebar.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>toggle</code></td>
     <td>Toggles the state of the sidebar.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
@@ -544,10 +580,12 @@ event.response</pre></td>
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>refresh</code></td>
     <td>Refetches data at the `src` attribute while ignoring browser cache.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
@@ -556,10 +594,12 @@ event.response</pre></td>
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>dismiss (default)</code></td>
     <td>Hides the referenced user notification element.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
@@ -571,42 +611,51 @@ The actions below are supported in the following AMP video elements: `amp-video`
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>play</code></td>
     <td>Plays the video.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>pause</code></td>
     <td>Pauses the video.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>mute</code></td>
     <td>Mutes the video.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>unmute</code></td>
     <td>Unmutes the video.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>fullscreen</code></td>
     <td>Takes the video to fullscreen.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
-### form
+### amp-form
 <table>
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>clear</code></td>
     <td>Clears any values in the form's inputs.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>submit</code></td>
     <td>Submits the form.</td>
+    <td>HIGH</td>
   </tr>
 </table>
 
@@ -619,34 +668,43 @@ The following are targets provided by the AMP system that have special requireme
 The `AMP` target is provided by the AMP runtime and implements top-level
 actions that apply to the whole document.
 
+Note: All actions on the `AMP` target require a high trust event.
+
 <table>
   <tr>
     <th width="40%">Action</th>
     <th>Description</th>
+    <th width="10%">Required Trust Level</th>
   </tr>
   <tr>
     <td><code>navigateTo(url=STRING, target=STRING, opener=BOOLEAN)</code></td>
     <td>Navigates current window to given URL, to the optional specified target if given (currenly only supporting <code>_top</code> and <code>_blank </code>). The optional <code>opener</code> parameter can be specified when using a target of <code>_blank</code> to allow the newly opened page to access <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/opener"><code>window.opener<code></a>. Supports <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md">standard URL substitutions</a>.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>closeOrNavigateTo(url=STRING, target=STRING, opener=BOOLEAN)</code></td>
     <td>Tries to close the window if allowed, otherwise it navigates similar to <code>navigateTo</code> Action. Useful for use-cases where a "Back" button may need to close the window if it were opened in a new window from previous page or navigate if it wasn't opened.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>goBack</code></td>
     <td>Navigates back in history.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>print</code></td>
     <td>Opens the Print Dialog to print the current page.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td>scrollTo(id=STRING, duration=INTEGER, position=STRING)</td>
     <td>Scrolls to the provided element ID on the current page.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td>optoutOfCid</td>
     <td>Opts out of Client ID generation for all scopes.</td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>setState({foo: 'bar'})</code><sup>1</sup></td>
@@ -655,12 +713,14 @@ actions that apply to the whole document.
       <p>Merges an object literal into the bindable state.</p>
       <p></p>
     </td>
+    <td>HIGH</td>
   </tr>
   <tr>
     <td><code>pushState({foo: 'bar'})</code><sup>1</sup></td>
     <td>
       <p>Requires <a href="https://amp.dev/documentation/components/amp-bind.html#modifying-history-with-amppushstate">amp-bind</a>.</p>
       <p>Merges an object literal into the bindable state and pushes a new entry onto browser history stack. Popping the entry will restore the previous values of variables (in this example, <code>foo</code>).    </td>
+    <td>HIGH</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Closes [https://github.com/ampproject/amphtml/issues/24441](https://github.com/ampproject/amphtml/issues/24441)

### Changes
- Adds an explanation about what event and action trust levels are
- Adds a column to specify the required trust level for every action