### PR TITLE
✨ Implement the experiment toggle in standalone sample preview 

### DIFF
--- a/frontend/scss/components/molecules/device-toggle.scss
+++ b/frontend/scss/components/molecules/device-toggle.scss
@@ -14,16 +14,8 @@
 @import 'components/atoms/_button.scss';
 
 .#{molecule('device-toggle')} {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 0 auto;
-  padding: 10px 0;
-
-  @media (max-width: 767px) {
-    display: none;
-  }
+  flex: 0 0 130px;
+  text-align: center;
 
   &-button {
     @include unset-button;

--- a/frontend/scss/components/molecules/device-toggle.scss
+++ b/frontend/scss/components/molecules/device-toggle.scss
@@ -14,7 +14,6 @@
 @import 'components/atoms/_button.scss';
 
 .#{molecule('device-toggle')} {
-  flex: 0 0 180px;
   text-align: center;
   line-height: 0;
 

--- a/frontend/scss/components/molecules/device-toggle.scss
+++ b/frontend/scss/components/molecules/device-toggle.scss
@@ -14,7 +14,7 @@
 @import 'components/atoms/_button.scss';
 
 .#{molecule('device-toggle')} {
-  flex: 0 0 130px;
+  flex: 0 0 180px;
   text-align: center;
 
   &-button {

--- a/frontend/scss/components/molecules/device-toggle.scss
+++ b/frontend/scss/components/molecules/device-toggle.scss
@@ -16,6 +16,7 @@
 .#{molecule('device-toggle')} {
   flex: 0 0 180px;
   text-align: center;
+  line-height: 0;
 
   &-button {
     @include unset-button;

--- a/frontend/scss/components/molecules/experiments.scss
+++ b/frontend/scss/components/molecules/experiments.scss
@@ -155,7 +155,7 @@
     border-radius: 50%;
   }
 
-  .reload-hint {
+  &-reload-hint {
     margin-right: 15px;
   }
 }

--- a/frontend/scss/components/molecules/experiments.scss
+++ b/frontend/scss/components/molecules/experiments.scss
@@ -158,8 +158,4 @@
     border: 1px solid color('white');
     border-radius: 50%;
   }
-
-  &-reload-hint {
-    margin-right: 15px;
-  }
 }

--- a/frontend/scss/components/molecules/experiments.scss
+++ b/frontend/scss/components/molecules/experiments.scss
@@ -24,8 +24,10 @@
     flex: 1 0 33.3333%;
     padding: 0;
     margin: 0;
-    text-align: right;
     background: none;
+
+    @media (max-device-width: 767px) { text-align: center; }
+    @media (min-device-width: 768px) { text-align: right; }
   }
 
   &-controls {
@@ -37,9 +39,11 @@
 
     #{$self}-iframe & {
       display: inline-flex;
-      justify-content: flex-end;
       padding: 0;
       margin: 0;
+
+      @media (max-device-width: 767px) { justify-content: center; }
+      @media (min-device-width: 768px) { justify-content: flex-end; }
     }
   }
 

--- a/frontend/scss/components/molecules/experiments.scss
+++ b/frontend/scss/components/molecules/experiments.scss
@@ -15,9 +15,18 @@
 @import 'components/atoms/_headline.scss';
 
 .#{molecule('experiments')} {
+  $self: &;
   background: color('white');
   margin: 0 0 32px -30px;
   padding: 20px 30px 20px 30px;
+
+  &-iframe {
+    flex: 1 0 33.3333%;
+    padding: 0;
+    margin: 0;
+    text-align: right;
+    background: none;
+  }
 
   &-controls {
     display: flex;
@@ -25,6 +34,13 @@
     padding: 25px 0 0 0;
     margin: 0 -15px;
     list-style: none;
+
+    #{$self}-iframe & {
+      display: inline-flex;
+      justify-content: flex-end;
+      padding: 0;
+      margin: 0;
+    }
   }
 
   &-control {
@@ -35,12 +51,23 @@
     padding: 15px 10px;
     margin: 0 15px;
     background-color: color('wild-sand');
+
+    #{$self}-iframe & {
+      flex-grow: 0;
+      padding: 0;
+      margin: 4px 15px;
+      background: none;
+    }
   }
 
   &-label {
     flex: 1 0 auto;
     @include txt-font-accent;
     color: color('black');
+
+    #{$self}-iframe & {
+      margin-right: 15px;
+    }
   }
 
   &-channel {
@@ -53,6 +80,14 @@
 
       &.active {
         color: color('blue-ribbon');
+      }
+
+      #{$self}-iframe & {
+        color: color('oslo-gray');
+
+        &.active {
+          color: color('blue-ribbon');
+        }
       }
     }
   }

--- a/frontend/scss/components/molecules/experiments.scss
+++ b/frontend/scss/components/molecules/experiments.scss
@@ -1,8 +1,8 @@
 /*
 
-########################
-### MOLECULE: banner ###
-########################
+#############################
+### MOLECULE: experiments ###
+#############################
 
 */
 
@@ -19,7 +19,7 @@
   margin: 0 0 32px -30px;
   padding: 20px 30px 20px 30px;
 
-  & &-controls {
+  &-controls {
     display: flex;
     flex-wrap: wrap;
     padding: 25px 0 0 0;
@@ -27,7 +27,7 @@
     list-style: none;
   }
 
-  & &-control {
+  &-control {
     position: relative;
     display: flex;
     align-items: center;
@@ -65,6 +65,7 @@
     height: 100%;
     width: 80px;
     opacity: 0;
+    margin: 0;
     cursor: pointer;
 
     &:checked {
@@ -81,7 +82,7 @@
 
   &-indicator {
     position: relative;
-    height: 100%;
+    height: 25px;
     width: 50px;
     border-radius: 2px;
     padding: 2px;

--- a/frontend/scss/components/molecules/experiments.scss
+++ b/frontend/scss/components/molecules/experiments.scss
@@ -154,4 +154,8 @@
     border: 1px solid color('white');
     border-radius: 50%;
   }
+
+  .reload-hint {
+    margin-right: 15px;
+  }
 }

--- a/frontend/scss/components/molecules/experiments.scss
+++ b/frontend/scss/components/molecules/experiments.scss
@@ -158,4 +158,8 @@
     border: 1px solid color('white');
     border-radius: 50%;
   }
+
+  &-reload-hint {
+    margin-right: 15px;
+  }
 }

--- a/frontend/scss/components/organisms/preview-pane.scss
+++ b/frontend/scss/components/organisms/preview-pane.scss
@@ -29,7 +29,7 @@
     justify-content: space-between;
     width: 100%;
     max-width: 1460px;
-    padding: 10px 15px;
+    padding: 5px 15px;
 
     @media (max-width: 767px) {
       display: none;

--- a/frontend/scss/components/organisms/preview-pane.scss
+++ b/frontend/scss/components/organisms/preview-pane.scss
@@ -45,27 +45,6 @@
     padding: 0;
     margin: 0;
     background: none;
-
-    &-controls {
-      justify-content: flex-end;
-      padding: 0;
-      margin: 0;
-    }
-
-    &-control {
-      flex-grow: 0;
-      padding: 0;
-      margin: 4px 15px;
-      background: none;
-    }
-
-    &-label {
-      margin-right: 15px;
-    }
-
-    &-channel-name {
-      color: color('oslo-gray');
-    }
   }
 }
 

--- a/frontend/scss/components/organisms/preview-pane.scss
+++ b/frontend/scss/components/organisms/preview-pane.scss
@@ -23,6 +23,10 @@
   justify-content: flex-start;
   min-height: calc(100vh - 60px);
 
+  @media (max-width: 767px) {
+    flex-direction: column-reverse;
+  }
+
   &-header {
     display: flex;
     align-items: center;
@@ -32,19 +36,26 @@
     padding: 5px 15px;
 
     @media (max-width: 767px) {
-      display: none;
+      padding-left: 0;
+      padding-right: 0;
     }
 
     &-spacer {
       flex: 1 0 33.3333%;
+      @media (max-width: 767px) { display: none; }
     }
-  }
 
-  .#{molecule('experiments')} {
-    flex: 1 0 33.3333%;
-    padding: 0;
-    margin: 0;
-    background: none;
+    .#{molecule('device-toggle')} {
+      flex: 0 0 180px;
+      @media (max-width: 767px) { display: none; }
+    }
+
+    .#{molecule('experiments')} {
+      flex: 1 0 33.3333%;
+      padding: 0;
+      margin: 0;
+      background: none;
+    }
   }
 }
 
@@ -158,7 +169,7 @@
 
   @media (max-width: 767px) {
     width: calc(100vw);
-    height: calc(100vh - 60px);
+    height: calc(100vh - 131px);
     transform: none;
   }
 }

--- a/frontend/scss/components/organisms/preview-pane.scss
+++ b/frontend/scss/components/organisms/preview-pane.scss
@@ -22,6 +22,51 @@
   align-items: center;
   justify-content: flex-start;
   min-height: calc(100vh - 60px);
+
+  &-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    max-width: 1460px;
+    padding: 10px 15px;
+
+    @media (max-width: 767px) {
+      display: none;
+    }
+
+    &-spacer {
+      flex: 1 0 33.3333%;
+    }
+  }
+
+  .#{molecule('experiments')} {
+    flex: 1 0 33.3333%;
+    padding: 0;
+    margin: 0;
+    background: none;
+
+    &-controls {
+      justify-content: flex-end;
+      padding: 0;
+      margin: 0;
+    }
+
+    &-control {
+      flex-grow: 0;
+      padding: 0;
+      margin: 4px 15px;
+      background: none;
+    }
+
+    &-label {
+      margin-right: 15px;
+    }
+
+    &-channel-name {
+      color: color('oslo-gray');
+    }
+  }
 }
 
 .#{organism('preview-pane')} {
@@ -137,5 +182,4 @@
     height: calc(100vh - 60px);
     transform: none;
   }
-
 }

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -122,9 +122,14 @@
 
       {# Render widget to toggle experiments if there are any #}
       {% if doc.example.document.metadata.experiments %}
-      {% with experiments = doc.example.document.metadata.experiments %}
+      <script>
+      const experiments = [
+        {%- for experiment in doc.example.document.metadata.experiments -%}
+        "{{ experiment }}"{{ ', ' if not loop.last }}
+        {%- endfor -%}
+      ]
+      </script>
       {% include '/views/partials/experiments/experiments.j2' %}
-      {% endwith %}
       {% endif %}
 
       {# Check if the sample has a demo button as then this is the primary CTA #}

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -121,31 +121,10 @@
       <h1 class="ap--title" id="{{ doc.example.document.title|slug }}">{{ doc.example.document.title }}</h1>
 
       {# Render widget to toggle experiments if there are any #}
-      {% set experiments = doc.example.document.metadata.experiments %}
-      {% if experiments %}
-      {% do doc.styles.addCssFile('/css/components/molecules/experiments.css', 100) %}
-      <section class="ap-m-experiments">
-        <h3>Experimental</h3>
-        <p>{{ _('This example uses the following experimental feature:') }} {% for experiment in experiments %}<code>{{ experiment }}</code>{% endfor %}. {{ _('Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well.') }} Learn more about <a href="{{ g.doc('/content/amp-dev/documentation/guides-and-tutorials/learn/experimental.md', locale=doc.locale).url.path }}">experimental features</a>.</p>
-
-        <ul class="ap-m-experiments-controls">
-          <li class="ap-m-experiments-control">
-            <label class="ap-m-experiments-label" for="experiments-toggle">Enable Experiment</label>
-            <input class="ap-m-experiments-toggle" id="experiments-toggle" type="checkbox">
-            <aside class="ap-m-experiments-indicator">
-              <div id="indicator"></div>
-            </aside>
-          </li>
-
-          <li class="ap-m-experiments-control">
-            <div class="ap-m-experiments-label">AMP Version</div>
-            <a class="ap-m-experiments-channel" target="_blank" href="https://cdn.ampproject.org/experiments.html">
-              <span class="ap-m-experiments-channel-name" id="prod-channel">PROD</span>
-              <span class="ap-m-experiments-channel-name" id="dev-channel">DEV</span>
-            </a>
-          </li>
-        </ul>
-      </section>
+      {% if doc.example.document.metadata.experiments %}
+      {% with experiments = doc.example.document.metadata.experiments %}
+      {% include '/views/partials/experiments/experiments.j2' %}
+      {% endwith %}
       {% endif %}
 
       {# Check if the sample has a demo button as then this is the primary CTA #}
@@ -243,71 +222,6 @@
   </div>
 </main>
 {% include 'views/partials/example-sidebar.j2' %}
-
-{% if doc.example.document.metadata.experiments %}
-{% set experiments = doc.example.document.metadata.experiments %}
-<script>
-document.addEventListener("DOMContentLoaded", function(event) {
-  (window.AMP = window.AMP || []).push(function(AMP) {
-
-    function areAllExperimentsEnabled() {
-      {% for experiment in experiments %}
-      console.log('isExperimentOn {{ experiment }}:' + AMP.isExperimentOn('{{ experiment }}'));
-      if (!AMP.isExperimentOn('{{ experiment }}')) {
-        return false;
-      }
-      {% endfor %}
-
-      return true;
-    }
-
-    function enableExperiments() {
-      {% for experiment in experiments %}
-      if (!AMP.isExperimentOn('{{ experiment }}')) {
-        AMP.toggleExperiment('{{ experiment }}');
-      }
-      {% endfor %}
-
-      location.reload();
-    }
-
-    function disableExperiments() {
-      {% for experiment in experiments %}
-      if (AMP.isExperimentOn('{{ experiment }}')) {
-        AMP.toggleExperiment('{{ experiment }}');
-      }
-      {% endfor %}
-
-      location.reload();
-    }
-
-    // enable active experiment button
-    var experimentToggle = document.getElementById('experiments-toggle');
-    var indicator = document.getElementById('indicator');
-    if (!areAllExperimentsEnabled()) {
-      experimentToggle.addEventListener('click', enableExperiments);
-      indicator.classList.add('off');
-    } else {
-      experimentToggle.checked = true;
-      experimentToggle.addEventListener('click', disableExperiments);
-      indicator.classList.add('on');
-    }
-
-    // Set appropriate state on channel indicator
-    if (!window.AMP_CONFIG.canary) {
-      document.getElementById('prod-channel').classList.add('active');
-    } else {
-      document.getElementById('dev-channel').classList.add('active');
-    }
-
-    // Inform inspecting user that this intenioally invalid AMP
-    if (window.location.hash.includes('development=1')) {
-      console.log('This sample is intentionally not valid AMP.');
-    }
-  });
-});
-</script>
-{% endif %}
 {% endblock %}
 
 {% block serviceWorker %}

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -122,13 +122,7 @@
 
       {# Render widget to toggle experiments if there are any #}
       {% if doc.example.document.metadata.experiments %}
-      <script>
-      const experiments = [
-        {%- for experiment in doc.example.document.metadata.experiments -%}
-        "{{ experiment }}"{{ ', ' if not loop.last }}
-        {%- endfor -%}
-      ]
-      </script>
+      <script>const experiments = {{ experiments|tojson }}</script>
       {% include '/views/partials/experiments/experiments.j2' %}
       {% endif %}
 

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -122,8 +122,10 @@
 
       {# Render widget to toggle experiments if there are any #}
       {% if doc.example.document.metadata.experiments %}
+      {% with experiments = doc.example.document.metadata.experiments %}
       <script>const experiments = {{ experiments|tojson }}</script>
       {% include '/views/partials/experiments/experiments.j2' %}
+      {% endwith %}
       {% endif %}
 
       {# Check if the sample has a demo button as then this is the primary CTA #}

--- a/frontend/templates/views/examples/preview.j2
+++ b/frontend/templates/views/examples/preview.j2
@@ -58,15 +58,6 @@
     {# Render widget to toggle experiments if there are any #}
     {% if doc.example.document.metadata.experiments %}
     <div class="ap-m-experiments">
-      <script>
-      window.addEventListener('message', receiveMessage, false);
-
-      function receiveMessage(e) {
-        if (e.data === 'reload parent') {
-          location.reload();
-        }
-      }
-      </script>
       <amp-iframe layout="fixed-height"
                   height="66"
                   sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-presentation allow-top-navigation"

--- a/frontend/templates/views/examples/preview.j2
+++ b/frontend/templates/views/examples/preview.j2
@@ -58,6 +58,15 @@
     {# Render widget to toggle experiments if there are any #}
     {% if doc.example.document.metadata.experiments %}
     <div class="ap-m-experiments">
+      <script>
+      window.addEventListener('message', receiveMessage, false);
+
+      function receiveMessage(e) {
+        if (e.data === 'reload parent') {
+          location.reload();
+        }
+      }
+      </script>
       <amp-iframe layout="fixed-height"
                   height="66"
                   sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-presentation allow-top-navigation"

--- a/frontend/templates/views/examples/preview.j2
+++ b/frontend/templates/views/examples/preview.j2
@@ -36,21 +36,36 @@
 {% block main %}
 {% do doc.styles.addCssFile('/css/components/organisms/preview-pane.css') %}
 <main class="ap--preview-pane">
-  {% if not doc.example.document.isAmpAds %}
-  {% do doc.styles.addCssFile('/css/components/molecules/device-toggle.css') %}
-  <div class="ap-m-device-toggle">
-    {% set devices = ['mobile', 'tablet', 'desktop'] %}
+  <div class="ap--preview-pane-header">
+    <div class="ap--preview-pane-header-spacer"></div>
 
-    {% for device in devices %}
-    {% do doc.icons.useIcon('/icons/device-' + device + '.svg') %}
-    <button class="ap-m-device-toggle-button {% if device == 'mobile' %}active{% endif %}" [class]="device.selected == '{{ device }}' ? 'ap-m-device-toggle-button active' : 'ap-m-device-toggle-button'" on="tap:AMP.setState({device: {selected: '{{ device }}'}})">
-      <svg class="ap-a-ico ap-m-device-toggle-icon">
-        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#device-{{ device }}"></use>
-      </svg>
-    </button>
-    {% endfor %}
+    {% if not doc.example.document.isAmpAds %}
+    {% do doc.styles.addCssFile('/css/components/molecules/device-toggle.css') %}
+    <div class="ap-m-device-toggle">
+      {% set devices = ['mobile', 'tablet', 'desktop'] %}
+
+      {% for device in devices %}
+      {% do doc.icons.useIcon('/icons/device-' + device + '.svg') %}
+      <button class="ap-m-device-toggle-button {% if device == 'mobile' %}active{% endif %}" [class]="device.selected == '{{ device }}' ? 'ap-m-device-toggle-button active' : 'ap-m-device-toggle-button'" on="tap:AMP.setState({device: {selected: '{{ device }}'}})">
+        <svg class="ap-a-ico ap-m-device-toggle-icon">
+          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#device-{{ device }}"></use>
+        </svg>
+      </button>
+      {% endfor %}
+    </div>
+    {% endif %}
+
+    {# Render widget to toggle experiments if there are any #}
+    {% if doc.example.document.metadata.experiments %}
+    {% do doc.styles.addCssFile('/css/components/molecules/experiments.css', 100) %}
+    {% with experiments = doc.example.document.metadata.experiments %}
+    <div class="ap-m-experiments">
+      {% include '/views/partials/experiments/experiments-controls.j2' %}
+    </div>
+    {% include '/views/partials/experiments/experiments-script.j2' %}
+    {% endwith %}
+    {% endif %}
   </div>
-  {% endif %}
 
   {% set base_class = 'ap-o-preview-pane ap-o-preview-pane-' + doc.formats[0] %}
   <div class="{{ base_class }} ap-o-preview-pane-mobile" [class]="'{{ base_class }} ap-o-preview-pane-' + device.selected" {% if doc.example.document.metadata.width and doc.example.document.isAmpAds %} style="min-width: {{ doc.example.document.metadata.width }}px;"{% endif %}>

--- a/frontend/templates/views/examples/preview.j2
+++ b/frontend/templates/views/examples/preview.j2
@@ -57,13 +57,17 @@
 
     {# Render widget to toggle experiments if there are any #}
     {% if doc.example.document.metadata.experiments %}
-    {% do doc.styles.addCssFile('/css/components/molecules/experiments.css', 100) %}
-    {% with experiments = doc.example.document.metadata.experiments %}
     <div class="ap-m-experiments">
-      {% include '/views/partials/experiments/experiments-controls.j2' %}
+      <amp-iframe layout="fixed-height"
+                  height="66"
+                  sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-presentation allow-top-navigation"
+                  allowfullscreen
+                  allowpaymentrequest
+                  frameborder="0"
+                  src="{{ podspec.base_urls.preview }}/shared/experiments/?experiments={{doc.example.document.metadata.experiments|join(',')}}">
+        <div placeholder=""></div>
+      </amp-iframe>
     </div>
-    {% include '/views/partials/experiments/experiments-script.j2' %}
-    {% endwith %}
     {% endif %}
   </div>
 

--- a/frontend/templates/views/partials/experiments/experiments-controls.j2
+++ b/frontend/templates/views/partials/experiments/experiments-controls.j2
@@ -1,0 +1,17 @@
+<ul class="ap-m-experiments-controls">
+  <li class="ap-m-experiments-control">
+    <label class="ap-m-experiments-label" for="experiments-toggle">Enable Experiment</label>
+    <input class="ap-m-experiments-toggle" id="experiments-toggle" type="checkbox">
+    <aside class="ap-m-experiments-indicator">
+      <div id="indicator"></div>
+    </aside>
+  </li>
+
+  <li class="ap-m-experiments-control">
+    <div class="ap-m-experiments-label">AMP Version</div>
+    <a class="ap-m-experiments-channel" target="_blank" href="https://cdn.ampproject.org/experiments.html">
+      <span class="ap-m-experiments-channel-name" id="prod-channel">PROD</span>
+      <span class="ap-m-experiments-channel-name" id="dev-channel">DEV</span>
+    </a>
+  </li>
+</ul>

--- a/frontend/templates/views/partials/experiments/experiments-script.j2
+++ b/frontend/templates/views/partials/experiments/experiments-script.j2
@@ -3,32 +3,32 @@ document.addEventListener("DOMContentLoaded", function(event) {
   (window.AMP = window.AMP || []).push(function(AMP) {
 
     function areAllExperimentsEnabled() {
-      {% for experiment in experiments %}
-      console.log('isExperimentOn {{ experiment }}:' + AMP.isExperimentOn('{{ experiment }}'));
-      if (!AMP.isExperimentOn('{{ experiment }}')) {
-        return false;
+      for (var i = 0; i < experiments.length; i++) {
+        console.log('isExperimentOn ' + experiments[i] + ':' + AMP.isExperimentOn(experiments[i]));
+        if (!AMP.isExperimentOn(experiments[i])) {
+          return false;
+        }
       }
-      {% endfor %}
 
       return true;
     }
 
     function enableExperiments() {
-      {% for experiment in experiments %}
-      if (!AMP.isExperimentOn('{{ experiment }}')) {
-        AMP.toggleExperiment('{{ experiment }}');
+      for (var i = 0; i < experiments.length; i++) {
+        if (!AMP.isExperimentOn(experiments[i])) {
+          AMP.toggleExperiment(experiments[i]);
+        }
       }
-      {% endfor %}
 
       location.reload();
     }
 
     function disableExperiments() {
-      {% for experiment in experiments %}
-      if (AMP.isExperimentOn('{{ experiment }}')) {
-        AMP.toggleExperiment('{{ experiment }}');
+      for (var i = 0; i < experiments.length; i++) {
+        if (AMP.isExperimentOn(experiments[i])) {
+          AMP.toggleExperiment(experiments[i]);
+        }
       }
-      {% endfor %}
 
       location.reload();
     }

--- a/frontend/templates/views/partials/experiments/experiments-script.j2
+++ b/frontend/templates/views/partials/experiments/experiments-script.j2
@@ -37,7 +37,10 @@ document.addEventListener("DOMContentLoaded", function(event) {
       if (self==top) {
         location.reload();
       } else {
-        window.parent.postMessage('reload parent', '*');
+        setTimeout(function () {
+          document.querySelector('.ap-m-experiments-controls').hidden = true;
+          document.querySelector('.ap-m-experiments-reload-hint').hidden = false;
+        }, 250);
       }
     }
 

--- a/frontend/templates/views/partials/experiments/experiments-script.j2
+++ b/frontend/templates/views/partials/experiments/experiments-script.j2
@@ -37,10 +37,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
       if (self==top) {
         location.reload();
       } else {
-        setTimeout(function () {
-          document.querySelector('.ap-m-experiments-controls').hidden = true;
-          document.querySelector('.ap-m-experiments-reload-hint').hidden = false;
-        }, 250);
+        window.parent.postMessage('reload parent', '*');
       }
     }
 

--- a/frontend/templates/views/partials/experiments/experiments-script.j2
+++ b/frontend/templates/views/partials/experiments/experiments-script.j2
@@ -1,0 +1,61 @@
+<script>
+document.addEventListener("DOMContentLoaded", function(event) {
+  (window.AMP = window.AMP || []).push(function(AMP) {
+
+    function areAllExperimentsEnabled() {
+      {% for experiment in experiments %}
+      console.log('isExperimentOn {{ experiment }}:' + AMP.isExperimentOn('{{ experiment }}'));
+      if (!AMP.isExperimentOn('{{ experiment }}')) {
+        return false;
+      }
+      {% endfor %}
+
+      return true;
+    }
+
+    function enableExperiments() {
+      {% for experiment in experiments %}
+      if (!AMP.isExperimentOn('{{ experiment }}')) {
+        AMP.toggleExperiment('{{ experiment }}');
+      }
+      {% endfor %}
+
+      location.reload();
+    }
+
+    function disableExperiments() {
+      {% for experiment in experiments %}
+      if (AMP.isExperimentOn('{{ experiment }}')) {
+        AMP.toggleExperiment('{{ experiment }}');
+      }
+      {% endfor %}
+
+      location.reload();
+    }
+
+    // enable active experiment button
+    var experimentToggle = document.getElementById('experiments-toggle');
+    var indicator = document.getElementById('indicator');
+    if (!areAllExperimentsEnabled()) {
+      experimentToggle.addEventListener('click', enableExperiments);
+      indicator.classList.add('off');
+    } else {
+      experimentToggle.checked = true;
+      experimentToggle.addEventListener('click', disableExperiments);
+      indicator.classList.add('on');
+    }
+
+    // Set appropriate state on channel indicator
+    if (!window.AMP_CONFIG.canary) {
+      document.getElementById('prod-channel').classList.add('active');
+    } else {
+      document.getElementById('dev-channel').classList.add('active');
+    }
+
+    // Inform inspecting user that this intenioally invalid AMP
+    if (window.location.hash.includes('development=1')) {
+      console.log('This sample is intentionally not valid AMP.');
+    }
+  });
+});
+</script>

--- a/frontend/templates/views/partials/experiments/experiments-script.j2
+++ b/frontend/templates/views/partials/experiments/experiments-script.j2
@@ -39,7 +39,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
       } else {
         setTimeout(function () {
           document.querySelector('.ap-m-experiments-controls').hidden = true;
-          document.querySelector('.reload-hint').hidden = false;
+          document.querySelector('.ap-m-experiments-reload-hint').hidden = false;
         }, 250);
       }
     }

--- a/frontend/templates/views/partials/experiments/experiments-script.j2
+++ b/frontend/templates/views/partials/experiments/experiments-script.j2
@@ -20,7 +20,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
         }
       }
 
-      location.reload();
+      reloadPage();
     }
 
     function disableExperiments() {
@@ -30,7 +30,18 @@ document.addEventListener("DOMContentLoaded", function(event) {
         }
       }
 
-      location.reload();
+      reloadPage();
+    }
+
+    function reloadPage() {
+      if (self==top) {
+        location.reload();
+      } else {
+        setTimeout(function () {
+          document.querySelector('.ap-m-experiments-controls').hidden = true;
+          document.querySelector('.reload-hint').hidden = false;
+        }, 250);
+      }
     }
 
     // enable active experiment button

--- a/frontend/templates/views/partials/experiments/experiments.j2
+++ b/frontend/templates/views/partials/experiments/experiments.j2
@@ -1,0 +1,9 @@
+{% do doc.styles.addCssFile('/css/components/molecules/experiments.css', 100) %}
+<section class="ap-m-experiments">
+  <h3>Experimental</h3>
+  <p>{{ _('This example uses the following experimental feature:') }} {% for experiment in experiments %}<code>{{ experiment }}</code>{% endfor %}. {{ _('Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well.') }} Learn more about <a href="{{ g.doc('/content/amp-dev/documentation/guides-and-tutorials/learn/experimental.md', locale=doc.locale).url.path }}">experimental features</a>.</p>
+
+  {% include '/views/partials/experiments/experiments-controls.j2' %}
+</section>
+
+{% include '/views/partials/experiments/experiments-script.j2' %}

--- a/pages/content/shared/experiments.html
+++ b/pages/content/shared/experiments.html
@@ -12,5 +12,16 @@ $sitemap:
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
+  <div class="ap-m-experiments ap-m-experiments-iframe">
+    {% include '/views/partials/experiments/experiments-controls.j2' %}
+  </div>
+  <script>
+  const experiments = [
+    [%- for experiment in experiments -%]
+      "[= experiment =]"[= ', ' if not loop.last =]
+    [%- endfor -%]
+  ]
+  </script>
+  {% include '/views/partials/experiments/experiments-script.j2' %}
 </body>
 </html>

--- a/pages/content/shared/experiments.html
+++ b/pages/content/shared/experiments.html
@@ -10,6 +10,14 @@ $sitemap:
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp-custom>
+    {% do doc.styles.addCssFile('css/base.css', -3) %}
+    {% do doc.styles.addCssFile('css/components/atoms/anchor.css', -2) %}
+    {% do doc.styles.addCssFile('/css/components/molecules/experiments.css', -1) %}
+    {{ doc.styles.emit() }}
+    html, body { background: none transparent; }
+    body { display: flex; min-height: 100vh; align-items: center; }
+  </style>
 </head>
 <body>
   <div class="ap-m-experiments ap-m-experiments-iframe">

--- a/pages/content/shared/experiments.html
+++ b/pages/content/shared/experiments.html
@@ -22,7 +22,7 @@ $sitemap:
 <body>
   <div class="ap-m-experiments ap-m-experiments-iframe">
     {% include '/views/partials/experiments/experiments-controls.j2' %}
-    <b class="reload-hint" hidden>{{ _('Please reload the page.' ) }} ↻</b>
+    <b class="ap-m-experiments-reload-hint" hidden>{{ _('Please reload the page.' ) }} ↻</b>
   </div>
   <script>const experiments = [= experiments|dump|safe =]</script>
   {% include '/views/partials/experiments/experiments-script.j2' %}

--- a/pages/content/shared/experiments.html
+++ b/pages/content/shared/experiments.html
@@ -24,7 +24,7 @@ $sitemap:
     {% include '/views/partials/experiments/experiments-controls.j2' %}
     <b class="ap-m-experiments-reload-hint" hidden>{{ _('Please reload the page.' ) }} ↻</b>
   </div>
-  <script>const experiments = [= experiments|dump|safe =]</script>
+  <script>const experiments = (window.location.search.split('=')[1] || '').split(',')</script>
   {% include '/views/partials/experiments/experiments-script.j2' %}
 </body>
 </html>

--- a/pages/content/shared/experiments.html
+++ b/pages/content/shared/experiments.html
@@ -22,6 +22,7 @@ $sitemap:
 <body>
   <div class="ap-m-experiments ap-m-experiments-iframe">
     {% include '/views/partials/experiments/experiments-controls.j2' %}
+    <b class="reload-hint" hidden>{{ _('Please reload the page.' ) }} ↻</b>
   </div>
   <script>
   const experiments = [

--- a/pages/content/shared/experiments.html
+++ b/pages/content/shared/experiments.html
@@ -1,0 +1,16 @@
+$view: /layouts/blank.j2
+$sitemap:
+  enabled: false
+---
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="/" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/pages/content/shared/experiments.html
+++ b/pages/content/shared/experiments.html
@@ -22,7 +22,6 @@ $sitemap:
 <body>
   <div class="ap-m-experiments ap-m-experiments-iframe">
     {% include '/views/partials/experiments/experiments-controls.j2' %}
-    <b class="ap-m-experiments-reload-hint" hidden>{{ _('Please reload the page.' ) }} ↻</b>
   </div>
   <script>const experiments = (window.location.search.split('=')[1] || '').split(',')</script>
   {% include '/views/partials/experiments/experiments-script.j2' %}

--- a/pages/content/shared/experiments.html
+++ b/pages/content/shared/experiments.html
@@ -24,13 +24,7 @@ $sitemap:
     {% include '/views/partials/experiments/experiments-controls.j2' %}
     <b class="reload-hint" hidden>{{ _('Please reload the page.' ) }} ↻</b>
   </div>
-  <script>
-  const experiments = [
-    [%- for experiment in experiments -%]
-      "[= experiment =]"[= ', ' if not loop.last =]
-    [%- endfor -%]
-  ]
-  </script>
+  <script>const experiments = [= experiments|dump|safe =]</script>
   {% include '/views/partials/experiments/experiments-script.j2' %}
 </body>
 </html>

--- a/pages/content/shared/experiments.html
+++ b/pages/content/shared/experiments.html
@@ -22,6 +22,7 @@ $sitemap:
 <body>
   <div class="ap-m-experiments ap-m-experiments-iframe">
     {% include '/views/partials/experiments/experiments-controls.j2' %}
+    <b class="ap-m-experiments-reload-hint" hidden>{{ _('Please reload the page.' ) }} ↻</b>
   </div>
   <script>const experiments = (window.location.search.split('=')[1] || '').split(',')</script>
   {% include '/views/partials/experiments/experiments-script.j2' %}

--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -32,6 +32,7 @@ const routers = {
     embeds: require('@lib/routers/example/embeds.js'),
     sources: require('@lib/routers/example/sources.js'),
     static: require('@lib/routers/example/static.js'),
+    experiments: require('@lib/routers/example/experiments.js'),
     inline: require('@lib/routers/inlineExamples.js'),
   },
   log: require('@lib/routers/runtimeLog.js'),
@@ -134,6 +135,7 @@ class Platform {
       routers.example.static,
       routers.example.embeds,
       routers.example.sources,
+      routers.example.experiments,
       routers.example.inline,
     ])));
   }

--- a/platform/lib/routers/example/experiments.js
+++ b/platform/lib/routers/example/experiments.js
@@ -17,7 +17,7 @@
 'use strict';
 
 
-const {Templates, createRequestContext} = require('@lib/templates/index.js');
+const {Templates} = require('@lib/templates/index.js');
 const express = require('express');
 
 // eslint-disable-next-line new-cap

--- a/platform/lib/routers/example/experiments.js
+++ b/platform/lib/routers/example/experiments.js
@@ -26,7 +26,7 @@ const sharedPages = express.Router();
 sharedPages.get('/shared/experiments/', async (req, res, next) => {
   try {
     const template = await Templates.get('/shared/experiments.html');
-    const rendered = template.render({'experiments': req.query.experiments.split(',')});
+    const rendered = template.render({'experiments': (req.query.experiments || '').split(',')});
     res.send(rendered);
   } catch (e) {
     // page not found

--- a/platform/lib/routers/example/experiments.js
+++ b/platform/lib/routers/example/experiments.js
@@ -26,7 +26,7 @@ const sharedPages = express.Router();
 sharedPages.get('/shared/experiments/', async (req, res, next) => {
   try {
     const template = await Templates.get('/shared/experiments.html');
-    const rendered = template.render({'experiments': (req.query.experiments || '').split(',')});
+    const rendered = template.render({});
     res.send(rendered);
   } catch (e) {
     next(e);

--- a/platform/lib/routers/example/experiments.js
+++ b/platform/lib/routers/example/experiments.js
@@ -29,8 +29,7 @@ sharedPages.get('/shared/experiments/', async (req, res, next) => {
     const rendered = template.render({'experiments': (req.query.experiments || '').split(',')});
     res.send(rendered);
   } catch (e) {
-    // page not found
-    next();
+    next(e);
   }
 });
 

--- a/platform/lib/routers/example/experiments.js
+++ b/platform/lib/routers/example/experiments.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+
+const {Templates, createRequestContext} = require('@lib/templates/index.js');
+const express = require('express');
+
+// eslint-disable-next-line new-cap
+const sharedPages = express.Router();
+
+sharedPages.get('/shared/experiments/', async (req, res, next) => {
+  try {
+    const template = await Templates.get('/shared/experiments.html');
+    const rendered = template.render({'experiments': req.query.experiments.split(',')});
+    res.send(rendered);
+  } catch (e) {
+    // page not found
+    next();
+  }
+});
+
+module.exports = sharedPages;


### PR DESCRIPTION
With this PR the existing experiment toggle from the example pages coming to the standalone sample previews (View demo button).

Closes: #2991

![Screenshot 2019-10-11 at 12 30 11](https://user-images.githubusercontent.com/22053023/66645232-2cbb6580-ec23-11e9-96bc-954890258271.png)

## Desktop
![Screenshot 2019-10-11 at 12 30 26](https://user-images.githubusercontent.com/22053023/66645233-2cbb6580-ec23-11e9-9819-964ec82d2866.png)

## Mobile
![Screenshot 2019-10-11 at 12 31 10](https://user-images.githubusercontent.com/22053023/66645234-2d53fc00-ec23-11e9-90e3-423bfd94b978.png)


