### PR TITLE
add missing strings to po files

### DIFF
--- a/pages/translations/ar/LC_MESSAGES/messages.po
+++ b/pages/translations/ar/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr ""
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/en/LC_MESSAGES/messages.po
+++ b/pages/translations/en/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr "Social"
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/es/LC_MESSAGES/messages.po
+++ b/pages/translations/es/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr ""
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/fr/LC_MESSAGES/messages.po
+++ b/pages/translations/fr/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr ""
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/id/LC_MESSAGES/messages.po
+++ b/pages/translations/id/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr "sosial"
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/it/LC_MESSAGES/messages.po
+++ b/pages/translations/it/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr ""
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/ja/LC_MESSAGES/messages.po
+++ b/pages/translations/ja/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr "ソーシャル"
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/ko/LC_MESSAGES/messages.po
+++ b/pages/translations/ko/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr ""
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/pages/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr "social"
 msgid "…while trying to load the search results."
 msgstr "...enquanto tenta carregar os resultados da pesquisa."
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/ru/LC_MESSAGES/messages.po
+++ b/pages/translations/ru/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr ""
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/tr/LC_MESSAGES/messages.po
+++ b/pages/translations/tr/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr ""
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/pages/translations/zh_CN/LC_MESSAGES/messages.po
@@ -1103,3 +1103,51 @@ msgstr ""
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+


### PR DESCRIPTION
In setting up some of the i18n work, I saw a number of strings on the site that were referenced in `_('*')` blocks were not actually defined in the po files. 
This just added all of the missing things to the po files

scripted it to automate the work

```bash
LANGS=(ar en es fr id it ja ko pt_BR ru tr zh_CN)

function join { local IFS="$1"; shift; echo "$*"; }

IFS=$'\n'

# find all instances of _('FOOBAR'), from all the pages
for i in `ag -o "_\('\K([^)]*)(?=\'\))" | sed '/^$/d'`; do
  IFS=':'
  read -a INFO <<< "${i}"
  IFS=$'\n'

  FILENAME=${INFO[0]}
  LINE_NUMBER=${INFO[1]}
  THE_REST=$(join : ${INFO[@]:2})

  # iterate through all the languages
for L in "${LANGS[@]}"; do
  LANG_FILE="pages/translations/$L/LC_MESSAGES/messages.po"
   if [[ -z $(grep "$THE_REST" "$LANG_FILE" ) ]]; then
      echo "#: $FILENAME:$LINE_NUMBER" >> "$LANG_FILE"
      echo msgid \"$THE_REST\" >> "$LANG_FILE"
      echo msgstr \"\" >> "$LANG_FILE"
      echo "" >> "$LANG_FILE"
   fi;
  done;
done

```

presumably this should be added to the repo in a more portable language, but not sure what would be the correct place to add it - @sebastianbenz @CrystalOnScript any opinion?