### PR TITLE
🐛 Allow carriage return in MarkdownDocument

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure.md
@@ -71,8 +71,8 @@ case, emails will display the `text/html` or `text/plain` part.
 
 <!-- prettier-ignore-start -->
 [sourcecode:html]
-From:  Person A <persona@gmail.com>
-To: Person B <personb@gmail.com>
+From:  Person A <persona@example.com>
+To: Person B <personb@example.com>
 Subject: An AMP email!
 Content-Type: multipart/alternative; boundary="001a114634ac3555ae05525685ae"
 

--- a/pages/shared/data/blog.yaml
+++ b/pages/shared/data/blog.yaml
@@ -2,6 +2,12 @@ entries:
 
 - title: "Blog"
   image: ""
+  headline: "Skimlinks’ Pioneering AMP Extension Helps Maximize Commerce Content Revenues"
+  date: "November 1, 2019"
+  url: "https://blog.amp.dev/2019/11/01/skimlinks-pioneering-amp-extension-helps-maximize-commerce-content-revenues/"
+
+- title: "Blog"
+  image: ""
   headline: "Users Prefer Tappable Stories On The Mobile Web"
   date: "October 25, 2019"
   url: "https://blog.amp.dev/2019/10/25/users-prefer-tappable-stories-on-the-mobile-web/"
@@ -23,9 +29,3 @@ entries:
   headline: "AMP is joining the OpenJS Foundation incubation program"
   date: "October 10, 2019"
   url: "https://blog.amp.dev/2019/10/10/amp-is-joining-the-openjs-foundation-incubation-program/"
-
-- title: "Blog"
-  image: "https://blog.amp.dev/wp-content/uploads/2019/09/image2-copy-2.png"
-  headline: "People Behind The Code: Simon Rønbøl’s AMP journey"
-  date: "September 25, 2019"
-  url: "https://blog.amp.dev/2019/09/25/people-behind-the-code-simon-ronbols-amp-journey/"

--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -199,10 +199,9 @@ class MarkdownDocument {
 
   _bootstrapFrontmatter() {
     // Check if the document defines its own frontmatter already
-    if (this._contents.startsWith('---\n')) {
-      const FRONTMATTER_PATTERN = /---\n.*\n---\n/ms;
+    if (this._contents.startsWith('---')) {
+      const FRONTMATTER_PATTERN = /^---\r?\n.*\r?\n---\r?\n/ms;
       let frontmatter = this._contents.match(FRONTMATTER_PATTERN);
-
       if (!frontmatter) {
         LOG.warn(`Unparseable frontmatter in ${this.path}`);
       } else {


### PR DESCRIPTION
The docs for `amp-izlesene` seem to have been authored on a Windows machine which caused them to have `\r\n` instead of just `\n` in them. That made splicing out the frontmatter fail.