### PR TITLE
:fire: Disable animation for standalone preview

### DIFF
--- a/frontend/scss/components/organisms/code-preview.scss
+++ b/frontend/scss/components/organisms/code-preview.scss
@@ -130,6 +130,7 @@
 
     &-portrait &-background {
       width: 177.78%;
+      transform: scale(.5625, 1.7778);
     }
 
     &-landscape &-background {

--- a/frontend/templates/views/partials/code-preview/code-preview.j2
+++ b/frontend/templates/views/partials/code-preview/code-preview.j2
@@ -22,30 +22,6 @@
     </script>
   </amp-state>
 
-  <amp-animation id="fadeAnimation{{ preview.index }}" layout="nodisplay">
-    <script type="application/json">{
-      "selector": ".ap-o-code-preview-top-preview-{{ preview.index }} amp-iframe",
-      "duration": 250,
-      "delay": 250,
-      "fill": "backwards",
-      "easing": "linear",
-      "keyframes": {
-        "opacity": ["0", "1"]
-      }
-    }</script>
-  </amp-animation>
-  <amp-animation id="morphAnimation{{ preview.index }}" layout="nodisplay">
-    <script type="application/json">{
-      "selector": ".ap-o-code-preview-top-preview-{{ preview.index }} .ap-o-code-preview-preview-iframe-background",
-      "duration": 250,
-      "fill": "both",
-      "easing": "cubic-bezier(0.4, 0, 0.2, 1)",
-      "keyframes": {
-        "transform": ["scale(.5625, 1.7778)", "scale(1, 1)"]
-      }
-    }</script>
-  </amp-animation>
-
   <div class="ap-o-code-preview-top-preview ap-o-code-preview-top-preview-{{ preview.index }}">
 
     <div class="ap-o-code-preview-controls">
@@ -54,10 +30,7 @@
               on="tap:
                   AMP.setState({orientation{{ preview.index }}: false}),
                   iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-landscape'),
-                  iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-portrait'),
-                  fadeAnimation{{ preview.index }}.restart,
-                  morphAnimation{{ preview.index }}.restart,
-                  morphAnimation{{ preview.index }}.reverse">
+                  iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-portrait')">
         <div class="ap-a-ico ap-o-code-preview-controls-icon">
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#orientation-toggle"></use></svg>
         </div>
@@ -67,9 +40,7 @@
               on="tap:
                   AMP.setState({orientation{{ preview.index }}: true}),
                   iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-portrait'),
-                  iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-landscape'),
-                  fadeAnimation{{ preview.index }}.restart,
-                  morphAnimation{{ preview.index }}.restart">
+                  iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-landscape')">
         <div class="ap-a-ico ap-o-code-preview-controls-icon">
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#orientation-toggle"></use></svg>
         </div>


### PR DESCRIPTION
Disabling this because of the issue in Safari won't fix.
Tackling this again another time, with a different solution.

Closes: #2695