### PR TITLE
🌐 Add insticator to translated md-files for amp-ad component.

### DIFF
--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ar.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ar.md
@@ -418,6 +418,7 @@ draw3p(function(config, done) {
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@es.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@es.md
@@ -420,6 +420,7 @@ Consulta las [reglas de amp-ad](https://github.com/ampproject/amphtml/blob/maste
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@fr.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@fr.md
@@ -419,6 +419,7 @@ Consultez les [règles relatives à amp-ad](https://github.com/ampproject/amphtm
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@id.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@id.md
@@ -419,6 +419,7 @@ Lihat [aturan amp-ad](https://github.com/ampproject/amphtml/blob/master/extensio
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@it.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@it.md
@@ -422,6 +422,7 @@ Consulta le [regole amp-ad](https://github.com/ampproject/amphtml/blob/master/ex
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ja.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ja.md
@@ -416,6 +416,7 @@ AMP 検証ツールの仕様で [amp-ad のルール](https://github.com/ampproj
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ko.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ko.md
@@ -420,6 +420,7 @@ AMP 유효성 검사기 사양의 [amp-ad 규칙](https://github.com/ampproject/
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@pt_BR.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@pt_BR.md
@@ -419,6 +419,7 @@ Consulte as [regras de amp-ad](https://github.com/ampproject/amphtml/blob/master
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ru.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ru.md
@@ -418,6 +418,7 @@ draw3p(function(config, done) {
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@tr.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@tr.md
@@ -417,6 +417,7 @@ AMP doğrulayıcı spesifikasyonundaki [amp-ad kurallarına](https://github.com/
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@zh_CN.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@zh_CN.md
@@ -417,6 +417,7 @@ draw3p(function(config, done) {
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)
 * [Epeex](https://github.com/ampproject/amphtml/blob/master/ads/epeex.md)
+* [Insticator](https://github.com/ampproject/amphtml/blob/master/ads/insticator.md)
 * [Jubna](https://github.com/ampproject/amphtml/blob/master/ads/jubna.md)
 * [Outbrain](https://github.com/ampproject/amphtml/blob/master/ads/outbrain.md)
 * [Postquare](https://github.com/ampproject/amphtml/blob/master/ads/postquare.md)


### PR DESCRIPTION
Update translated md-files for `amp-ad` / `amp-embed` component to add Insticator to the list of supported embed types.

Languages: ar, es, fr, id, it, ja, ko, pt, ru, tr, cn.

@CrystalOnScript 

cc @triso07