### PR TITLE
👌 Prefill search input field with value instead of placeholder

### DIFF
--- a/frontend/templates/views/partials/search.j2
+++ b/frontend/templates/views/partials/search.j2
@@ -54,7 +54,7 @@
                  name="q"
                  placeholder="{{_('What are you looking for?')}}"
                  on="input-throttled:AMP.setState({ throttledValue: event.value })"
-                 [placeholder]="query == null ? '{{_('What are you looking for?')}}' : query"
+                 [value]="query == null ? '' : query"
                  required
           >
           <button class="ap-o-search-submit" type="submit" name="search-submit" disabled [disabled]="!throttledValue">{{_('Search')}}</button>


### PR DESCRIPTION
This PR changes the prefilled search input from placeholder to value.


### before
![search-input-placeholder](https://user-images.githubusercontent.com/22053023/72917439-22415980-3d44-11ea-8819-70f4991c6e84.jpg)

### after
![search-input-value](https://user-images.githubusercontent.com/22053023/72917441-22415980-3d44-11ea-99e1-2e8549b341d5.jpg)
