### PR TITLE
Remove WP Stories editor while we're rebooting

### DIFF
--- a/pages/shared/data/tools.yaml
+++ b/pages/shared/data/tools.yaml
@@ -41,17 +41,6 @@ creation:
       height: 549
     formats:
       - ads
-  - name: AMP Stories for WordPress (Beta)
-    official: true
-    description: The AMP for WordPress plugin now comes with a fully integrated story editor.
-    url: https://github.com/ampproject/amp-wp/wiki/AMP-Stories-Experimental
-    type: WYSIWYG Editor
-    image:
-      src: /static/img/tools/amp_stories_for_wordpress.jpg
-      width: 700
-      height: 402
-    formats:
-      - stories
   - name: Google Web Designer
     description: Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device.
     url: https://support.google.com/webdesigner/answer/7529856?hl=en


### PR DESCRIPTION
This will remove the WP story editor from the tools page while in its current rough beta state to be more consistent of what quality bar tools need to meet to appear on the page.