### PR TITLE
feat(meta): disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This PR will prevent stuff like this:

- https://github.com/ampproject/amp.dev/issues/3361
- https://github.com/ampproject/amp.dev/issues/3332

It would require contributors to use an issue template.

More info on this config.yml can be found at [Configuring the template chooser](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser).