### PR TITLE
🐛Fix not showing burger menu icon

### DIFF
--- a/frontend/scss/components/organisms/burger-menu.scss
+++ b/frontend/scss/components/organisms/burger-menu.scss
@@ -36,7 +36,7 @@
   /* The following elements are not inside the burger-menu itself */
   &-label {
     position: fixed;
-    z-index: 17;
+    z-index: 1001;
     top: 12px;
     right: 20px;
     cursor: pointer;


### PR DESCRIPTION
Increase z-index of burger-menu to the same value as the recently increased z-index of header #3428