### PR TITLE
contrib: improve issue template formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 
+[*.md]
+# Trailing whitespace is significant in Markdown.
+trim_trailing_whitespace = false
+
 [*.json]
 indent_style = tab
 indent_size = 2

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -7,25 +7,30 @@ assignees: ''
 
 ---
 
+<!--
+Thank you for reporting a possible bug in amp.dev.
+
+Please fill in as much of the below template as you're able.
+-->
+
 ## Bug Report
 
-### Current Behavior
+**Current Behavior**  
 A clear and concise description of the bug you found on amp.dev.
 
 Please also provide:
 - Page link: <insert the URL link to the amp.dev page(s) that you found the issue on>
 - (Optional) Screenshots / videos
 
-### Expected behavior/code
+**Expected behavior/code**  
 A clear and concise description of what you expected to happen.
 
-### How do we reproduce the issue?
-
+**How do we reproduce the issue?**  
 Please provide the steps to reproduce the issue:
 
 1. Step 1 to reproduce
 2. Step 2 to reproduce
 3. …
 
-What browser are you using?
+What browser are you using?  
 What O/S are you using?

--- a/.github/ISSUE_TEMPLATE/content.md
+++ b/.github/ISSUE_TEMPLATE/content.md
@@ -7,16 +7,23 @@ assignees: ''
 
 ---
 
+<!--
+Thank you for wanting to make amp.dev better.
+
+Please fill in as much of the below template as you're able.
+-->
+
 ## 📖 Missing or out-of-date documentation
 
-**Describe the content that is missing or should be up dated**
-A clear and concise description of what content is missing, or needs to be updated. Could be a missing guide explaining a concept, a tutorial, or something that is confusing or doesn't work when you tried it.
+**Describe the content that is missing or should be up dated.**  
+A clear and concise description of what content is missing, or needs to be updated.
+Could be a missing guide explaining a concept, a tutorial, or something that is confusing or doesn't work when you tried it.
 
-**Which part of the site would that content live at?**
+**In which part of the site would that content live at?**  
 Where would it go? In the reference docs? About pages? Guides and tutorials?
 
-**What's the type of content?**
+**What type of content is it?**  
 Are we talking about a tutorial, a paragraph somewhere or API docs?
 
-**Optional: Proposed information architecture**
+**Optional: Propose information architecture.**  
 If you have ideas on how we should structure the content, tell us!

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,22 +2,27 @@
 name: "\U0001F680 Feature Request"
 about: "I have a suggestion (and may want to implement it \U0001F642)!"
 title: ''
-labels: 'Status: Pending Triage, Type: Bug'
+labels: 'Status: Pending Triage, Type: Feature'
 assignees: ''
 
 ---
 
-## Feature Request
+<!--
+Thank you for suggesting an idea to make amp.dev better.
 
-# Is your feature request related to a problem? Please describe.
+Please fill in as much of the template below as you're able.
+-->
+
+## 🚀 Feature Request
+
+**Is your feature request related to a problem? Please describe.**  
 A clear and concise description of what the problem is. Ex. I have an issue when [...]
 
-# Describe the solution you'd like
-A clear and concise description of what you want to happen. Add any considered drawbacks.
+**Describe the solution you'd like.**  
+A clear and concise description of what is desired, including any potential drawbacks.
 
-# Describe alternatives you've considered
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe alternatives you've considered.**  
+A clear and concise description of any alternative solutions or features you've found.
 
-# Optional: Teachability, Documentation, Adoption, Migration Strategy
-If you can, explain how users will be able to use this and possibly write out a version the docs.
-Maybe a screenshot or design?
+**Optional: Teachability, Documentation, Adoption, Migration Strategy**  
+An explanation of how users will be able to use the proposed feature, potentially including screenshots or designs.

--- a/.github/ISSUE_TEMPLATE/tool.md
+++ b/.github/ISSUE_TEMPLATE/tool.md
@@ -7,7 +7,13 @@ assignees: ''
 
 ---
 
-## Request to add third-party tool/service/platform/vendor
+<!--
+Thank you for wanting to add a community resource to amp.dev.
+
+Please fill in as much of the below template as you're able.
+-->
+
+## 🛠️ Request to add third-party tool/service/platform/vendor
 
 **1. What's the name?**
 (Insert name here)
@@ -22,8 +28,8 @@ assignees: ''
 1. [amp.dev/support/faq/platform-and-vendor-partners](https://amp.dev/support/faq/platform-and-vendor-partners)
 2. [amp.dev/documentation/tools](https://amp.dev/documentation/tools)
 
-**5. If you choose 1 in Step 4:**
-Please provide a at least 800x400 image to appear on the [Tools](https://amp.dev/documentation/tools) page, as well as a short description (max 100 characters).
+**5. If you chose 1 in Step 4:**  
+Please provide an image (min. 800x400 pixels) to appear on the [Tools](https://amp.dev/documentation/tools) page, as well as a short description (max. 100 characters).
 
-**5. If you choose 2 in Step 4:**
-Please provide link(s) to your documentation page(s) on your domain, and for ads the configuration page in the [ads/](https://github.com/ampproject/amphtml/tree/master/ads) folder in the `amphtml` repository.
+**5. If you chose 2 in Step 4:**  
+Please provide link(s) to your documentation page(s) on your domain and for ads, the configuration page in the [ads/](https://github.com/ampproject/amphtml/tree/master/ads) folder of the `amphtml` repository.


### PR DESCRIPTION
Prior to this commit, the GitHub issue templates
had inconsistent and suboptimal formatting.

* Correct various typos
* Add emoji to issue template headings<sup>1</sup>
* Add greeting comments to issue templates<sup>1</sup>
* Allow trailing whitespace in Markdown files<sup>2</sup>

<sup>1</sup> Follows [implementation by Node.js](https://github.com/nodejs/node/tree/master/.github/ISSUE_TEMPLATE), adapted for amp.dev purposes
<sup>2</sup> A line break preceded by two or more spaces [makes _hard line breaks_](https://github.github.com/gfm/#hard-line-breaks)

The "new feature" template is the most noticeably incorrect with inverted headings. I discovered this while in the process of making a feature request. Please consider merging this fix.
