### PR TITLE
♻️ Hardcode redis instances for page cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@ampproject/toolbox-cors": "1.1.1",
     "@ampproject/toolbox-optimizer": "1.1.2",
     "@google-cloud/datastore": "5.0.1",
-    "@google-cloud/redis": "1.4.0",
     "acorn": "7.1.0",
     "casual": "1.6.2",
     "cheerio": "1.0.0-rc.3",

--- a/platform/config/environments/production.json
+++ b/platform/config/environments/production.json
@@ -45,5 +45,15 @@
       "host": "ig-amp-dev-packager-ct43.c.amp-dev-230314.internal",
       "port": "8080"
     }
+	},
+	"redis": {
+		"europe-west2": {
+			"host": "10.156.30.203",
+			"port": "6379"
+		},
+		"us-east1": {
+			"host": "10.64.29.227",
+			"port": "6379"
+		}
 	}
 }

--- a/platform/config/environments/staging.json
+++ b/platform/config/environments/staging.json
@@ -45,5 +45,11 @@
       "host": "amp-dev-sxg.appspot.com",
       "port": ""
     }
+	},
+	"redis": {
+		"us-central1": {
+			"host": "10.139.214.155",
+			"port": "6379"
+		}
 	}
 }

--- a/platform/lib/config.js
+++ b/platform/lib/config.js
@@ -70,6 +70,8 @@ class Config {
       this.hostNames.add(hostName);
     });
 
+    this.redis = env.redis || {};
+
     this.shared = require(utils.project.absolute('platform/config/shared.json'));
 
     // Globally initialize command line arguments for use across all modules

--- a/platform/lib/utils/pageCache.js
+++ b/platform/lib/utils/pageCache.js
@@ -19,7 +19,6 @@
 require('module-alias/register');
 
 const config = require('@lib/config.js');
-const {CloudRedisClient} = require('@google-cloud/redis');
 const Redis = require('ioredis');
 const ms = require('ms');
 const utils = require('@lib/utils');
@@ -43,44 +42,20 @@ const EXPIRATION_TIME = ms('1d') / 1000;
 const LRU_MAX_ITEMS = 100;
 
 /**
- * The Google Cloud project which is searched for Redis instances
- * @type {String}
- */
-const PROJECT_ID = process.env.GCP_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
-
-/**
  * The region the querying instance is running in
  * @type {String}
  */
 const REGION = process.env.FUNCTION_REGION || '-';
 
 /**
- * A list of available redis instances for the region the Google Computing
- * instance is running in
- * @type {Array}
+ * Contains host and port a configured redis instance for the region the
+ * Google Computing instance is running in
+ * @type {Object|null}
  */
-const instances = (async () => {
+const instance = (async () => {
   // Do not try to search for instances if running locally
   if (config.isDevMode() || config.isLocalMode()) {
-    return [];
-  }
-
-  // Project id is most likely set by environment variable. Check if it's
-  // there, otherwise query metadata servers
-  let projectId = PROJECT_ID;
-  if (!projectId) {
-    try {
-      projectId = await gcpMetadata.project('project-id');
-      console.log('[PAGE_CACHE]: Project ID', projectId);
-    } catch (e) {
-      console.error('[PAGE_CACHE]: Fetching project id failed', e);
-      return [];
-    }
-  }
-
-  if (!projectId) {
-    console.warn('[PAGE_CACHE]: Not running on Google Cloud Platform.');
-    return [];
+    return null;
   }
 
   let region = null;
@@ -89,7 +64,8 @@ const instances = (async () => {
     let zone = await gcpMetadata.instance('zone');
     zone = zone.split('/').pop();
 
-    // As CloudRedis queries instances by region, slice the zone identifier
+    // As instances are available across zones in the same region,
+    // slice the zone identifier
     region = zone.slice(0, -2);
 
     console.log('[PAGE_CACHE]: Zone & Region', zone, region);
@@ -98,27 +74,17 @@ const instances = (async () => {
     region = REGION;
   }
 
-  const client = new CloudRedisClient();
-  const formattedParent = client.locationPath(projectId, region);
-  const request = {
-    parent: formattedParent,
-  };
-  const resp = (await client.listInstances(request))[0];
-
-  console.log('[PAGE_CACHE]: Cloud Redis instances', resp);
-
-  return resp;
+  return config.redis[region] || null;
 })();
 
 let redis = null;
 let lru = null;
 
-instances.then((instances) => {
+instance.then((instance) => {
   // Check if there is an instance available. If there is, instantiate
   // a client to use it, if there is none fall back to LRU cache
-  if (instances.length) {
-    const instance = instances[0];
-    console.log('[PAGE_CACHE]: About to connect to Redis at', instance.port, instance.host);
+  if (instance) {
+    console.log('[PAGE_CACHE]: Connecting to Redis', instance.port, instance.host);
     try {
       redis = new Redis(instance.port, instance.host);
       console.log('[PAGE_CACHE]: Connected to Redis instance at',


### PR DESCRIPTION
I already wasted so much time trying to figure out why looking up instances per API doesn't work... this PR hardcodes the available instances to our config to finally make caching work on production.