### PR TITLE
Fix comparing `input-throttled` and `input-debounced` to non-existing `input` event

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md
@@ -173,14 +173,14 @@ event.value</pre>
   <tr>
     <td><code>input-debounced</code></td>
     <td>Fired when the value of the element is changed. This is similar to the standard <code>change</code> event, but it only fires when 300ms have passed after the value of the input has stopped changing.</td>
-    <td>Elements that fire <code>input</code> event.</td>
+    <td>Elements that fire a <code>change</code> event.</td>
     <td>Same as <code>change</code> event data.</td>
   </tr>
     <!-- input-throttled -->
   <tr>
     <td><code>input-throttled</code></td>
     <td>Fired when the value of the element is changed. This is similar to the standard <code>change</code> event, but it is throttled to firing at most once every 100ms while the value of the input is changing.</td>
-    <td>Elements that fire <code>input</code> event.</td>
+    <td>Elements that fire a <code>change</code> event.</td>
     <td>Same as <code>change</code> event data.</td>
   </tr>
 </table>


### PR DESCRIPTION
Closes #1341