### PR TITLE
Don't transform URL if it contains <%

### DIFF
--- a/platform/lib/config.js
+++ b/platform/lib/config.js
@@ -152,6 +152,10 @@ class Config {
    * @return {String} The absolute URL
    */
   absoluteUrl(hostConfig, url) {
+    // The URL uses a template, don't process it.
+    if (url.indexOf('<%') > -1) {
+      return url;
+    }
     return new URL(url, this.getHost(hostConfig)).toString();
   }
 


### PR DESCRIPTION
If the URL contains templates like `<% base_path %>`, then `absoluteUrl` will escape this:

```js
absoluteUrl(conf, '<% base_path %>/test') === 'https://amp.dev/%3C%%20base_path%20%%3E/test'
```

This makes `absoluteUrl` ignore these URLs (which are probably absolute anyway) and fixes the current issue where transformed samples don't work (e.g. star rating for email).