### PR TITLE
💄 Optimize spacing at the end of line in code-snippets

### DIFF
--- a/frontend/scss/components/molecules/code-snippet.scss
+++ b/frontend/scss/components/molecules/code-snippet.scss
@@ -18,6 +18,7 @@ Styles taken and combined from: https://raw.githubusercontent.com/richleland/pyg
 @import 'components/atoms/_text.scss';
 
 .#{molecule('code-snippet')} {
+  display: flex;
   overflow-x: auto;
   margin: 1.1rem 0 0 0;
   padding: 0 1em;
@@ -25,6 +26,14 @@ Styles taken and combined from: https://raw.githubusercontent.com/richleland/pyg
   line-height: 1.3em;
   background: color('ebony-clay');
   font-size: 0.9em;
+
+  &::after {
+    content: '\00a0\00a0\00a0\00a0\00a0';
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
 
   &::-webkit-scrollbar {
     width: 4px;


### PR DESCRIPTION
I added multiple `&nbsp;` as spacer after the code-snippets to force a space between the last character in the longest line and the edge of the box.

I know this is not the prettiest solution, but after trying to fix this with different approaches like padding, margin, width, calculation etc., I'm almost sure that this is the only solution.
Additionally I made sure that the characters are not selectable.

If anyone has an idea to fix this in a different way, please let me know.

Closes: #2499

<img width="641" alt="Screenshot 2019-10-08 at 14 30 40" src="https://user-images.githubusercontent.com/22053023/66395684-56cd1780-e9d8-11e9-9ffe-731bdb40a443.png">
