### PR TITLE
Import `release-schedule.md` into AMP.dev

### DIFF
--- a/platform/config/imports/spec.json
+++ b/platform/config/imports/spec.json
@@ -25,6 +25,14 @@
     "formats": ["websites", "stories"]
   },
   {
+    "title": "AMP Release Schedule",
+    "order": 4,
+    "repo": "ampproject/amphtml",
+    "from": "contributing/release-schedule.md",
+    "to": "documentation/guides-and-tutorials/learn/spec/release-schedule.md",
+    "formats": ["websites", "email", "stories", "ads"]
+  },
+  {
     "title": "AMPHTML Layout System",
     "order": 1,
 		"repo": "ampproject/amphtml",


### PR DESCRIPTION
As we prepare to announce changes to [release names](https://github.com/ampproject/amphtml/issues/25560), new [nightly releases](https://github.com/ampproject/amphtml/issues/25616), and the new [LTS release channel](https://github.com/ampproject/amphtml/issues/25578), the Release Schedule doc is getting a major [rewrite/upgrade](https://github.com/ampproject/amphtml/pull/26085). This doc includes details on how changes in `ampproject/amphtml` make it through nightly, weekly, and into LTS releases; provides information on the opt-in cookie for the experimental/beta build channels; and includes details on how to use the LTS release channel in a page.

There will be an accompanying blog post (thanks @nainar ) early next year to announce the changes, but it seemed reasonable that we also make this information visible within AMP.dev