### PR TITLE
🐛 Search: fix autosubmitting by clicking outside of the input

### DIFF
--- a/frontend/scss/components/organisms/search.scss
+++ b/frontend/scss/components/organisms/search.scss
@@ -155,7 +155,8 @@
 
   &-submit {
     @include btn;
-    display: none;
+    opacity: 0;
+    pointer-events: none;
     position: absolute;
     top: 11px;
     right: 10px;
@@ -181,9 +182,11 @@
     }
   }
 
+  &-submit:focus,
   &-input:focus + &-submit {
     @media (min-width: 1024px) {
-      display: inline-block;
+      opacity: 1;
+      pointer-events: auto;
     }
   }
 

--- a/frontend/templates/views/partials/search.j2
+++ b/frontend/templates/views/partials/search.j2
@@ -37,7 +37,7 @@
             class="ap-o-search-form"
             id="searchForm"
             method="POST"
-            on="submit:searchResult.focus"
+            on="submit:AMP.setState({ query: throttledValue }),searchResult.focus"
             target="_top">
         <amp-autocomplete class="ap-o-search-autocomplete"
                           filter="substring"
@@ -53,10 +53,7 @@
                  class="ap-o-search-input"
                  name="q"
                  placeholder="{{_('What are you looking for?')}}"
-                 on="input-throttled:
-                       AMP.setState({ throttledValue: event.value });
-                     change:
-                       AMP.setState({ query: event.value })"
+                 on="input-throttled:AMP.setState({ throttledValue: event.value })"
                  required
           >
           <button class="ap-o-search-submit" type="submit" name="search-submit" disabled [disabled]="!throttledValue">{{_('Search')}}</button>


### PR DESCRIPTION
With this PR it is possible again to click on any result or teaser, while something new is typed in the input field.

Fixes: #3164