### PR TITLE
Fixed example top-frame preview in portrait mode

### DIFF
--- a/frontend/scss/components/organisms/code-preview.scss
+++ b/frontend/scss/components/organisms/code-preview.scss
@@ -82,14 +82,6 @@
       }
     }
 
-    &.landscape {
-      display: block;
-      amp-iframe {
-        width: auto;
-        height: auto;
-      }
-    }
-
     &-portrait,
     &-landscape {
       width: 100%;
@@ -142,6 +134,10 @@
 
     &-landscape &-background {
       width: 100%;
+    }
+
+    &-background.initial-portrait {
+      transform: scale(.5625, 1.7778);
     }
   }
 

--- a/frontend/templates/views/partials/code-preview/code-preview.j2
+++ b/frontend/templates/views/partials/code-preview/code-preview.j2
@@ -92,7 +92,7 @@
                   frameborder="0">
         <div placeholder></div>
       </amp-iframe>
-      <div class="ap-o-code-preview-preview-iframe-background"></div>
+      <div class="ap-o-code-preview-preview-iframe-background initial-{{ initial_orientation }}"></div>
     </div>
   </div>
   {% endif %}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting.md
@@ -437,7 +437,7 @@ This is what it looks like:
 Here is a `top-frame` sample using a remote endpoint. Mustache templates need to be escaped in samples using <code>&#123;% raw %&#125;</code> and <code>&#123;% endraw %}</code>:
 
 <div class="ap-m-code-snippet">
-  <pre>&#91;example preview=&quot;top-frame&quot; orientation=&quot;portrait&quot;
+  <pre>&#91;example preview=&quot;top-frame&quot;
         playground=&quot;true&quot;
         imports=&quot;amp-list:0.1&quot;
         template=&quot;amp-mustache:0.2&quot;]


### PR DESCRIPTION
fix https://github.com/ampproject/amp.dev/issues/2975

also did some small cleanup