### PR TITLE
🐛 Prevent grid columns from oversizing in Chrome Canary

### DIFF
--- a/frontend/scss/components/organisms/banner.scss
+++ b/frontend/scss/components/organisms/banner.scss
@@ -16,7 +16,7 @@
 
 .#{utility('banner')} {
   display: grid;
-  grid-template-columns: repeat(24, 1fr);
+  grid-template-columns: repeat(24, minmax(0, 1fr));
   padding: 3em 0 4em;
   background-color: color('blue-ribbon');
 

--- a/frontend/scss/components/organisms/resources-overview.scss
+++ b/frontend/scss/components/organisms/resources-overview.scss
@@ -16,7 +16,7 @@
 .#{organism('resources-overview')} {
   position: relative;
   display: grid;
-  grid-template-columns: repeat(24, 1fr);
+  grid-template-columns: repeat(24, minmax(0, 1fr));
   margin: 11em 0 0;
   padding: 3em 0;
 

--- a/frontend/scss/components/templates/_default.scss
+++ b/frontend/scss/components/templates/_default.scss
@@ -20,7 +20,7 @@
   @media (min-width: 768px) {
     display: grid;
     grid-gap: 30px;
-    grid-template-columns: repeat(24, 1fr);
+    grid-template-columns: repeat(24, minmax(0, 1fr));
     padding: 0 30px;
   }
 }
@@ -47,7 +47,7 @@
   @media (min-width: 768px) {
     display: grid;
     grid-gap: 30px;
-    grid-template-columns: repeat(24, 1fr);
+    grid-template-columns: repeat(24, minmax(0, 1fr));
     padding: 0;
   }
 }

--- a/frontend/scss/components/templates/overview.scss
+++ b/frontend/scss/components/templates/overview.scss
@@ -28,7 +28,7 @@
   .#{utility('content')} {
     display: grid;
     grid-column: 1 / 25;
-    grid-template-columns: repeat(24, 1fr);
+    grid-template-columns: repeat(24, minmax(0, 1fr));
     width: 100%;
     background-color: color('white');
     @include content-shadow;

--- a/frontend/scss/components/templates/support-overview.scss
+++ b/frontend/scss/components/templates/support-overview.scss
@@ -28,7 +28,7 @@
   .#{utility('content')} {
     display: grid;
     grid-column: 1 / 25;
-    grid-template-columns: repeat(24, 1fr);
+    grid-template-columns: repeat(24, minmax(0, 1fr));
     width: 100%;
     background-color: color('white');
     padding-bottom: 4em;


### PR DESCRIPTION
Fixing this by setting a minmax to the grid-columns

<img width="1312" alt="Screenshot 1" src="https://user-images.githubusercontent.com/22053023/67018270-482ee080-f0fb-11e9-8112-5dbc38dfc98c.png">
