### PR TITLE
Add timestamp to deploy tag

### DIFF
--- a/gulpfile.js/deploy.js
+++ b/gulpfile.js/deploy.js
@@ -28,10 +28,12 @@ const PACKAGER_PREFIX = PREFIX + '-packager';
 // Parse commandline arguments
 const argv = mri(process.argv.slice(2));
 
-// We tag docker images by the current git commit SHA,
+const TIMESTAMP = Date.now();
+
+// We tag docker images by the current git commit SHA + TIMESTAMP,
 // this makes it easy to identify and reproduce builds.
 // Pass a specific tag via commandline using `gulp updateStart --tag ABCDE...`
-const TAG = argv.tag || require('@lib/utils/git').version;
+const TAG = argv.tag || `${require('@lib/utils/git').version}.${TIMESTAMP}`;
 
 // The Google Cloud project id, pass via commandline
 // using `gulp deploy --project my-gcloud-project


### PR DESCRIPTION
This will allow repeated builds with the same commit SHA.