### PR TITLE
Only perform https redirect if scheme is set to https

### DIFF
--- a/platform/lib/middleware/redirects.js
+++ b/platform/lib/middleware/redirects.js
@@ -92,6 +92,11 @@ module.exports = (req, res, next) => {
     return;
   }
 
+  // the following checks are only relevant for https
+  if (config.hosts.platform.scheme !== 'https') {
+    return next();
+  }
+
   // redirect http to https
   setHsts(res);
   if (req.headers['x-forwarded-proto'] === 'https') {

--- a/platform/lib/middleware/redirects.js
+++ b/platform/lib/middleware/redirects.js
@@ -81,11 +81,6 @@ module.exports = (req, res, next) => {
     }
   }
 
-  // don't perform the other redirects on localhost
-  if (req.hostname === 'localhost') {
-    return next();
-  }
-
   // redirect www.amp.dev to amp.dev
   if (req.get('host').startsWith(WWW_PREFIX)) {
     res.redirect(301, `${req.protocol}://${req.host.substring(WWW_PREFIX.length)}${req.originalUrl}`);


### PR DESCRIPTION
This enables local testing with other host name than 'localhost'
Useful for testing with other devices in a local network.
Still not all things will work without https (like search)