### PR TITLE
🐛 Fix examples documentation pages styling bugs

### DIFF
--- a/frontend/scss/components/templates/_default.scss
+++ b/frontend/scss/components/templates/_default.scss
@@ -62,7 +62,7 @@
   }
 
   @media (min-width: 1024px) {
-    grid-column: 7 / 24;
+    grid-column: 7 / 25;
   }
 
 
@@ -161,7 +161,7 @@
     & ~ .#{utility('content')} {
       padding-top: 0;
       @media (min-width: 768px) {
-        grid-column: 8/25;
+        grid-column: 8 / 25;
         padding-left: 30px;
       }
 
@@ -170,6 +170,11 @@
         padding-left: 30px;
         padding-right: 30px;
       }
+    }
+
+    & ~ .#{utility('help')} ~ .#{utility('content')} {
+      @media (min-width: 768px) { grid-column-end: 25; }
+      @media (min-width: 1024px) { grid-column-end: 25; }
     }
   }
 

--- a/frontend/scss/components/templates/examples/manual.scss
+++ b/frontend/scss/components/templates/examples/manual.scss
@@ -35,7 +35,7 @@
     }
 
     @media (min-width: 1024px) {
-      grid-column: 6 / 24;
+      grid-column: 6 / 25;
       padding-left: 30px;
       padding-right: 30px;
     }

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -68,7 +68,7 @@
 {% block body %}
 {% set body_tag = doc.example.document.body %}
 {% set available_formats = ' '.join(doc.formats or doc.collection.formats or ['websites', 'stories', 'ads', 'email']) %}
-{{ (body_tag.replace('>', ' data-available-formats="' + available_formats + '">'))|safe }}
+{{ (body_tag.replace('>', ' data-available-formats="' + available_formats + '" class="[= \'ap--\' + format if format =]">'))|safe }}
 {{ doc.example.document.elementsAfterBody|safe }}
 {% endblock %}
 


### PR DESCRIPTION
This PR fixes the following bugs of each example docs page:
- missing background color for the current format
- gap at the help/author section on the bottom

Fixes: #3165 
