### PR TITLE
Update the location information for the AMP Contributor Summit

### DIFF
--- a/pages/content/amp-dev/events/amp-cs-2019.html
+++ b/pages/content/amp-dev/events/amp-cs-2019.html
@@ -302,13 +302,13 @@ section_links:
         </p>
         <ul>
           <li class="ap-m-conf-location-content-text">
-          Tuesday @ <a href="https://goo.gl/maps/ERvhnggy6MKjBpjz9">111 8th Avenue, New York, NY</a>.  Enter the 8th Avenue lobby and look for people with AMP Contributor Summit badges at the Events desk near the Chase.
+          Tuesday @ <a href="https://goo.gl/maps/ERvhnggy6MKjBpjz9">111 8th Avenue, New York, NY</a>.  Enter the main 8th Avenue lobby (near the Chase) and head to the Events section near the back.  Look for people with AMP Contributor Summit badges.
           </li>
           <li class="ap-m-conf-location-content-text">
-            Wednesday @ <a href="https://goo.gl/maps/kH779dQEdLjC967H9">85 10th Avenue, New York, NY</a>.  Enter the 10th Avenue lobby and look for people with AMP Contributor Summit badges at the registration desk.
+            Wednesday @ <a href="https://goo.gl/maps/kH779dQEdLjC967H9">85 10th Avenue, New York, NY</a>.  Enter the 10th Avenue lobby and use the elevator to go to the 3rd floor.  When you exit the elevator on the 3rd floor you will be near the summit location; look for people with AMP Contributor Summit badges.
           </li>
           <li class="ap-m-conf-location-content-text">
-            Thursday @ <a href="https://goo.gl/maps/ERvhnggy6MKjBpjz9">111 8th Avenue, New York, NY</a>.  Enter the 8th Avenue lobby and look for people with AMP Contributor Summit badges at the Events desk near the Chase.
+            Thursday @ <a href="https://goo.gl/maps/ERvhnggy6MKjBpjz9">111 8th Avenue, New York, NY</a>.  Enter the main 8th Avenue lobby (near the Chase) and head to the Events section near the back.  Look for people with AMP Contributor Summit badges.
           </li>
       </div>
 


### PR DESCRIPTION
This updates the location information for the AMP Contributor Summit to be more clear on where people should go.

/cc @ampproject/wg-outreach 