### PR TITLE
🐛 Fix FAQ teasers

### DIFF
--- a/frontend/scss/components/molecules/teaser-faq.scss
+++ b/frontend/scss/components/molecules/teaser-faq.scss
@@ -24,10 +24,11 @@
     margin: 0 0 2rem;
 
     & > a {
-      @include teaser-linking;
+      position: relative;
       height: 100%;
       display: flex;
       flex-direction: column;
+      transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
 
       &:hover {
         @include teaser-linking-hover;


### PR DESCRIPTION
Stop including `display: block;` from `teaser-linking` mixin and copy the relevant styles instead.

Fixes: #3111

<img width="1183" alt="Screenshot 2" src="https://user-images.githubusercontent.com/22053023/67035825-b3d47600-f11a-11e9-981c-e05a60f4f682.png">
