### PR TITLE
Remove obsolete @filter logic

### DIFF
--- a/platform/lib/samples/CodeSection.js
+++ b/platform/lib/samples/CodeSection.js
@@ -88,7 +88,6 @@ module.exports = class CodeSection {
 
   appendDoc(doc) {
     doc = doc.replace(/<!--|-->/gm, '') + '\n';
-    doc = this.parseFilters(doc);
     this.extractHeadings(doc);
     this.doc_ += doc;
     this.cachedMarkedDoc = false;
@@ -252,18 +251,6 @@ module.exports = class CodeSection {
       return string;
     }
     return lines.slice(1, lines.length-1).join('\n');
-  }
-
-  parseFilters(line) {
-    const filterMatch = line.match(/@filter\(([^)]+)\)/);
-    if (!filterMatch) {
-      return line;
-    }
-    if (this.filters) {
-      throw new Error('Multiple @filter annotations found in section');
-    }
-    this.filters = filterMatch[1].split(',').map((f) => f.trim());
-    return line.replace(filterMatch[0], '');
   }
 
   extractHeadings(line) {

--- a/platform/lib/samples/CodeSection.test.js
+++ b/platform/lib/samples/CodeSection.test.js
@@ -79,13 +79,6 @@ describe('CodeSection', () => {
       section.appendDoc('  -->');
       expect(section.doc).toEqual('\nhello\n\n\nworld\n\n');
     });
-
-    it('parses filters', () => {
-      section.appendDoc('<!--hello');
-      section.appendDoc('world! @filter(websites, email)-->');
-      expect(section.doc).toEqual('hello\nworld! \n');
-      expect(section.filters).toEqual(['websites', 'email']);
-    });
   });
   describe('hide columns if code section', () => {
     /*


### PR DESCRIPTION
I'm not sure how I missed this, but #2411 added the same feature as `@formats` and in a different place.