### PR TITLE
🏗 Automatically pin exact versions with `npm install`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
This PR will, by default, pin exact dependency versions saved to package.json.

The equivalent amphtml PR is https://github.com/ampproject/amphtml/pull/23290.

Refs
- https://docs.npmjs.com/files/npmrc.html#per-project-config-file
- https://docs.npmjs.com/misc/config#save-exact