### PR TITLE
Ensure whitespace is aligned correctly when parsing samples

### DIFF
--- a/examples/source/1.components/amp-video.html
+++ b/examples/source/1.components/amp-video.html
@@ -75,8 +75,8 @@ author: sebastianbenz
     The videos below have the bitrate burnt into the video files themselves to
     make it easier to discover when the browser switches between streams. If
     your browser does not support HLS, you will see "No HLS". If you need to
-    create files in the appropriate format, we recommend investigating [shaka
-    packager](https://github.com/google/shaka-packager).
+    create files in the appropriate format, we recommend investigating
+    [shaka packager](https://github.com/google/shaka-packager).
   -->
   <amp-video width="480" height="270"
              poster="/static/samples/img/tokyo.jpg"
@@ -98,9 +98,9 @@ author: sebastianbenz
     </center>
     <br />
 
-    <p>With the implementation of the MediaSessionAPI on AMP, you can now show rich notifications that describe the playing media
+    With the implementation of the MediaSessionAPI on AMP, you can now show rich notifications that describe the playing media
     through the `artist`, `album`, `artwork` and `title` attributes.
-    Learn more by following [this tutorial](/advanced/Rich_Media_Notifications/).</p>
+    Learn more by following [this tutorial](/documentation/examples/multimedia-animations/rich_media_notifications/).
   -->
   <amp-video
     autoplay

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -272,8 +272,9 @@ class SamplesBuilder {
       // Unwrap code snippet from wrapping divs and remove trailing whitespace
       section.code = section.codeSnippet();
 
+      // get the markdown with the 'doc' method that does additional whitespace alignment
+      let markdown = section.doc;
       // Replace GitHub sourcecode syntax by python-markdown
-      let markdown = section.doc_;
       markdown = MarkdownDocument.rewriteCodeBlocks(markdown);
       markdown = MarkdownDocument.escapeMustacheTags(markdown);
 


### PR DESCRIPTION
This will fix #3048
Also fix an invalid link inside amp-video sample