### PR TITLE
🐛 Change success stories tag labels from format to category

### DIFF
--- a/frontend/scss/components/molecules/tag.scss
+++ b/frontend/scss/components/molecules/tag.scss
@@ -53,4 +53,9 @@ TODO: Add info text to this molecule.
 		@include color-e-mails;
 		@include gradient-e-mails;
 	}
+
+	&-general {
+		color: color('white');
+		background-color: color('blue-ribbon');
+	}
 }

--- a/frontend/templates/views/partials/teaser.j2
+++ b/frontend/templates/views/partials/teaser.j2
@@ -6,9 +6,9 @@
     [hidden]="filter.category != 'none' && filter.category != '{{ teaser_doc.category|slug }}'">
   <a href="{{ teaser_doc.url.path }}">
 
-    {% if teaser_doc.formats %}
+    {% if teaser_doc.category %}
     {% do doc.styles.addCssFile('css/components/molecules/tag.css') %}
-    <div class="ap-m-tag ap-m-tag-{{ teaser_doc.formats[0] }} ap-m-teaser-tag">{{ teaser_doc.formats[0] }}</div>
+    <div class="ap-m-tag ap-m-tag-general ap-m-teaser-tag">{{ teaser_doc.category }}</div>
     {% endif %}
 
     <div class="ap-m-teaser-card">


### PR DESCRIPTION
This PR changes the tag labels on success stories page from format to category.

Fixes: #3387

![amp-dev-success-stories-tag-labels](https://user-images.githubusercontent.com/22053023/72635178-7e7b3680-395c-11ea-803a-f1670c6438cd.png)

![amp-dev-success-stories-tag-labels-filtered](https://user-images.githubusercontent.com/22053023/72635177-7e7b3680-395c-11ea-9e6d-ea2cdc5a3725.png)