### PR TITLE
Adds a go link for AMP's Working Groups

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -29,6 +29,7 @@
 /tools: /documentation/tools
 /vision-mission: /about/mission-and-vision
 /websites: /about/websites
+/wg: https://github.com/ampproject/meta/tree/master/working-groups
 
 # Regex-based entries
 ^/c/amp-([a-z-]+)$:


### PR DESCRIPTION
This points go.amp.dev/wg to the [Working Groups page](https://github.com/ampproject/meta/tree/master/working-groups) on GitHub.

/cc @ampproject/wg-outreach 