### PR TITLE
Add go.amp.dev/cherry-picks link

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -5,6 +5,7 @@
 /ampcs: /events/amp-cs-2019/#Schedule
 /auto-sw: https://github.com/ampproject/amp-sw/
 /camp-code: https://github.com/ampproject/samples/tree/master/amp-camp
+/cherry-picks: https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md#Cherry-picks
 /contribute/code: https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md
 /contribute/code-samples: /documentation/guides-and-tutorials/contribute/contribute-documentation/formatting/?format=websites#preview-code-samples
 /contribute/docs: /documentation/guides-and-tutorials/contribute/contribute-documentation


### PR DESCRIPTION
Currently, we link to bit.ly/amp-cherry-picks for the cherry-pick documentation. https://github.com/ampproject/amphtml/pull/26085 moves that cherry-pick documentation to a different document, but we are unable to change a bit.ly shortlink. This adds an AMP Go link for cherry-pick instructions so we can 1) update docs to use the AMP shortlink and 2) edit that shortlink as needed.