### PR TITLE
amp-list rendering from amp-state height fix.

### DIFF
--- a/examples/source/1.components/amp-list.html
+++ b/examples/source/1.components/amp-list.html
@@ -145,7 +145,7 @@ The template can also be specified using an ID of an existing `template` element
   <!--
     ## Rendering `amp-state`
 
-    This sample shows off once of `amp-list`'s most powerful features: being able to directly render objects from `amp-state`, This is possible by binding the results of an `amp-bind` expression to the `src` attribute: `[src]="items"`. To make sure that the `amp-list` resizes accordingly, we dynamically calculate the `height` based on the number of list elements: `[height]="items.length * 24"`. The initial state (an empty list) is defined in an `amp-state` element.
+    This sample shows off once of `amp-list`'s most powerful features: being able to directly render objects from `amp-state`, This is possible by binding the results of an `amp-bind` expression to the `src` attribute: `[src]="items"`. To make sure that the `amp-list` resizes accordingly, we dynamically calculate the `height` based on the number of list elements: `[height]="items.length * 22"`. The initial state (an empty list) is defined in an `amp-state` element.
 
     Important: `amp-bind` expressions are **not** evaluated on page load, but only after an user interaction has taken place. Initial `amp-list` content still needs to be fetched from a JSON endpoint.
 
@@ -159,7 +159,7 @@ The template can also be specified using an ID of an existing `template` element
     </amp-state>
     <amp-list layout="fixed-height" height="0"
         [src]="items"
-        [height]="items.length * 24"
+        [height]="items.length * 22"
         single-item
         items="."
         binding="no">


### PR DESCRIPTION
**summary**
The height of each row is actually only 22px.
See the "Rendering amp-list" [here](https://amp.dev/documentation/examples/components/amp-list/?format=websites#rendering-amp-state).

**screenshot**
![Screen Shot 2019-12-11 at 1 36 36 PM](https://user-images.githubusercontent.com/4656974/70649512-4ecd6600-1c1b-11ea-866f-22b795a81830.png)
