### PR TITLE
Fix sample doc pages not validating

### DIFF
--- a/platform/lib/routers/growPages.js
+++ b/platform/lib/routers/growPages.js
@@ -23,6 +23,7 @@ const config = require('@lib/config');
 const {Templates, createRequestContext} = require('@lib/templates/index.js');
 const AmpOptimizer = require('@ampproject/toolbox-optimizer');
 const CssTransformer = require('@lib/utils/cssTransformer');
+const HeadDedupTransformer = require('@lib/utils/HeadDedupTransformer');
 const signale = require('signale');
 const {getFormatFromRequest} = require('../amp/formatHelper.js');
 
@@ -183,6 +184,7 @@ const growPages = express.Router();
 
 const optimizer = AmpOptimizer.create({
   transformations: [
+    HeadDedupTransformer,
     ...AmpOptimizer.TRANSFORMATIONS_AMP_FIRST,
     CssTransformer,
   ],

--- a/platform/lib/utils/HeadDedupTransformer.js
+++ b/platform/lib/utils/HeadDedupTransformer.js
@@ -24,8 +24,8 @@ const TAGS_TO_DEDUP = {
 };
 
 /**
- * A custom transformer for the @ampproject/toolbox-optimizer rewriting
- * CSS selectors to save bytes in <style amp-custom>.
+ * A custom transformer for the @ampproject/toolbox-optimizer removing
+ * all duplicated viewport and link rel=canonical tags.
  */
 class HeadDedupTransformer {
   constructor(config) {

--- a/platform/lib/utils/HeadDedupTransformer.js
+++ b/platform/lib/utils/HeadDedupTransformer.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://wwwapache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const TAGS_TO_DEDUP = {
+  meta: {
+    name: 'viewport',
+  },
+  link: {
+    rel: 'canonical',
+  },
+};
+
+/**
+ * A custom transformer for the @ampproject/toolbox-optimizer rewriting
+ * CSS selectors to save bytes in <style amp-custom>.
+ */
+class HeadDedupTransformer {
+  constructor(config) {
+    this.log_ = config.log.tag('HeadDedupTransformer');
+  }
+
+  transform(tree) {
+    const html = tree.root.firstChildByTag('html');
+    if (!html) return;
+
+    const head = html.firstChildByTag('head');
+    if (!head) return;
+
+    // build a map of all potential duplicates
+    const matches = new Map();
+    for (const child of head.children) {
+      const dedupRule = this.getDedupRule(child);
+      if (dedupRule) {
+        const existingMatches = matches.get(dedupRule) || [];
+        existingMatches.push(child);
+        matches.set(dedupRule, existingMatches);
+      }
+    }
+    // remove duplicates
+    matches.forEach((matches) => {
+      matches.slice(1).forEach((node) => {
+        node.remove();
+      });
+    });
+  }
+
+  getDedupRule(node) {
+    for (const [key, value] of Object.entries(TAGS_TO_DEDUP)) {
+      if (node.tagName === key) {
+        return this.matchAttributes(node, value) ? value : null;
+      }
+    };
+    return null;
+  }
+
+  matchAttributes(node, obj) {
+    for (const [key, value] of Object.entries(obj)) {
+      if (node.attribs[key] !== value) {
+        return false;
+      }
+    };
+    return true;
+  }
+}
+
+module.exports = HeadDedupTransformer;

--- a/platform/lib/utils/HeadDedupTransformer.test.js
+++ b/platform/lib/utils/HeadDedupTransformer.test.js
@@ -1,0 +1,33 @@
+const AmpOptimizer = require('@ampproject/toolbox-optimizer');
+
+const HeadDedupTransformer = require('./HeadDedupTransformer.js');
+
+test('removes duplicate canonical link and viewport', async () => {
+  expect(await transform(
+      `<html><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <link rel="canonical" href="self1.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <link rel="canonical" href="self2.html">
+</head>
+<body>
+</body></html>`
+  )).toEqual(
+      `<html><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <link rel="canonical" href="self1.html">
+  
+  
+</head>
+<body>
+</body></html>`);
+});
+
+async function transform(string) {
+  const optimizer = AmpOptimizer.create({
+    transformations: [HeadDedupTransformer],
+  });
+  return optimizer.transformHtml(string);
+}


### PR DESCRIPTION
The samples define head tags are injected into the template
causing validation errors due to duplicated tags. I couldn't
come up with a clean handle this on a template level. Instead,
I've opted for writing a optimizer transformer that'll remove
duplicates.
