### PR TITLE
[docs] add translated apology banner for all languages

### DIFF
--- a/pages/translations/ar/LC_MESSAGES/messages.po
+++ b/pages/translations/ar/LC_MESSAGES/messages.po
@@ -1105,7 +1105,7 @@ msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
 msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgstr "لم تتم ترجمة هذه الصفحة حتى الآن، لكننا نرحّب ببعض المساعدة لتنفيذ ذلك. يمكنك الاطّلاع على <a href="/documentation/guides-and-tutorials/contribute/translations">دليل الترجمة</a> لمعرفة كيفية المساهمة في ذلك."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/es/LC_MESSAGES/messages.po
+++ b/pages/translations/es/LC_MESSAGES/messages.po
@@ -1105,7 +1105,7 @@ msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
 msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgstr "Desafortunadamente, esta página todavía no está traducida, pero puedes ayudarnos a conseguir que lo esté. Consulta la <a href="/documentation/guides-and-tutorials/contribute/translations">guía de traducción</a> sobre cómo puedes colaborar."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/fr/LC_MESSAGES/messages.po
+++ b/pages/translations/fr/LC_MESSAGES/messages.po
@@ -1105,7 +1105,7 @@ msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
 msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgstr "Cette page n'est malheureusement pas traduite pour le moment. Si vous souhaitez nous aider à la traduire, consultez le <a href="/documentation/guides-and-tutorials/contribute/translations">guide de traduction</a> pour savoir comment apporter votre contribution."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/id/LC_MESSAGES/messages.po
+++ b/pages/translations/id/LC_MESSAGES/messages.po
@@ -1105,7 +1105,7 @@ msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
 msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgstr "Sayangnya, halaman ini belum diterjemahkan, tetapi kita dapat menggunakan bantuan untuk melakukannya. Lihat <a href="/documentation/guides-and-tutorials/contribute/translations">panduan terjemahan</a> untuk mengetahui caranya jika Anda ingin berkontribusi."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/it/LC_MESSAGES/messages.po
+++ b/pages/translations/it/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-#: /views/partials/case-band.j2:6 /views/partials/case-band.j2:7
+    #: /views/partials/case-band.j2:6 /views/partials/case-band.j2:7
 msgid "A screenshot of a website using AMP."
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
 msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgstr "Purtroppo questa pagina non è ancora stata tradotta, ma potrebbe servirci una mano a farlo. Consulta la <a href="/documentation/guides-and-tutorials/contribute/translations">guida alla traduzione</a> su come puoi contribuire."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/ja/LC_MESSAGES/messages.po
+++ b/pages/translations/ja/LC_MESSAGES/messages.po
@@ -1105,7 +1105,7 @@ msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
 msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgstr "このページはまだ翻訳されていません。本サイトでは、翻訳のご協力をお待ちしています。翻訳を提出する方法については、<a href="/documentation/guides-and-tutorials/contribute/translations">翻訳ガイド</a>をご覧ください。"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/ko/LC_MESSAGES/messages.po
+++ b/pages/translations/ko/LC_MESSAGES/messages.po
@@ -1105,7 +1105,7 @@ msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
 msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgstr "죄송하지만 이 페이지는 아직 번역되지 않았습니다. 이 페이지를 번역하는 데 도움을 주고 싶다면 참여해 주세요. <a href="/documentation/guides-and-tutorials/contribute/translations">번역 가이드</a>에서 어떻게 참여할 수 있는지 알아보세요."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/messages.po
+++ b/pages/translations/messages.po
@@ -1103,3 +1103,51 @@ msgstr ""
 msgid "…while trying to load the search results."
 msgstr ""
 
+#: frontend/templates/layouts/default.j2:129
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgstr "很遗憾，此页面尚未翻译，但我们可以凭借一些帮助将其翻译出来。请参阅<a href="/documentation/guides-and-tutorials/contribute/translations">翻译指南</a>，了解您可以如何做贡献。"
+
+#: frontend/templates/views/examples/documentation.j2:206
+msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
+msgstr ""
+
+#: frontend/templates/views/examples/documentation.j2:213
+msgid "The AMP project strongly encourages your participation and contributions! We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about."
+msgstr ""
+
+#: frontend/templates/views/detail/component-detail.j2:33
+msgid "You've read this document a dozen times but it doesn't really cover all of your questions? Maybe other people felt the same  reach out to them on Stack Overflow."
+msgstr ""
+
+#: frontend/templates/views/partials/experiments/experiments.j2:4
+msgid "Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well."
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:54
+msgid "Example  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:56
+msgid "Demo  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:58
+msgid "Documentation  "
+msgstr ""
+
+#: frontend/templates/views/partials/structured-data.j2:60
+msgid "Success Story  "
+msgstr ""
+
+#: frontend/templates/views/partials/search.j2:140
+msgid "Although there are {hits} hits in total we cannot show more than 100.', hits='{'+'{result.totalResults}'+'}"
+msgstr ""
+
+#: frontend/templates/views/partials/content.j2:24
+msgid "Important  this component does not support your currently selected format"
+msgstr ""
+
+#: pages/content/amp-dev/documentation/templates/index.html:112
+msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
+msgstr ""
+

--- a/pages/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/pages/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1105,7 +1105,7 @@ msgstr "...enquanto tenta carregar os resultados da pesquisa."
 
 #: frontend/templates/layouts/default.j2:129
 msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgstr "Infelizmente, esta página ainda não foi traduzida, mas você pode nos ajudar a fazer isso. Veja o <a href="/documentation/guides-and-tutorials/contribute/translations">guia de tradução</a> para saber como você pode contribuir."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/ru/LC_MESSAGES/messages.po
+++ b/pages/translations/ru/LC_MESSAGES/messages.po
@@ -1105,7 +1105,7 @@ msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
 msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgstr "Эта страница пока не переведена, но вы можете помочь нам в этом. Чтобы узнать больше, ознакомьтесь с <a href="/documentation/guides-and-tutorials/contribute/translations">руководством по переводу.</a>"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/tr/LC_MESSAGES/messages.po
+++ b/pages/translations/tr/LC_MESSAGES/messages.po
@@ -1105,7 +1105,7 @@ msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
 msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgstr "Maalesef bu sayfa henüz çevrilmedi, ancak bunun için yardım almak isteriz. Nasıl katkıda bulunabileceğinizi öğrenmek için <a href="/documentation/guides-and-tutorials/contribute/translations">çeviri kılavuzuna</a> bakın."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."


### PR DESCRIPTION
also I moved the zh-CN file from a `.pot` to a `.po`, as it isn't a template