### PR TITLE
Fix support section overview and breadcrumbs

### DIFF
--- a/frontend/scss/components/templates/support-overview.scss
+++ b/frontend/scss/components/templates/support-overview.scss
@@ -1,0 +1,49 @@
+/*
+
+##################################
+### TEMPLATE: support overview ###
+##################################
+
+### INFO:
+
+*/
+@import '_extends';
+@import '_functions';
+@import '_mixins';
+@import '_variables';
+
+@import 'components/atoms/_text.scss';
+@import 'components/atoms/_color.scss';
+@import 'components/atoms/_headline.scss';
+
+@import 'components/templates/_default.scss';
+
+.#{template('overview')} {
+  background-color: color('whisper');
+
+  .#{utility('container')} {
+    @include container;
+  }
+
+  .#{utility('content')} {
+    display: grid;
+    grid-column: 1 / 25;
+    grid-template-columns: repeat(24, 1fr);
+    width: 100%;
+    background-color: color('white');
+    padding-bottom: 4em;
+    @include content-shadow;
+  }
+
+  .#{utility('section')} {
+    grid-column: 2 / 23;
+
+    @media (min-width: 600px) {
+      grid-column: 3 / 23;
+    }
+
+    &-fullscreen {
+      grid-column: 1 / 25;
+    }
+  }
+}

--- a/frontend/templates/views/overview/support.j2
+++ b/frontend/templates/views/overview/support.j2
@@ -1,0 +1,26 @@
+{% extends '/layouts/default.j2' %}
+
+{% block styles %}
+{{ super() }}
+
+{% do doc.styles.addCssFile('/css/components/templates/support-overview.css') %}
+{% endblock %}
+
+{% block main %}
+<main class="ap--main ap-t-overview">
+  <div class="ap--container">
+    <div class="ap--content">
+      {% do doc.styles.addCssFile('/css/components/molecules/overview-title.css') %}
+      <section class="ap--section">
+        <div class="ap--overview-title">
+          <div class="ap-m-overview-title">
+            {% include '/views/partials/breadcrumbs.j2' %}
+            <h1>{{ doc.title }}</h1>
+          </div>
+        </div>
+        {{ doc.html|render|safe }}
+      </section>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/frontend/templates/views/partials/breadcrumbs.j2
+++ b/frontend/templates/views/partials/breadcrumbs.j2
@@ -102,11 +102,17 @@ and the current page title #}
 <nav class="ap-m-breadcrumbs">
   {% set support = g.doc('/content/amp-dev/support/index.md', locale=doc.locale) %}
   <a class="ap-m-breadcrumbs-crumb" href="{{ support.url.path }}">{{ _('Support') }}</a>
+
   <span class="ap-m-breadcrumbs-divider">
     <svg class="ap-a-ico ap-m-breadcrumbs-angle"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
   </span>
-  {% set faq = g.doc('/content/amp-dev/support/faq/index.html', locale=doc.locale) %}
-  <a class="ap-m-breadcrumbs-crumb" href="{{ faq.url.path }}">{{ faq.titles('navigation') }}</a>
+
+  {# Use breadcrumb title if it exists #}
+  {% if doc.titles('breadcrumb') %}
+    <div class="ap-m-breadcrumbs-crumb">{{ doc.titles('breadcrumb') }}</div>
+  {% else %}
+    <div class="ap-m-breadcrumbs-crumb">{{ doc.title }}</div>
+  {% endif %}
 </nav>
 {% endif %}
 {% endif %}

--- a/pages/content/amp-dev/support/_blueprint.yaml
+++ b/pages/content/amp-dev/support/_blueprint.yaml
@@ -1,5 +1,5 @@
 $title@: Support
-$view: /views/meta.j2
+$view: /views/overview/support.j2
 $path: /support/{base}.html
 $localization:
   path: /{locale}/support/{base}.html

--- a/pages/content/amp-dev/support/faq/platform-involvement.md
+++ b/pages/content/amp-dev/support/faq/platform-involvement.md
@@ -1,5 +1,7 @@
 ---
 $title@: Platform and Technology Company Involvement
+$titles:
+  breadcrumb: Platform Involvement
 $order: 2
 teaser:
   image:


### PR DESCRIPTION
This pull request fixes issues #2339 (P0) and #3036.

I created an overview template for the support section based on the styles being used by other overview templates since there weren't any preexisting ones with this particular format.

Once I added breadcrumbs to this page, they weren't working properly because the support section breadcrumbs weren't meant to target an overview page like this, so I changed them to mimic the behavior seen in [Get Started](https://amp.dev/documentation/), which is the overview page for the documentation section.

Once the breadcrumbs were properly terminating, one of the FAQ page titles was very long, which caused it to look strange. I opted to allow pages in the support section to specify their own breadcrumb title in the frontmatter ($titles.breadcrumb) if necessary. Then, I provided a better breadcrumb title for this FAQ page.

Here's how the overview page will look if merged.

![fresh-support](https://user-images.githubusercontent.com/17770407/65826576-9451d800-e255-11e9-8afd-f4f9586a769b.png)
