### PR TITLE
Update README to use Yarn instead of NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ To get started with contributing to amp.dev, you first need to [fork the reposit
 $ git clone https://github.com/YOUR-USERNAME/amp.dev
 ```
 
-... and then install the dependencies via NPM:
+... and then install the dependencies via Yarn:
 
 ```sh
 $ cd amp.dev
-$ npm install
+$ yarn
 ```
 
 ### Develop


### PR DESCRIPTION
When you try to run `npm install` as the README suggests, you get a console error indicating the project is using Yarn.