### PR TITLE
Adds "Import email" button to the playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16710,6 +16710,15 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
+    "quoted-printable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/quoted-printable/-/quoted-printable-1.0.1.tgz",
+      "integrity": "sha1-nuv16z0R7vAismT9LStrK7O4TMM=",
+      "dev": true,
+      "requires": {
+        "utf8": "^2.1.0"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -20006,6 +20015,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "utf8": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
+      "dev": true
     },
     "utif": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "octonode": "0.9.5",
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "preload-webpack-plugin": "3.0.0-beta.4",
+    "quoted-printable": "^1.0.1",
     "recursive-search": "1.0.1",
     "sass-loader": "8.0.0",
     "striptags": "3.1.1",

--- a/playground/src/app.critical.scss
+++ b/playground/src/app.critical.scss
@@ -11,7 +11,7 @@
 
 * {
   box-sizing: border-box;
-  -webkit-tap-highlight-color:  rgba(255, 255, 255, 0); 
+  -webkit-tap-highlight-color:  rgba(255, 255, 255, 0);
 }
 
 .elevation-2dp {
@@ -123,8 +123,10 @@
       height: 100%;
     }
     .button {
-      width: 48px;
       height: 48px;
+    }
+    .button.square {
+      width: 48px;
     }
     .button:active {
       background: color('silver');
@@ -166,8 +168,9 @@
       & > *:first-child {
         border-right: 1px solid color('silver');
       }
-      & > *:last-child {
+      & > *:last-child > * {
         border-left: 1px solid color('silver');
+        border-radius: 0;
       }
       select {
         background-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' width='36' height='36' viewBox='0 0 24 24'%3E%3Cpath d='M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z' fill='%23FFF'/%3E%3Cpath fill='none' d='M0 0h24v24H0V0z'/%3E%3C/svg%3E");
@@ -226,10 +229,10 @@
 }
 
 .button[disabled] {
-  color: color('silver'); 
+  color: color('silver');
 }
 .button[disabled] svg {
-  fill: #dddddd; 
+  fill: #dddddd;
 }
 
 .panel-header select {
@@ -240,7 +243,7 @@
   font: inherit;
   line-height: 1em;
   padding: 0.5em 1.5em 0.5em 0em;
-  margin: 0;      
+  margin: 0;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -387,7 +390,7 @@ main > .panel + .panel {
   display: none;
 }
 
-@media (max-width: 767px) { 
+@media (max-width: 767px) {
   .hide-on-desktop {
     display: block;
   }

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -210,7 +210,7 @@ Button.from(document.getElementById('menu-format-source'), formatSource);
 
 const loadEmail = () => {
   emailLoader.loadEmailFromFile()
-    .catch(error => alert(`Error loading email.\n${error.message}`));
+      .catch((error) => alert(`Error loading email.\n${error.message}`));
 };
 Button.from(document.getElementById('import-email'), loadEmail);
 

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -113,11 +113,7 @@ events.subscribe(EVENT_SET_RUNTIME, (newRuntime) => {
   activeRuntime = newRuntime;
 
   const emailButton = document.getElementById('import-email');
-  if (activeRuntime.id === 'amp4email') {
-    emailButton.classList.remove('hidden');
-  } else {
-    emailButton.classList.add('hidden');
-  }
+  emailButton.classList.toggle('hidden', activeRuntime.id !== 'amp4email');
 });
 
 runtimes.init();
@@ -210,7 +206,7 @@ Button.from(document.getElementById('menu-format-source'), formatSource);
 
 const loadEmail = () => {
   emailLoader.loadEmailFromFile()
-      .catch((error) => alert(`Error loading email.\n${error.message}`));
+      .catch((error) => alert(`Error loading email: ${error.message}`));
 };
 Button.from(document.getElementById('import-email'), loadEmail);
 

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -24,6 +24,7 @@ import Fab from './fab/fab.js';
 
 import * as AutoImporter from './auto-importer/auto-importer.js';
 import * as ComponentsProvider from './components-provider/components-provider.js';
+import * as EmailLoader from './email-loader/email-loader.js';
 import * as ErrorList from './error-list/error-list.js';
 import * as Validator from './validator/validator.js';
 import * as Editor from './editor/editor.js';
@@ -71,6 +72,8 @@ const componentsProvider = ComponentsProvider.createComponentsProvider();
 // Create AMP component auto-importer
 const autoImporter = AutoImporter.createAutoImporter(componentsProvider, editor);
 
+const emailLoader = EmailLoader.createEmailLoader(editor);
+
 // runtime select
 const runtimeChanged = (runtimeId) => {
   const newRuntime = runtimes.get(runtimeId);
@@ -108,6 +111,13 @@ events.subscribe(EVENT_SET_RUNTIME, (newRuntime) => {
   };
   validator.validate(editor.getSource());
   activeRuntime = newRuntime;
+
+  const emailButton = document.getElementById('import-email');
+  if (activeRuntime.id === 'amp4email') {
+    emailButton.classList.remove('hidden');
+  } else {
+    emailButton.classList.add('hidden');
+  }
 });
 
 runtimes.init();
@@ -198,6 +208,11 @@ const formatSource = () => {
 Button.from(document.getElementById('format-source'), formatSource);
 Button.from(document.getElementById('menu-format-source'), formatSource);
 
+const loadEmail = () => {
+  emailLoader.loadEmailFromFile()
+    .catch(error => alert(`Error loading email.\n${error.message}`));
+};
+Button.from(document.getElementById('import-email'), loadEmail);
 
 window.onpopstate = () => {
   if (!params.get('preview')) {

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -206,6 +206,7 @@ Button.from(document.getElementById('menu-format-source'), formatSource);
 
 const loadEmail = () => {
   emailLoader.loadEmailFromFile()
+      .then(formatSource)
       .catch((error) => alert(`Error loading email: ${error.message}`));
 };
 Button.from(document.getElementById('import-email'), loadEmail);

--- a/playground/src/email-loader/email-loader.js
+++ b/playground/src/email-loader/email-loader.js
@@ -1,0 +1,149 @@
+// Copyright 2019 The AMPHTML Authors
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as quotedPrintable from 'quoted-printable';
+
+const multipartContentType = /^(multipart\/\w+)\s*;\s*boundary=(.+)$/i;
+
+export function createEmailLoader(editor) {
+  return new EmailLoader(editor);
+}
+
+class EmailLoader {
+  constructor(editor) {
+    this.editor = editor;
+  }
+
+  async loadEmailFromFile() {
+    const files = await new Promise((resolve) => {
+      const dialog = document.createElement('input');
+      dialog.setAttribute('type', 'file');
+      dialog.setAttribute('accept', '.eml');
+      dialog.addEventListener('change', () => resolve(dialog.files));
+      dialog.click();
+    });
+    if (files.length !== 1) {
+      throw new Error('You must select a file');
+    }
+    const data = await files[0].text();
+    this._loadEmail(data);
+  }
+
+  _loadEmail(emailCode) {
+    emailCode = emailCode.replace(/\r\n/g, '\n');
+    const [head, body] = twoSplit(emailCode, '\n\n');
+    if (!body) {
+      throw new Error('No body found in email');
+    }
+
+    const headers = this._parseHeaders(head);
+    const {contentType, boundary} = this._parseMultipartContentType(
+        headers.get('content-type'),
+    );
+    if (contentType !== 'multipart/alternative') {
+      throw new Error('Email is not multipart/alternative');
+    }
+    const parts = this._parseMultipartBody(body, boundary);
+
+    const ampPart = parts.find((part) =>
+      part.contentType.startsWith('text/x-amp-html'),
+    );
+    if (!ampPart) {
+      throw new Error('No AMP part found in multipart/alternative');
+    }
+    this.editor.setSource(ampPart.body);
+  }
+
+  _parseHeaders(head) {
+    const lines = head.split('\n');
+    let current = 0;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line.match(/^\s/)) {
+        current = i;
+        continue;
+      }
+      lines[current] += ' ' + line.trim();
+      lines[i] = null;
+    }
+
+    return new Map(
+        lines
+            .filter((line) => line)
+            .map((line) => {
+              const [key, value] = twoSplit(line, ':');
+              return [key.toLowerCase(), value.trim()];
+            }),
+    );
+  }
+
+  _parseMultipartBody(body, boundary) {
+    const rawParts = body.split('--' + boundary);
+    if (
+      rawParts[0].trim() !== '' ||
+      rawParts[rawParts.length - 1].trim() !== '--'
+    ) {
+      throw new Error('Invalid multipart body');
+    }
+    const parts = rawParts.slice(1, -1);
+
+    return parts.map((part) => {
+      let [head, body] = twoSplit(part, '\n\n');
+      if (!body) {
+        throw new Error('No body found in email part');
+      }
+      const headers = this._parseHeaders(head);
+      const encoding = headers.get('content-transfer-encoding');
+      switch (encoding) {
+        case 'base64':
+          body = atob(body.replace(/\s/g, ''));
+          break;
+        case 'quoted-printable':
+          body = quotedPrintable.decode(body.replace('=E2=9A=A1', '⚡'));
+          break;
+      }
+      return {
+        contentType: headers.get('content-type') || '',
+        body,
+      };
+    });
+  }
+
+  _parseMultipartContentType(contentType) {
+    const matches = (contentType || '').match(multipartContentType);
+    if (!matches) {
+      throw new Error('Invalid content type');
+    }
+    let boundary = matches[2].trim();
+    if (boundary.startsWith('"')) {
+      boundary = JSON.parse(boundary);
+    }
+    return {
+      contentType: matches[1],
+      boundary,
+    };
+  }
+}
+
+// like String.prototype.split, but returns only two parts
+function twoSplit(str, separator) {
+  const pos =
+    separator instanceof RegExp ?
+      str.search(separator) :
+      str.indexOf(separator);
+  if (pos === -1) {
+    return [str];
+  }
+  return [str.substring(0, pos), str.substring(pos).replace(separator, '')];
+}

--- a/playground/src/email-loader/email-loader.test.js
+++ b/playground/src/email-loader/email-loader.test.js
@@ -1,0 +1,94 @@
+const {createEmailLoader} = require('./email-loader.js');
+
+describe('EmailLoader', () => {
+  let emailLoader = null;
+  let setSourceMock = null;
+
+  beforeEach(() => {
+    setSourceMock = jest.fn();
+    emailLoader = createEmailLoader({
+      setSource: setSourceMock,
+    });
+  });
+
+  test('throws when email is not multipart', () => {
+    expect(() => {
+      emailLoader._loadEmail(`
+From:  Person A <persona@example.com>
+To: Person B <personb@example.com>
+Subject: Test
+Content-Type: text/plain
+
+Hello World in plain text!
+    `);
+    }).toThrow();
+  });
+
+  test('throws when email has no AMP part', () => {
+    expect(() => {
+      emailLoader._loadEmail(`
+From:  Person A <persona@example.com>
+To: Person B <personb@example.com>
+Subject: Test
+Content-Type: multipart/alternative; boundary="001a114634ac3555ae05525685ae"
+
+--001a114634ac3555ae05525685ae
+Content-Type: text/plain
+
+Hello World in plain text!
+
+--001a114634ac3555ae05525685ae
+Content-Type: text/html
+
+<span>Hello World in HTML!</span>
+--001a114634ac3555ae05525685ae--
+    `);
+    }).toThrow();
+  });
+
+  test('parses valid email', () => {
+    emailLoader._loadEmail(`
+From:  Person A <persona@example.com>
+To: Person B <personb@example.com>
+Subject: An AMP email!
+Content-Type: multipart/alternative; boundary="001a114634ac3555ae05525685ae"
+
+--001a114634ac3555ae05525685ae
+Content-Type: text/plain; charset="UTF-8"; format=flowed; delsp=yes
+
+Hello World in plain text!
+
+--001a114634ac3555ae05525685ae
+Content-Type: text/x-amp-html; charset="UTF-8"
+
+<!doctype html>
+<html ⚡4email>
+<head>
+  <meta charset="utf-8">
+  <style amp4email-boilerplate>body{visibility:hidden}</style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+Hello World in AMP!
+</body>
+</html>
+--001a114634ac3555ae05525685ae
+Content-Type: text/html; charset="UTF-8"
+
+<span>Hello World in HTML!</span>
+--001a114634ac3555ae05525685ae--
+    `);
+    expect(setSourceMock.mock.calls[0][0]).toBe(`<!doctype html>
+<html ⚡4email>
+<head>
+  <meta charset="utf-8">
+  <style amp4email-boilerplate>body{visibility:hidden}</style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+Hello World in AMP!
+</body>
+</html>
+`);
+  });
+});

--- a/playground/src/index.hbs
+++ b/playground/src/index.hbs
@@ -73,7 +73,8 @@
       <div class="panel-header hide-on-mobile">
         <div id="runtime-select"></div>
         <div class="flex-right">
-        {{> button/button.hbs id="format-source" class="" ariaLabel="format source code" text="{  }"}}
+        {{> button/button.hbs id="import-email" class="hidden" text="Import email"}}
+        {{> button/button.hbs id="format-source" class="square" ariaLabel="format source code" text="{  }"}}
         </div>
       </div>
       {{> loader/loader.hbs theme="light"}}


### PR DESCRIPTION
This button opens a file selection dialog, allowing a user to select an .eml file in the MIME format (that's usually created by email clients when you download a message). If the opened email contains an AMP part, that part is loaded into the playground.

![image](https://user-images.githubusercontent.com/250887/71416769-eb4f2980-2659-11ea-9e69-2be50e5ba9d3.png)
