### PR TITLE
🐛 Fix iframe preview rotation glitch and overflow fading-bar

### DIFF
--- a/frontend/scss/components/organisms/code-preview.scss
+++ b/frontend/scss/components/organisms/code-preview.scss
@@ -156,20 +156,19 @@
       position: relative;
       width: 100%;
       min-height: 0;
+      padding: 1em 1em 0;
       margin-top: 0;
-      padding-bottom: 2em;
+    }
 
-      &::before {
-        content: '';
-        display: block;
-        width: calc(100% + 2em);
-        height: 2em;
-        position: sticky;
-        position: -webkit-sticky;
-        top: 0;
-        margin-left: -1em;
-        background: linear-gradient(0deg, rgba(color('ebony-clay'), 0) 0%, color('ebony-clay') 50%);
-      }
+    &::after {
+      content: '';
+      display: block;
+      width: calc(100% - 4px);
+      height: 2em;
+      position: absolute;
+      top: 100%;
+      left: 0;
+      background: linear-gradient(0deg, rgba(color('ebony-clay'), 0) 0%, color('ebony-clay') 50%);
     }
   }
 

--- a/frontend/templates/views/partials/code-preview/code-preview.j2
+++ b/frontend/templates/views/partials/code-preview/code-preview.j2
@@ -30,7 +30,8 @@
               on="tap:
                   AMP.setState({orientation{{ preview.index }}: false}),
                   iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-landscape'),
-                  iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-portrait')">
+                  iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-portrait'),
+                  bgContainer{{ preview.index }}.toggleClass(class='initial-{{ initial_orientation }}', force=false)">
         <div class="ap-a-ico ap-o-code-preview-controls-icon">
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#orientation-toggle"></use></svg>
         </div>
@@ -40,7 +41,8 @@
               on="tap:
                   AMP.setState({orientation{{ preview.index }}: true}),
                   iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-portrait'),
-                  iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-landscape')">
+                  iframeContainer{{ preview.index }}.toggleClass(class='ap-o-code-preview-preview-iframe-landscape'),
+                  bgContainer{{ preview.index }}.toggleClass(class='initial-{{ initial_orientation }}', force=false)">
         <div class="ap-a-ico ap-o-code-preview-controls-icon">
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#orientation-toggle"></use></svg>
         </div>
@@ -63,7 +65,7 @@
                   frameborder="0">
         <div placeholder></div>
       </amp-iframe>
-      <div class="ap-o-code-preview-preview-iframe-background initial-{{ initial_orientation }}"></div>
+      <div id="bgContainer{{ preview.index }}" class="ap-o-code-preview-preview-iframe-background initial-{{ initial_orientation }}"></div>
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
This PR fixes the rotation glitch on preview iframes (#3166) by removing the initial orientation class.

Additionally, I found a bug on the overflow fading-bar on top of the code snippets (when scrolling the code up). I fixed this by placing the bar on the parent element.

Fixes: #3166 