### PR TITLE
AMP-CS: add dates to the tab titles of the schedule

### DIFF
--- a/pages/content/amp-dev/events/amp-cs-2019.html
+++ b/pages/content/amp-dev/events/amp-cs-2019.html
@@ -68,7 +68,7 @@ section_links:
   <div class="ap--content-x-wide">
     <amp-selector role="tablist" layout="container" class="ap--flex-container">
 
-        <div class="ap-o-agenda-selector-button ampcs" selected role="tab" tabindex="0" option="a">Tuesday<small>Hackathon / New Contributor Workshop (Optional)</small></div>
+        <div class="ap-o-agenda-selector-button ampcs" selected role="tab" tabindex="0" option="a">Tuesday 8<small>Hackathon / New Contributor Workshop (Optional)</small></div>
 
         <div class="ap-o-agenda">
           <div class="ap--container ampconf-agenda">
@@ -127,7 +127,7 @@ section_links:
           </div>
         </div>
 
-        <div class="ap-o-agenda-selector-button ampcs" role="tab" tabindex="0" option="b">Wednesday<small>Talks + Breakouts</small></div>
+        <div class="ap-o-agenda-selector-button ampcs" role="tab" tabindex="0" option="b">Wednesday 9<small>Talks + Breakouts</small></div>
 
         <div class="ap-o-agenda">
           <div class="ap--container ampconf-agenda">
@@ -188,7 +188,7 @@ section_links:
           </div>
         </div>
 
-        <div class="ap-o-agenda-selector-button ampcs" role="tab" tabindex="0" option="b">Thursday<small>Talks + Breakouts</small></div>
+        <div class="ap-o-agenda-selector-button ampcs" role="tab" tabindex="0" option="b">Thursday 10<small>Talks + Breakouts</small></div>
 
         <div class="ap-o-agenda">
           <div class="ap--container ampconf-agenda">

--- a/pages/content/amp-dev/events/amp-cs-2019.html
+++ b/pages/content/amp-dev/events/amp-cs-2019.html
@@ -68,7 +68,7 @@ section_links:
   <div class="ap--content-x-wide">
     <amp-selector role="tablist" layout="container" class="ap--flex-container">
 
-        <div class="ap-o-agenda-selector-button ampcs" selected role="tab" tabindex="0" option="a">Tuesday 8<small>Hackathon / New Contributor Workshop (Optional)</small></div>
+        <div class="ap-o-agenda-selector-button ampcs" selected role="tab" tabindex="0" option="a">Tuesday, Oct. 8th<small>Hackathon / New Contributor Workshop (Optional)</small></div>
 
         <div class="ap-o-agenda">
           <div class="ap--container ampconf-agenda">
@@ -127,7 +127,7 @@ section_links:
           </div>
         </div>
 
-        <div class="ap-o-agenda-selector-button ampcs" role="tab" tabindex="0" option="b">Wednesday 9<small>Talks + Breakouts</small></div>
+        <div class="ap-o-agenda-selector-button ampcs" role="tab" tabindex="0" option="b">Wednesday, Oct. 9th<small>Talks + Breakouts</small></div>
 
         <div class="ap-o-agenda">
           <div class="ap--container ampconf-agenda">
@@ -188,7 +188,7 @@ section_links:
           </div>
         </div>
 
-        <div class="ap-o-agenda-selector-button ampcs" role="tab" tabindex="0" option="b">Thursday 10<small>Talks + Breakouts</small></div>
+        <div class="ap-o-agenda-selector-button ampcs" role="tab" tabindex="0" option="b">Thursday, Oct. 10th<small>Talks + Breakouts</small></div>
 
         <div class="ap-o-agenda">
           <div class="ap--container ampconf-agenda">


### PR DESCRIPTION
This simply adds the dates to the tab titles of the schedule.