### PR TITLE
Properly extract strings for i18n on non documentation pages

### DIFF
--- a/frontend/templates/layouts/default.j2
+++ b/frontend/templates/layouts/default.j2
@@ -130,7 +130,7 @@
     {% if not '@' in doc.pod_path and not doc.locale == podspec.default_locale %}
     {% do doc.styles.addCssFile('/css/components/organisms/translation-hint.css') %}
     <aside class="ap-o-translation-hint">
-      <p class="ap-o-translation-hint-wrapper">{{ _('Sadly this page isn\'t translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute.') }}</p>
+      <p class="ap-o-translation-hint-wrapper">{{ _('Sadly this page isn\'t translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute.') }}</p>
     </aside>
     {% endif %}
 

--- a/frontend/templates/views/detail/working-group-detail.j2
+++ b/frontend/templates/views/detail/working-group-detail.j2
@@ -16,8 +16,8 @@
     <div class="ap-o-stage">
       <div class="ap--container-fluid">
         <div class="ap-o-stage-content">
-          <h1 class="ap-o-stage-content-headline">Working Groups</h1>
-          <h2 class="ap-o-stage-content-subline">Encouraging More Voices in AMP</h2>
+          <h1 class="ap-o-stage-content-headline">{{ _('Working Groups') }}</h1>
+          <h2 class="ap-o-stage-content-subline">{{ _('Encouraging More Voices in AMP') }}</h2>
         </div>
         <div class="ap-o-stage-image">
           <amp-img alt="AMP Working Group"
@@ -41,16 +41,16 @@
 
   <div class="ap-o-wg">
     <section class="ap-o-wg-intro">
-      <p>An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMPS's Technical Steering Committee.</p>
-      <p>Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews.</p>
-      <h4>AMP's Working Groups are:</h4>
+      <p>{{ _('An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee.') }}</p>
+      <p>{{ _('Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews.') }}</p>
+      <h4>{{ _('AMP’s Working Groups are:') }}</h4>
     </section>
     <section class="ap-o-wg-content">
       <div class="ap-o-wg-nav">
         <ul>
           {% for group in g.collection('/content/amp-dev/community/working-groups').list_docs(locale=doc.locale) %}
           <li class="ap-o-wg-nav-bubble {% if group.name in doc.path %} active {% endif %}">
-            <a href="{{ g.doc('/content/amp-dev/community/working-groups/' + group.name, locale=doc.locale).url.path }}">{{ group.full_name }}</a>
+            <a href="{{ g.doc('/content/amp-dev/community/working-groups/' + group.name, locale=doc.locale).url.path }}">{{ _(group.full_name) }}</a>
           </li>
           {% endfor %}
         </ul>
@@ -65,15 +65,15 @@
           </div>
 
           <section class="ap-o-wg-group-section ap-o-wg-group-description">
-            <p>Working Group</p>
-            <h2>{{ doc.full_name }}</h2>
-            <p>{{ doc.description|markdown|safe }}</p>
-            <p>The facilitator of {{ doc.full_name }} is: <a href="#">@{{ doc.facilitator.login }}</a></p>
+            <p>{{ _('Working Group') }}</p>
+            <h2>{{ _(doc.full_name) }}</h2>
+            <p>{{ _(doc.description|markdown|safe) }}</p>
+            <p>{{ _('The facilitator of {name} is: ', name=doc.full_name) }}<a href="#">@{{ doc.facilitator.login }}</a></p>
           </section>
 
           {% if doc.issues %}
           <section class="ap-o-wg-group-section">
-            <h3>Current Issues</h3>
+            <h3>{{ _('Current Issues') }}</h3>
             {% if doc.issues|length > 3 %}
             <input type="checkbox" id="load-issues-checkbox"/>
             {% endif %}
@@ -102,14 +102,14 @@
             </div>
             {% if doc.issues|length > 3 %}
             <label class="ap-a-btn ap-o-wg-load-btn" for="load-issues-checkbox">
-              <span>View all</span>
+              <span>{{ _('View all') }}</span>
             </label>
             {% endif %}
           </section>
           {% endif %}
 
           <section class="ap-o-wg-group-section">
-            <h3>Members</h3>
+            <h3>{{ _('Members') }}</h3>
             <div class="ap-o-wg-grid">
               <a href="https://github.com/{{ doc.facilitator.login }}" target="_blank" rel="noopener" class="ap-o-wg-member active">
                 <amp-img class="ap-o-wg-member-img"
@@ -141,12 +141,12 @@
               {% endfor %}
               {% endif %}
             </div>
-            <p><a href={{ doc.html_url }} target="_blank" rel="noopener">The GitHub Team</a> also includes {{ doc.full_name }} WG members.</p>
+            <p>{{ _('<a href={{ doc.html_url }} target="_blank" rel="noopener">The GitHub Team</a> also includes { name } WG members.',  name=doc.full_name) }}</p>
           </section>
 
           {% if doc.communication %}
           <section class="ap-o-wg-group-section">
-            <h3>Communication Channels</h3>
+            <h3>{{ _('Communication Channels') }}</h3>
             {% for item in doc.communication %}
             <div class="ap-o-wg-channel">
               <div class="ap-o-wg-channel-icon ap-o-wg-channel-icon-{{ item.channel }}">
@@ -156,9 +156,9 @@
                 </div>
               </div>
               <div class="ap-o-wg-channel-text">
-                <h4>{{ item.name }}</h4>
+                <h4>{{ _(item.name) }}</h4>
                 {% for el in item.content %}
-                <p>{{ el.item|markdown|safe }}</p>
+                <p>{{ _(el.item|markdown|safe) }}</p>
                 {% endfor %}
 
                 {% if (item.channel == 'slack' or item.channel == 'github') %}
@@ -181,29 +181,29 @@
       </div>
     </section>
     <section class="ap-o-wg-related">
-      <h2>Other ways to get involved with AMP</h2>
+      <h2>{{ _('Other ways to get involved with AMP') }}</h2>
       <div class="ap-o-wg-related-item">
-        <h3>Contribute to AMP</h3>
-        <p>The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute.</p>
+        <h3>{{ _('Contribute to AMP') }}</h3>
+        <p>{{ _('The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute.') }}</p>
         <div class="ap-o-benefits-overview-link">
           <a href="{{ g.doc('/content/amp-dev/documentation/guides-and-tutorials/contribute/index.md', locale=doc.locale).url.path }}" class="ap-m-lnk ap-m-lnk-square">
             <div class="ap-a-ico ap-m-lnk-icon">
               {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
             </div>
-            <span class="ap-m-lnk-text">Contribute</span>
+            <span class="ap-m-lnk-text">{{ _('Contribute') }}</span>
           </a>
         </div>
       </div>
       <div class="ap-o-wg-related-item">
-        <h3>Governance Body</h3>
-        <p>Learn more about the Advisory Committee and Technical Steering Committee.</p>
+        <h3>{{ _('Governance Body') }}</h3>
+        <p>{{ _('Learn more about the Advisory Committee and Technical Steering Committee.') }}</p>
           <a href="{{ g.doc('/content/amp-dev/community/governance.md', locale=doc.locale).url.path }}" class="ap-m-lnk ap-m-lnk-square">
             <div class="ap-a-ico ap-m-lnk-icon">
               {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
             </div>
-            <span class="ap-m-lnk-text">Governance</span>
+            <span class="ap-m-lnk-text">{{ _('Governance') }}</span>
           </a>
         </div>
     </section>

--- a/frontend/templates/views/partials/breadcrumbs.j2
+++ b/frontend/templates/views/partials/breadcrumbs.j2
@@ -16,10 +16,10 @@ and the current page title #}
     </span>
 
     {% if not doc.collection.bucket %}
-      <a class="ap-m-breadcrumbs-crumb" href="{{ guides_and_tutorials.url.path }}">{{ guides_and_tutorials.titles('navigation') }}</a>
+      <a class="ap-m-breadcrumbs-crumb" href="{{ guides_and_tutorials.url.path }}">{{ _(guides_and_tutorials.titles('navigation')) }}</a>
     {% endif %}
     {% if doc.collection.bucket %}
-      <div class="ap-m-breadcrumbs-crumb">{{ guides_and_tutorials.titles('navigation') }}</div>
+      <div class="ap-m-breadcrumbs-crumb">{{ _(guides_and_tutorials.titles('navigation')) }}</div>
     {% endif %}
 
   {% endif %}
@@ -43,7 +43,7 @@ and the current page title #}
   </span>
 
   {% set examples = g.doc('/content/amp-dev/documentation/examples/index.html', locale=doc.locale) %}
-  <div class="ap-m-breadcrumbs-crumb">{{ examples.titles('navigation') }}</div>
+  <div class="ap-m-breadcrumbs-crumb">{{ _(examples.titles('navigation')) }}</div>
 </nav>
 
 {% elif doc.pod_path.startswith('/content/amp-dev/documentation/components') %}
@@ -56,7 +56,7 @@ and the current page title #}
   </span>
 
   {% set components = g.doc('/content/amp-dev/documentation/components/index.html', locale=doc.locale) %}
-  <div class="ap-m-breadcrumbs-crumb">{{ components.titles('navigation') }}</div>
+  <div class="ap-m-breadcrumbs-crumb">{{ _(components.titles('navigation')) }}</div>
 </nav>
 
 {% elif doc.pod_path.startswith('/content/amp-dev/documentation/courses') %}
@@ -70,10 +70,10 @@ and the current page title #}
 
   {% set courses = g.doc('/content/amp-dev/documentation/courses/index.html', locale=doc.locale) %}
   {% if not doc.collection.bucket %}
-    <a class="ap-m-breadcrumbs-crumb" href="{{ courses.url.path }}">{{ courses.titles('navigation') }}</a>
+    <a class="ap-m-breadcrumbs-crumb" href="{{ courses.url.path }}">{{ _(courses.titles('navigation')) }}</a>
   {% endif %}
   {% if doc.collection.bucket %}
-    <div class="ap-m-breadcrumbs-crumb">{{ courses.titles('navigation') }}</div>
+    <div class="ap-m-breadcrumbs-crumb">{{ _(courses.titles('navigation')) }}</div>
   {% endif %}
 
 
@@ -82,7 +82,7 @@ and the current page title #}
     <svg class="ap-a-ico ap-m-breadcrumbs-angle"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
   </span>
 
-  <div class="ap-m-breadcrumbs-crumb">{{ doc.collection.title }}</div>
+  <div class="ap-m-breadcrumbs-crumb">{{ _(doc.collection.title) }}</div>
   {% endif %}
 </nav>
 
@@ -95,7 +95,7 @@ and the current page title #}
     <svg class="ap-a-ico ap-m-breadcrumbs-angle"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
   </span>
 
-  <div class="ap-m-breadcrumbs-crumb">{{ get_started.titles('navigation') }}</div>
+  <div class="ap-m-breadcrumbs-crumb">{{ _(get_started.titles('navigation')) }}</div>
 </nav>
 
 {% elif doc.pod_path.startswith('/content/amp-dev/support') %}
@@ -109,9 +109,9 @@ and the current page title #}
 
   {# Use breadcrumb title if it exists #}
   {% if doc.titles('breadcrumb') %}
-    <div class="ap-m-breadcrumbs-crumb">{{ doc.titles('breadcrumb') }}</div>
+    <div class="ap-m-breadcrumbs-crumb">{{ _(doc.titles('breadcrumb')) }}</div>
   {% else %}
-    <div class="ap-m-breadcrumbs-crumb">{{ doc.title }}</div>
+    <div class="ap-m-breadcrumbs-crumb">{{ _(doc.title) }}</div>
   {% endif %}
 </nav>
 {% endif %}

--- a/frontend/templates/views/partials/category-filter.j2
+++ b/frontend/templates/views/partials/category-filter.j2
@@ -14,7 +14,7 @@
     [class]="activeFilter.chosenFilter == 'none' ? 'ap-m-filter-bubble filtered' : 'ap-m-filter-bubble'"
     on="tap:AMP.setState({ activeFilter: {chosenFilter: 'none' } })"
     name="all">
-    All
+    {{ _('All') }}
   </button>
   {% for category, components in categories %}
   {% set scope = namespace(categoryFormats = []) %}

--- a/frontend/templates/views/partials/filter-bubbles.j2
+++ b/frontend/templates/views/partials/filter-bubbles.j2
@@ -2,6 +2,6 @@
 
 <div class="ap-o-filter-bubbles-list">
   {% for button in buttons %}
-    <button class="ap-m-filter-bubble">{{button}}</button>
+    <button class="ap-m-filter-bubble">{{_(button)}}</button>
   {% endfor %}
 </div>

--- a/frontend/templates/views/partials/footer.j2
+++ b/frontend/templates/views/partials/footer.j2
@@ -82,7 +82,7 @@
       <ul class="ap-o-footer-legal-nav-menu">
         <li class="ap-o-footer-legal-nav-item"><a class="ap-o-footer-legal-nav-link" href="https://www.google.com/intl/en/policies/privacy/" rel="noopener">{{_('Privacy Policy')}}</a></li>
       </ul>
-      <div class="ap-o-footer-copyright">&copy; 2019 AMP Open Source Project</div>
+      <div class="ap-o-footer-copyright">{{ _('&copy; 2019 AMP Open Source Project') }}</div>
     </div>
 
   </div>

--- a/frontend/templates/views/partials/format-filter-hint.j2
+++ b/frontend/templates/views/partials/format-filter-hint.j2
@@ -4,7 +4,7 @@
 {% do doc.amp_dependencies.add('amp-user-notification', '0.1') %}
 <amp-user-notification class="ap-m-format-filter-hint" id="format-filter-hint" layout="nodisplay">
   <div class="ap-m-format-filter-hint-content">
-    <div class="ap-m-format-filter-hint-note">Select your format for a more streamlined experience</div>
+    <div class="ap-m-format-filter-hint-note">{{ _('Select your format for a more streamlined experience') }}</div>
 
     <div class="ap-m-format-filter-hint-formats">
       {% set formats = ['websites', 'stories', 'ads', 'email'] %}
@@ -14,7 +14,7 @@
         <span class="ap-a-ico">
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#amp-{{ format }}"></use></svg>
         </span>
-        <span>{{ format }}</span>
+        <span>{{ _(format) }}</span>
       </button>
       {% endfor %}
     </div>

--- a/frontend/templates/views/partials/fragment-slider-texts.j2
+++ b/frontend/templates/views/partials/fragment-slider-texts.j2
@@ -2,15 +2,15 @@
 <div [class]='"ap-o-fragment-slider-text slide" +selected.slide' class="ap-o-fragment-slider-text slide1">
 
   <div class="ap-o-fragment-slider-textslide active" [class]="selected.slide == 1 ? 'ap-o-fragment-slider-textslide active' : 'ap-o-fragment-slider-textslide'">
-    <h3 class="ap-o-fragment-slider-preheadline">E-Commerce</h3>
-    <h2 class="ap-o-fragment-slider-headline">AMP Camp</h2>
+    <h3 class="ap-o-fragment-slider-preheadline">{{ _('E-Commerce') }}</h3>
+    <h2 class="ap-o-fragment-slider-headline">{{ _('AMP Camp') }}</h2>
     <div class="copy copy-right ap--content">
 
-      <p>AMP shines for content pages. But it can also power e-commerce experiences.</p>
-      <p>To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike.</p>
+      <p>{{ _('AMP shines for content pages. But it can also power e-commerce experiences.') }}</p>
+      <p>{{ _('To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike.') }}</p>
       <div class="ap-o-fragment-slider-component-list">
       {% for component in ['amp-list', 'amp-mustache', 'amp-bind', 'amp-form', 'amp-sidebar', 'amp-selector'] %}
-        <a class="ap-o-fragment-slider-component" href="{{ g.doc('/content/amp-dev/documentation/components/reference/' + component + '.md', locale=doc.locale).url.path }}"><code>{{ component }}</code></a>
+        <a class="ap-o-fragment-slider-component" href="{{ g.doc('/content/amp-dev/documentation/components/reference/' + component + '.md', locale=doc.locale).url.path }}"><code>{{ _(component) }}</code></a>
         {% endfor %}
       </div>
     </div>
@@ -21,7 +21,7 @@
           {% do doc.icons.useIcon('icons/external.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#external"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Experience Demo</span>
+        <span class="ap-m-lnk-text">{{ _('Experience Demo') }}</span>
       </a>
 
       <a href="https://github.com/ampproject/samples/tree/master/amp-camp" class="ap-m-lnk ap-m-lnk-square" target="_blank" rel="noopener">
@@ -29,23 +29,23 @@
           {% do doc.icons.useIcon('icons/external.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#external"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">See on GitHub</span>
+        <span class="ap-m-lnk-text">{{ _('See on GitHub') }}</span>
       </a>
     </div>
   </div>
 
   <div class="ap-o-fragment-slider-textslide" [class]="selected.slide == 2 ? 'ap-o-fragment-slider-textslide active' : 'ap-o-fragment-slider-textslide'">
-    <h3 class="ap-o-fragment-slider-preheadline">Magazine article</h3>
-    <h2 class="ap-o-fragment-slider-headline">Breaking the status quo</h2>
+    <h3 class="ap-o-fragment-slider-preheadline">{{ _('Magazine article') }}</h3>
+    <h2 class="ap-o-fragment-slider-headline">{{ _('Breaking the status quo') }}</h2>
     <div class="copy copy-right ap--content">
 
-      <p>This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page.</p>
+      <p>{{ _('This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page.') }}</p>
 
-      <p><code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth "scrolly-telling" experience with minimal effort and without any custom JavaScript.</p>
+      <p>{{ _('<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth "scrolly-telling" experience with minimal effort and without any custom JavaScript.') }}</p>
 
       <div class="ap-o-fragment-slider-component-list">
       {% for component in ['amp-mustache', 'amp-sidebar', 'amp-access', 'amp-analytics', 'amp-selector', 'amp-live-list', 'amp-fit-text', 'amp-social-share', 'amp-position-observer', 'amp-animation', 'amp-youtube', 'amp-orientation-observer', 'amp-carousel', 'amp-accordion', 'amp-twitter', 'amp-instagram', 'amp-lightbox', 'amp-video'] %}
-        <a class="ap-o-fragment-slider-component" href="{{ g.doc('/content/amp-dev/documentation/components/reference/' + component + '.md', locale=doc.locale).url.path }}"><code>{{ component }}</code></a>
+        <a class="ap-o-fragment-slider-component" href="{{ g.doc('/content/amp-dev/documentation/components/reference/' + component + '.md', locale=doc.locale).url.path }}"><code>{{ _(component) }}</code></a>
         {% endfor %}
       </div>
     </div>
@@ -56,7 +56,7 @@
         {% do doc.icons.useIcon('icons/external.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#external"></use></svg>
       </div>
-      <span class="ap-m-lnk-text">Experience Demo</span>
+      <span class="ap-m-lnk-text">{{ _('Experience Demo') }}</span>
     </a>
 
       <a href="https://github.com/ampproject/samples/tree/master/amp-article" class="ap-m-lnk ap-m-lnk-square" target="_blank" rel="noopener">
@@ -64,23 +64,23 @@
           {% do doc.icons.useIcon('icons/external.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#external"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">See on GitHub</span>
+        <span class="ap-m-lnk-text">{{ _('See on GitHub') }}</span>
       </a>
     </div>
   </div>
 
   <div class="ap-o-fragment-slider-textslide" [class]="selected.slide == 3 ? 'ap-o-fragment-slider-textslide active' : 'ap-o-fragment-slider-textslide'">
-    <h3 class="ap-o-fragment-slider-preheadline">Band page</h3>
-    <h2 class="ap-o-fragment-slider-headline">Olga and the kings</h2>
+    <h3 class="ap-o-fragment-slider-preheadline">{{ _('Band page') }}</h3>
+    <h2 class="ap-o-fragment-slider-headline">{{ _('Olga and the kings') }}</h2>
     <div class="copy copy-right ap--content">
 
-      <p>Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience.</p>
+      <p>{{ _('Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience.') }}</p>
 
-      <p>The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app.</p>
+      <p>{{ _('The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app.') }}</p>
 
       <div class="ap-o-fragment-slider-component-list">
       {% for component in ['amp-mustache', 'amp-date-picker', 'amp-sidebar', 'amp-access', 'amp-analytics', 'amp-selector', 'amp-3d-gltf', 'amp-live-list', 'amp-geo', 'amp-timeago', 'amp-form', 'amp-position-observer', 'amp-animation', 'amp-pan-zoom'] %}
-        <a class="ap-o-fragment-slider-component" href="{{ g.doc('/content/amp-dev/documentation/components/reference/' + component + '.md', locale=doc.locale).url.path }}"><code>{{ component }}</code></a>
+        <a class="ap-o-fragment-slider-component" href="{{ g.doc('/content/amp-dev/documentation/components/reference/' + component + '.md', locale=doc.locale).url.path }}"><code>{{ _(component) }}</code></a>
         {% endfor %}
       </div>
     </div>
@@ -91,7 +91,7 @@
           {% do doc.icons.useIcon('icons/external.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#external"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Experience Demo</span>
+        <span class="ap-m-lnk-text">{{ _('Experience Demo') }}</span>
       </a>
 
       <a href="https://github.com/ampproject/samples/tree/master/amp-concert" class="ap-m-lnk ap-m-lnk-square" target="_blank" rel="noopener">
@@ -99,7 +99,7 @@
           {% do doc.icons.useIcon('icons/external.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#external"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">See on GitHub</span>
+        <span class="ap-m-lnk-text">{{ _('See on GitHub') }}</span>
       </a>
     </div>
   </div>

--- a/frontend/templates/views/partials/jumpto.j2
+++ b/frontend/templates/views/partials/jumpto.j2
@@ -6,7 +6,7 @@
     {% for item in (doc.section_links if not list else list) %}
     <li class="ap-o-jumpto-item">
       <a class="ap-o-jumpto-link" href="{{ '#' + item if not list else item.url }}">
-        {{- item if not list else item.label -}}
+        {{- _(item if not list else item.label) -}}
       </a>
     </li>
     {% endfor %}

--- a/frontend/templates/views/partials/rolling-formats.j2
+++ b/frontend/templates/views/partials/rolling-formats.j2
@@ -6,7 +6,7 @@
 <div class="ap-m-rolling-formats">
   <div class="ap-m-rolling-formats-list">
     {% for format in formats %}
-    <span class="ap-m-rolling-formats-item">{{ format }}.</span>
+    <span class="ap-m-rolling-formats-item">{{ _(format) }}.</span>
     {% endfor %}
   </div>
 </div>

--- a/frontend/templates/views/partials/teaser-grid.j2
+++ b/frontend/templates/views/partials/teaser-grid.j2
@@ -9,7 +9,7 @@
 <div class="ap-o-teaser-grid">
 
   {% if headline %}
-  <h2>{{ headline }}</h2>
+  <h2>{{ _(headline) }}</h2>
   {% endif %}
 
   <div class="ap-o-teaser-grid-list ap-o-teaser-grid-list-count-{{ teasers|count }}">
@@ -24,7 +24,7 @@
 
         {% if teaser.image %}
         <div class="ap-a-img ap-m-teaser-image">
-          <amp-img src="{{ teaser.image.src }}" layout="responsive" width="{{ teaser.image.width }}" height="{{ teaser.image.height }}" alt="{{ teaser.image.alt }}"></amp-img>
+          <amp-img src="{{ teaser.image.src }}" layout="responsive" width="{{ teaser.image.width }}" height="{{ teaser.image.height }}" alt="{{ _(teaser.image.alt) }}"></amp-img>
         </div>
         {% endif %}
 
@@ -39,14 +39,14 @@
           {% endif %}
 
           <div class="ap-m-teaser-content">
-            <h4 class="ap-m-teaser-headline">{{ teaser.headline }}</h4>
+            <h4 class="ap-m-teaser-headline">{{ _(teaser.headline) }}</h4>
             {% if teaser.video %}
             <div class="ap-m-teaser-video-length">
               {% do doc.icons.useIcon('icons/play.svg') %}
               <div class="ap-a-ico ap-m-teaser-video-length-icon">
                 <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#play"></use></svg>
               </div>
-              <span class="ap-m-teaser-video-length-text">{{ teaser.video.length }}</span>
+              <span class="ap-m-teaser-video-length-text">{{ _(teaser.video.length) }}</span>
             </div>
           {% endif %}
           </div>
@@ -66,7 +66,7 @@
       <a href="{{ teaser.doc.url|relative }}">
         {% if teaser.destination %}
         {% do doc.styles.addCssFile('css/components/molecules/tag.css') %}
-        <div class="ap-m-tag ap-m-tag-{{ teaser.destination }} ap-m-teaser-tag">{{ teaser.destination }}</div>
+        <div class="ap-m-tag ap-m-tag-{{ teaser.destination }} ap-m-teaser-tag">{{ _(teaser.destination) }}</div>
         {% endif %}
 
         <div class="ap-m-teaser-card">
@@ -75,7 +75,7 @@
           </div>
         </div>
         <div class="ap-m-teaser-content">
-          <h4 class="ap-m-teaser-headline">{{ teaser.headline }}</h4>
+          <h4 class="ap-m-teaser-headline">{{ _(teaser.headline) }}</h4>
         </div>
       </a>
     </div>
@@ -94,12 +94,12 @@
         <div class="ap-m-teaser-card">
           {% if teaser.image %}
           <div class="ap-a-img ap-m-teaser-image">
-            <amp-img src="{{ teaser.image.src }}" layout="responsive" width="{{ teaser.image.width }}" height="{{ teaser.image.height }}" alt="{{ teaser.image.alt }}"></amp-img>
+            <amp-img src="{{ teaser.image.src }}" layout="responsive" width="{{ teaser.image.width }}" height="{{ teaser.image.height }}" alt="{{ _(teaser.image.alt) }}"></amp-img>
           </div>
           {% endif %}
 
           <div class="ap-m-teaser-content">
-            <h4 class="ap-m-teaser-headline">{{ teaser.headline }}</h4>
+            <h4 class="ap-m-teaser-headline">{{ _(teaser.headline) }}</h4>
           </div>
         </div>
       </a>
@@ -163,8 +163,8 @@
               {% endfor %}
             </div>
             {% endif %}
-            <h4 class="ap-m-teaser-headline">{{ teaser.headline }}</h4>
-            <p class="ap-m-teaser-copy">{{ teaser.text }}</p>
+            <h4 class="ap-m-teaser-headline">{{ _(teaser.headline) }}</h4>
+            <p class="ap-m-teaser-copy">{{ _(teaser.text) }}</p>
           </div>
         </div>
       </a>
@@ -189,11 +189,11 @@
           {% endif %}
 
           <div class="ap-m-teaser-header">
-            <h4 class="ap-m-teaser-header-title">{{ teaser.headline }}</h4>
+            <h4 class="ap-m-teaser-header-title">{{ _(teaser.headline) }}</h4>
           </div>
 
           <div class="ap-m-teaser-content">
-            <p class="ap-m-teaser-copy">{{ teaser.text }}</p>
+            <p class="ap-m-teaser-copy">{{ _(teaser.text) }}</p>
           </div>
         </div>
       </a>
@@ -208,7 +208,7 @@
     <div class="ap-a-ico ap-m-lnk-icon">
       <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
     </div>
-    <span class="ap-m-lnk-text">{{ cta.text }}</span>
+    <span class="ap-m-lnk-text">{{ _(cta.text) }}</span>
   </a>
   {% endif %}
 </div>

--- a/frontend/templates/views/partials/teaser.j2
+++ b/frontend/templates/views/partials/teaser.j2
@@ -8,7 +8,7 @@
 
     {% if teaser_doc.category %}
     {% do doc.styles.addCssFile('css/components/molecules/tag.css') %}
-    <div class="ap-m-tag ap-m-tag-general ap-m-teaser-tag">{{ teaser_doc.category }}</div>
+    <div class="ap-m-tag ap-m-tag-general ap-m-teaser-tag">{{ _(teaser_doc.category) }}</div>
     {% endif %}
 
     <div class="ap-m-teaser-card">
@@ -32,8 +32,8 @@
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ teaser.icon }}"></use></svg>
           </div>
           {% endif %}
-          <span class="ap-m-kpi-number">{{ teaser.figure }}</span>
-          <span class="ap-m-kpi-text">{{ teaser.description }}</span>
+          <span class="ap-m-kpi-number">{{ _(teaser.figure) }}</span>
+          <span class="ap-m-kpi-text">{{ _(teaser.description) }}</span>
         </div>
       </div>
       {% endif %}
@@ -45,7 +45,7 @@
           </div>
         {% endif %}
 
-        <h4 class="ap-m-teaser-headline">{{ teaser.text }}</h4>
+        <h4 class="ap-m-teaser-headline">{{ _(teaser.text) }}</h4>
       </div>
     </div>
   </a>
@@ -64,7 +64,7 @@
   <a href="{{ navigation_url }}">
     {% if teaser_doc.formats %}
     {% do doc.styles.addCssFile('/css/components/molecules/tag.css') %}
-    <div class="ap-m-tag ap-m-tag-{{ teaser_doc.formats[0] }} ap-m-teaser-tag">{{ teaser_doc.formats[0] }}</div>
+    <div class="ap-m-tag ap-m-tag-{{ teaser_doc.formats[0] }} ap-m-teaser-tag">{{ _(teaser_doc.formats[0]) }}</div>
     {% endif %}
 
     <div class="ap-m-teaser-card">
@@ -80,7 +80,7 @@
       {% endif %}
     </div>
     <div class="ap-m-teaser-content">
-      <h4 class="ap-m-teaser-headline">{{ teaser_doc.titles('teaser') }}</h4>
+      <h4 class="ap-m-teaser-headline">{{ _(teaser_doc.titles('teaser')) }}</h4>
     </div>
   </a>
 </div>
@@ -95,9 +95,9 @@
       {% endwith %}
       <div class="ap-m-teaser-content">
         <div class="ap-m-teaser-content-text">
-          <code><span>{{ teaser_doc.title }}</span></code>
+          <code><span>{{ _(teaser_doc.title) }}</span></code>
           {% if teaser_doc.teaser %}
-          <p>{{ teaser_doc.teaser.text }}</p>
+          <p>{{ _(teaser_doc.teaser.text) }}</p>
           {% endif %}
         </div>
       </div>
@@ -112,7 +112,7 @@
 <div class="ap-m-teaser ap-m-teaser-example" data-category="{{ teaser_doc.category|slug }}" [hidden]="activeFilter.chosenFilter != 'none' && activeFilter.chosenFilter != '{{ teaser_doc.category|slug }}'">
   {% if teaser_doc.used_components %}
   <div class="ap-m-teaser-info-trigger">
-    <strong>{{ teaser_doc.used_components|length }} AMP components</strong> used
+    <strong>{{ _(teaser_doc.used_components|length) }} AMP components</strong> used
   </div>
 
   <div class="ap-m-teaser-info-content">
@@ -180,7 +180,7 @@
       </div>
 
       <div class="ap-m-teaser-content">
-        <h4 class="ap-m-teaser-headline">{{ teaser_doc.titles('teaser') }}</h4>
+        <h4 class="ap-m-teaser-headline">{{ _(teaser_doc.titles('teaser')) }}</h4>
       </div>
     </div>
   </a>
@@ -202,11 +202,11 @@
     <a href="{{ teaser_doc.url.path }}">
       <div class="ap-m-teaser-content">
         <div class="ap-m-teaser-content-text">
-          <h4>{{ teaser_doc.title }}</h4>
+          <h4>{{ _(teaser_doc.title) }}</h4>
           {% if teaser_doc.description %}
-          <p>{{ teaser_doc.description }}</p>
+          <p>{{ _(teaser_doc.description) }}</p>
           {% else %}
-          <p>Discover more...</p>
+          <p>{{ _('Discover more...') }}</p>
           {% endif %}
         </div>
         <div class="guide-tag">
@@ -217,7 +217,7 @@
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#tutorial"></use>
             </svg>
           </div>
-          <span class="guide-tag-text">Tutorial</span>
+          <span class="guide-tag-text">{{ _('Tutorial') }}</span>
           {% else %}
           <div class="guide-tag-icon guide-tag-icon-guide" >
             {% do doc.icons.useIcon('icons/guide.svg') %}
@@ -225,7 +225,7 @@
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#guide"></use>
             </svg>
           </div>
-          <span class="guide-tag-text">Guide</span>
+          <span class="guide-tag-text">{{ _('Guide') }}</span>
           {% endif %}
         </div>
       </div>
@@ -274,9 +274,9 @@
     {# card container #}
     <div class="ap-m-teaser-card">
       <div class="ap-m-teaser-content">
-        <h4 class="ap-m-teaser-headline">{{ teaser_doc.titles('teaser') }}</h4>
+        <h4 class="ap-m-teaser-headline">{{ _(teaser_doc.titles('teaser')) }}</h4>
         {% if teaser.text or teaser_doc.description %}
-          <p class="ap-m-teaser-copy">{{ teaser.text or teaser_doc.description }}</p>
+          <p class="ap-m-teaser-copy">{{ _(teaser.text or teaser_doc.description) }}</p>
         {% endif %}
         {% if teaser.label %}
           <span class="ap-m-lnk">
@@ -284,7 +284,7 @@
               {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
             </span>
-            <span class="ap-m-lnk-text">{{ teaser.label }}</span>
+            <span class="ap-m-lnk-text">{{ _(teaser.label) }}</span>
           </span>
         {% endif %}
       </div>
@@ -319,9 +319,9 @@
 
       <div class="ap-m-teaser-card">
         <div class="ap-m-teaser-content">
-          <h4 class="ap-m-teaser-headline">{{ teaser_doc.titles('teaser') }}</h4>
+          <h4 class="ap-m-teaser-headline">{{ _(teaser_doc.titles('teaser')) }}</h4>
           {% if teaser.text or teaser_doc.description %}
-            <p class="ap-m-teaser-copy">{{ teaser.text or teaser_doc.description }}</p>
+            <p class="ap-m-teaser-copy">{{ _(teaser.text or teaser_doc.description) }}</p>
           {% endif %}
           {% if teaser.label %}
             <span class="ap-m-lnk ap-m-teaser-link">
@@ -329,7 +329,7 @@
                 {% do doc.icons.useIcon('icons/internal.svg') %}
                 <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
               </span>
-              <span class="ap-m-lnk-text">{{ teaser.label }}</span>
+              <span class="ap-m-lnk-text">{{ _(teaser.label) }}</span>
             </span>
           {% endif %}
         </div>

--- a/frontend/templates/views/partials/tools-teaser.j2
+++ b/frontend/templates/views/partials/tools-teaser.j2
@@ -8,7 +8,7 @@
     <div class="ap-m-teaser-tag-icon ap-m-teaser-tag-{{tool.formats[0]}} ap-a-ico">
       <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#amp-{{tool.formats[0]}}"></use></svg>
     </div>
-    {{ tool.formats[0]|title }}
+    {{ _(tool.formats[0]|title) }}
   </div>
   {% endif %}
   <a href="{{ tool.url }}">
@@ -36,15 +36,15 @@
           {%- if teaser.official %}{% do doc.icons.useIcon('/icons/logo-transparent.svg') -%}
             <div class="ap-m-teaser-logo ap-a-ico"><svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#logo-transparent"></use></svg></div>
           {%- endif -%}
-          {{- teaser.name -}}
+          {{- _(teaser.name) -}}
           </h4>
           {% if teaser.description %}
-          <p>{{ teaser.description }}</p>
+          <p>{{ _(teaser.description) }}</p>
           {% endif %}
         </div>
 
         {% if teaser.type %}
-        <div class="ap-m-teaser-type ap-m-teaser-type-{{ tool.type|lower }}">{{ teaser.type }}</div>
+        <div class="ap-m-teaser-type ap-m-teaser-type-{{ tool.type|lower }}">{{ _(teaser.type) }}</div>
         {% endif %}
       </div>
 

--- a/frontend/templates/views/partials/tools-widget.j2
+++ b/frontend/templates/views/partials/tools-widget.j2
@@ -7,8 +7,19 @@
 <section class="ap--content">
   <div class="ap--container-fluid">
     <div class="ap-m-copy ap-m-copy-left-small">
-      <h1 id="tools">{% if format == 'email' %}Start sending AMP Emails{% else %}Start creating {{ format }}{% endif %}</h1>
-      <h5>Pick one of several editors to start creating {{ format }} without any coding involved.</h5>
+        {% if format == 'ads' %}
+          <h1 id="tools">{{ _('Start creating ads') }}</h1>
+          <h5>{{ _('Pick one of several editors to start creating ads without any coding involved.', fmt=format) }}</h5>
+        {% elif format == 'email' %}
+          <h1 id="tools">{{ _('Start sending AMP Emails') }}</h1>
+          <h5>{{ _('Pick one of several editors to start creating email without any coding involved.', fmt=format) }}</h5>
+        {% elif format == 'stories' %}
+          <h1 id="tools">{{ _('Start creating stories') }}</h1>
+          <h5>{{ _('Pick one of several editors to start creating stories without any coding involved.', fmt=format) }}</h5>
+        {% elif format == 'websites' %}
+          <h1 id="tools">{{ _('Start creating websites') }}</h1>
+          <h5>{{ _('Pick one of several editors to start creating websites without any coding involved.', fmt=format) }}</h5>
+        {% endif %}
     </div>
   </div>
 </section>
@@ -33,7 +44,7 @@
           {% do doc.icons.useIcon('icons/internal.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Discover all tools</span>
+        <span class="ap-m-lnk-text">{{ _('Discover all tools') }}</span>
       </a>
     </div>
   </div>

--- a/pages/content/amp-dev/about/ads.html
+++ b/pages/content/amp-dev/about/ads.html
@@ -38,12 +38,12 @@ kpis:
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bolt-solid"></use></svg>
           </div>
 
-          <h2 class="ap-o-stage-content-subline">AMP Ads</h2>
-          <h1 class="ap-o-stage-content-headline">Use AMP to build and serve lightning fast, safe ads to pages and stories.</h1>
+          <h2 class="ap-o-stage-content-subline">{{ _('AMP Ads') }}</h2>
+          <h1 class="ap-o-stage-content-headline">{{ _('Use AMP to build and serve lightning fast, safe ads to pages and stories.') }}</h1>
 
           {% do doc.styles.addCssFile('/css/components/atoms/button.css') %}
-          <a href="../documentation/guides-and-tutorials/start/create_amphtml_ad/index.md?format=ads" class="ap-o-stage-content-button ap-a-btn">Start developing</a>
-          <a href="#tools" class="ap-o-stage-content-button ap-a-btn">Explore tools</a>
+          <a href="../documentation/guides-and-tutorials/start/create_amphtml_ad/index.md?format=ads" class="ap-o-stage-content-button ap-a-btn">{{ _('Start developing') }}</a>
+          <a href="#tools" class="ap-o-stage-content-button ap-a-btn">{{ _('Explore tools') }}</a>
        </div>
     </div>
   </div>
@@ -54,17 +54,17 @@ kpis:
 <section class="ap--content">
   <div class="ap--container">
     <div class="ap-m-copy ap-m-copy-left" amp-fx="fade-in fly-in-left" data-margin-start="5%" data-duration="1s" data-fly-in-distance="5%">
-      <h1>AMP<br> Ads</h1>
-      <h5>These days, if it isn’t instant - it's not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user.</h5>
-      <p>AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike.</p>
-      <p>Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users.</p>
+      <h1>{{ _('AMP<br> Ads') }}</h1>
+      <h5>{{ _('These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user.') }}</h5>
+      <p>{{ _('AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike.') }}</p>
+      <p>{{ _('Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users.') }}</p>
       <div class="ap-o-component-visual-link">
         <a href="../documentation/guides-and-tutorials/index.html?format=ads" class="ap-m-lnk ap-m-lnk-square">
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Get Started</span>
+          <span class="ap-m-lnk-text">{{ _('Get Started') }}</span>
         </a>
       </div>
     </div>
@@ -74,19 +74,19 @@ kpis:
 <section class="ap--content">
     <div class="ap--container">
       <div class="ap-m-copy ap-m-copy-left" amp-fx="fade-in fly-in-left" data-duration="1s" data-fly-in-distance="5%">
-      <h1>A faster way to grow your business</h1>
-      <p>A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance.</p>
-      <p>AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads.</p>
-      <p>Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML.</p>
-      <p>AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware.</p>
-      <p>Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility.</p>
+        <h1>{{ _('A faster way to grow your business') }}</h1>
+        <p>{{ _('A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance.') }}</p>
+        <p>{{ _('AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads.') }}</p>
+        <p>{{ _('Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML.') }}</p>
+        <p>{{ _('AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware.') }}</p>
+        <p>{{ _('Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility.') }}</p>
       <div class="ap-o-component-visual-link">
         <a href="../documentation/guides-and-tutorials/start/create_amphtml_ad/index.md" class="ap-m-lnk ap-m-lnk-square">
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Get Started</span>
+          <span class="ap-m-lnk-text">{{ _('Get Started') }}</span>
         </a>
       </div>
       </div>
@@ -122,7 +122,7 @@ kpis:
           {% do doc.icons.useIcon('icons/exclamation.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#exclamation"></use></svg>
         </div>
-        <h1 class="ap-m-headline-icon-hl">The benefits of AMP ads</h1>
+        <h1 class="ap-m-headline-icon-hl">{{ _('The benefits of AMP ads') }}</h1>
       </div>
     </div>
 
@@ -135,8 +135,8 @@ kpis:
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ benefit.icon }}"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline">{{ benefit.headline }}</span>
-            <span class="ap-m-benefit-text-copy"> {{ benefit.text }}</span>
+            <span class="ap-m-benefit-text-headline">{{ _(benefit.headline) }}</span>
+            <span class="ap-m-benefit-text-copy"> {{ _(benefit.text) }}</span>
           </div>
         </div>
 
@@ -153,8 +153,8 @@ kpis:
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ benefit.icon }}"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline">{{ benefit.headline }}</span>
-            <span class="ap-m-benefit-text-copy"> {{ benefit.text }}</span>
+            <span class="ap-m-benefit-text-headline">{{ _(benefit.headline) }}</span>
+            <span class="ap-m-benefit-text-copy"> {{ _(benefit.text) }}</span>
           </div>
         </div>
 
@@ -168,7 +168,7 @@ kpis:
           {% do doc.icons.useIcon('icons/internal.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Read on about AMP ads</span>
+        <span class="ap-m-lnk-text">{{ _('Read on about AMP ads') }}</span>
       </a>
     </div>
 
@@ -185,16 +185,16 @@ kpis:
     </div>
     <div class="ap-m-quote-quote">
       <blockquote>
-        <p class="ap-a-txt">They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance.<p>
+        <p class="ap-a-txt">{{ _('They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance.') }}<p>
       </blockquote>
-      <p>Shaun Zacharia, President & Co-Founder, Triplelift.</p>
+      <p>{{ _('Shaun Zacharia, President & Co-Founder, Triplelift.') }}</p>
 
       <a href="success-stories/triplelift.yaml" class="ap-m-lnk">
         <div class="ap-a-ico ap-m-lnk-icon">
           {% do doc.icons.useIcon('icons/internal.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Read Success Story</span>
+        <span class="ap-m-lnk-text">{{ _('Read Success Story') }}</span>
       </a>
     </div>
   </div>
@@ -203,17 +203,17 @@ kpis:
 <section class="ap--content">
   <div class="ap--container">
     <div class="ap-m-copy ap-m-copy-left" amp-fx="fade-in fly-in-left" data-margin-start="5%" data-duration="1s" data-fly-in-distance="5%">
-      <h1>AMP for advertisers</h1>
-      <h5>Grow engagement and increase conversions with faster experiences</h5>
-      <p>The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. </p>
-      <p>AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase.</p>
+      <h1>{{ _('AMP for advertisers') }}</h1>
+      <h5>{{ _('Grow engagement and increase conversions with faster experiences') }}</h5>
+      <p>{{ _('The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. ') }}</p>
+      <p>{{ _('AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase.') }}</p>
       <div class="ap-o-component-visual-link">
         <a href="../documentation/guides-and-tutorials/learn/intro-to-amphtml-ads.md" class="ap-m-lnk ap-m-lnk-square">
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Get Started</span>
+          <span class="ap-m-lnk-text">{{ _('Get Started') }}</span>
         </a>
       </div>
     </div>
@@ -225,13 +225,13 @@ kpis:
 
   <div class="ap--container">
     <div class="ap-m-copy ap-m-copy-left" amp-fx="fade-in fly-in-left" data-margin-start="5%" data-duration="1s" data-fly-in-distance="5%">
-      <h1>What’s the difference between an AMPHTML ad and a regular ad? Seconds.</h1>
+      <h1>{{ _('What’s the difference between an AMPHTML ad and a regular ad? Seconds.') }}</h1>
     </div>
   </div>
 
   <div class="ap--shift-cards-grid ap--container">
     <div class="ap-m-shift-card ap-m-shift-card-1 small">
-      <div class="ap-m-shift-card-title">AMPHTML Ad</div>
+      <div class="ap-m-shift-card-title">{{ _('AMPHTML Ad') }}</div>
       {% do doc.styles.addCssFile('css/components/molecules/ghost-frame-mobile.css') %}
       <div class="ap-m-ghost-frame-mobile">
         <amp-video
@@ -247,7 +247,7 @@ kpis:
       </div>
     </div>
     <div class="ap-m-shift-card ap-m-shift-card-2 small">
-      <div class="ap-m-shift-card-title">Regular Ad</div>
+      <div class="ap-m-shift-card-title">{{ _('Regular Ad') }}</div>
       <div class="ap-m-ghost-frame-mobile">
         <amp-video
           width="410"

--- a/pages/content/amp-dev/about/email.html
+++ b/pages/content/amp-dev/about/email.html
@@ -40,12 +40,12 @@ email_clients:
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bolt-solid"></use></svg>
           </div>
 
-          <h2 class="ap-o-stage-content-subline">AMP Email</h2>
-          <h1 class="ap-o-stage-content-headline">Use AMP to send interactive, dynamic emails.</h1>
+          <h2 class="ap-o-stage-content-subline">{{ _('AMP Email') }}</h2>
+          <h1 class="ap-o-stage-content-headline">{{ _('Use AMP to send interactive, dynamic emails.') }}</h1>
 
           {% do doc.styles.addCssFile('/css/components/atoms/button.css') %}
-          <a href="../documentation/guides-and-tutorials/start/create_email.md?format=email" class="ap-o-stage-content-button ap-a-btn">Start developing</a>
-          <a href="#send-mails" class="ap-o-stage-content-button ap-a-btn">Send emails</a>
+          <a href="../documentation/guides-and-tutorials/start/create_email.md?format=email" class="ap-o-stage-content-button ap-a-btn">{{ _('Start developing') }}</a>
+          <a href="#send-mails" class="ap-o-stage-content-button ap-a-btn">{{ _('Send emails') }}</a>
         </div>
     </div>
   </div>
@@ -56,23 +56,23 @@ email_clients:
 <section class="ap--content">
   <div class="ap--container-fluid">
     <div class="ap-m-copy ap-m-copy-left-small" amp-fx="fade-in fly-in-left" data-margin-start="5%" data-duration="1s" data-fly-in-distance="5%">
-      <h1>AMP<br> Email</h1>
-      <h5>A whole new world of possibilities for content engagement</h5>
+      <h1>{{ _('AMP<br> Email') }}</h1>
+      <h5>{{ _('A whole new world of possibilities for content engagement') }}</h5>
 
       {% do doc.styles.addCssFile('/css/components/atoms/video.css') %}
       <figure class="ap-a-video">
         <amp-youtube id="myLiveChannel" data-videoid="R_YQB6rLo_M" width="358" height="204" layout="responsive"></amp-youtube>
       </figure>
 
-      <p>AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message.</p>
-      <p>More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe.</p>
+      <p>{{ _('AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message.') }}</p>
+      <p>{{ _('More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe.') }}</p>
       <div class="ap-o-component-visual-link">
         <a href="../documentation/guides-and-tutorials/start/create_email.md" class="ap-m-lnk ap-m-lnk-square">
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Get Started</span>
+          <span class="ap-m-lnk-text">{{ _('Get Started') }}</span>
         </a>
       </div>
     </div>
@@ -89,9 +89,9 @@ email_clients:
     </div>
     <div class="ap-m-quote-quote">
       <blockquote>
-        <p class="ap-a-txt">It’s the biggest thing happening to email since the creation of email.<p>
+        <p class="ap-a-txt">{{ _('It’s the biggest thing happening to email since the creation of email.') }}<p>
       </blockquote>
-      <p>Antony Malone, Senior Product Owner Direct Marketing at Booking.com</p>
+      <p>{{ _('Antony Malone, Senior Product Owner Direct Marketing at Booking.com') }}</p>
 
     </div>
   </div>
@@ -100,16 +100,16 @@ email_clients:
 <section class="ap--content">
   <div class="ap--container-fluid">
     <div class="ap-m-copy ap-m-copy-left-small" amp-fx="fade-in fly-in-left" data-margin-start="5%" data-duration="1s" data-fly-in-distance="5%">
-      <h1>Modern app functionality for email</h1>
-      <h5>Modernize email with the power of AMP</h5>
-      <p>AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features.</p>
+      <h1>{{ _('Modern app functionality for email') }}</h1>
+      <h5>{{ _('Modernize email with the power of AMP') }}</h5>
+      <p>{{ _('AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features.') }}</p>
       <div class="ap-o-component-visual-link">
         <a href="../documentation/guides-and-tutorials/start/create_email.md" class="ap-m-lnk ap-m-lnk-square">
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Get Started</span>
+          <span class="ap-m-lnk-text">{{ _('Get Started') }}</span>
         </a>
       </div>
     </div>
@@ -119,8 +119,8 @@ email_clients:
 <section class="ap--content">
   <div class="ap--container-fluid">
     <div class="ap-m-copy ap-m-copy-right-small" amp-fx="fade-in fly-in-right" data-margin-start="5%" data-duration="1s" data-fly-in-distance="5%">
-      <h1>Supported Email Clients</h1>
-      <h5>These email clients currently support receiving AMP Emails</h5>
+      <h1>{{ _('Supported Email Clients') }}</h1>
+      <h5>{{ _('These email clients currently support receiving AMP Emails') }}</h5>
       <div class="ap-o-component-visual-link">
       <div class="ap-o-teaser-grid-list">
         {% for tool in doc.email_clients %}
@@ -141,7 +141,7 @@ email_clients:
           {% do doc.icons.useIcon('icons/exclamation.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#exclamation"></use></svg>
         </div>
-        <h1 class="ap-m-headline-icon-hl">The benefits of AMP email</h1>
+        <h1 class="ap-m-headline-icon-hl">{{ _('The benefits of AMP email') }}</h1>
       </div>
     </div>
 
@@ -155,8 +155,8 @@ email_clients:
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ benefit.icon }}"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline">{{ benefit.headline }}</span>
-            <span class="ap-m-benefit-text-copy">{{ benefit.text }}</span>
+            <span class="ap-m-benefit-text-headline">{{ _(benefit.headline) }}</span>
+            <span class="ap-m-benefit-text-copy">{{ _(benefit.text) }}</span>
           </div>
         </div>
 
@@ -174,8 +174,8 @@ email_clients:
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ benefit.icon }}"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline">{{ benefit.headline }}</span>
-            <span class="ap-m-benefit-text-copy">{{ benefit.text }}</span>
+            <span class="ap-m-benefit-text-headline">{{ _(benefit.headline) }}</span>
+            <span class="ap-m-benefit-text-copy">{{ _(benefit.text) }}</span>
           </div>
         </div>
 
@@ -189,7 +189,7 @@ email_clients:
           {% do doc.icons.useIcon('icons/internal.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Read on about AMP email</span>
+        <span class="ap-m-lnk-text">{{ _('Read on about AMP email') }}</span>
       </a>
     </div>
 

--- a/pages/content/amp-dev/about/how-amp-works.html
+++ b/pages/content/amp-dev/about/how-amp-works.html
@@ -15,8 +15,8 @@ $view: /views/overview/custom-content.j2
       {% do doc.icons.useIcon('/icons/code-architecture.svg') %}
       <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#code-architecture"></use></svg>
     </div>
-    <h1 class="ap-m-jumbo-headline">How AMP works</h1>
-    <p class="ap-m-jumbo-copy">The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that's still too much to read, simply watch the explainer video:</p>
+    <h1 class="ap-m-jumbo-headline">{{ _('How AMP works') }}</h1>
+    <p class="ap-m-jumbo-copy">{{ _('The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:') }}</p>
 
     {% do doc.styles.addCssFile('css/components/atoms/video.css') %}
     <figure class="ap-a-video">
@@ -26,22 +26,22 @@ $view: /views/overview/custom-content.j2
 
   {% do doc.styles.addCssFile('/css/components/molecules/copy.css') %}
   <div class="ap-m-copy ap-m-copy-left-small">
-    <h2>Execute all AMP JavaScript asynchronously</h2>
-    <p>JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href="https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript. </p>
-    <p>AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. </p>
-    <p>While custom JS is allowed in <a href="../documentation/components/reference/amp-script.md"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href="http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page.</p>
+    <h2>{{ _('Execute all AMP JavaScript asynchronously') }}</h2>
+    <p>{{ _('JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href="https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript.') }} </p>
+    <p>{{ _('AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. ') }}</p>
+    <p>{{ _('While custom JS is allowed in <a href="../documentation/components/reference/amp-script.md"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href="http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page.') }}</p>
   </div>
 
   <div class="ap-m-copy ap-m-copy-center-small">
-    <h2>Size all resources statically</h2>
-    <p>External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. </p>
-    <p>AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href="#font-triggering-must-be-efficient">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load.</p>
+    <h2>{{ _('Size all resources statically') }}</h2>
+    <p>{{ _('External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. ') }}</p>
+    <p>{{ _('AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href="#font-triggering-must-be-efficient">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load.') }}</p>
   </div>
 
   <div class="ap-m-copy ap-m-copy-right-small">
-    <h2>Don’t let extension mechanisms block rendering</h2>
-    <p>AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href="../documentation/components/reference/amp-lightbox.md">lightboxes</a>, <a href="../documentation/components/reference/amp-instagram.md">instagram embeds</a>, <a href="../documentation/components/reference/amp-twitter.md">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering. </p>
-    <p>Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href="../documentation/components/reference/amp-iframe.md"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:</p>
+    <h2>{{ _('Don’t let extension mechanisms block rendering') }}</h2>
+    <p>{{ _('AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href="../documentation/components/reference/amp-lightbox.md">lightboxes</a>, <a href="../documentation/components/reference/amp-instagram.md">instagram embeds</a>, <a href="../documentation/components/reference/amp-twitter.md">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering.') }}</p>
+    <p>{{ _('Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href="../documentation/components/reference/amp-iframe.md"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:') }}</p>
 
     {% do doc.styles.addCssFile('css/components/molecules/code-snippet.css') %}
     {% set code_snippet = '<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>' %}
@@ -50,49 +50,49 @@ $view: /views/overview/custom-content.j2
   </div>
 
   <div class="ap-m-copy ap-m-copy-left-small">
-    <h2>Keep all third-party JavaScript out of the critical path</h2>
-    <p>Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading. </p>
-    <p>AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. </p>
-    <p>The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page.</p>
+    <h2>{{ _('Keep all third-party JavaScript out of the critical path') }}</h2>
+    <p>{{ _('Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading.') }}</p>
+    <p>{{ _('AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. ') }}</p>
+    <p>{{ _('The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page.') }}</p>
   </div>
 
   <div class="ap-m-copy ap-m-copy-center-small">
-    <h2>All CSS must be inline and size-bound</h2>
-    <p>CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. </p>
-    <p>Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene.</p>
+    <h2>{{ _('All CSS must be inline and size-bound') }}</h2>
+    <p>{{ _('CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. ') }}</p>
+    <p>{{ _('Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene.') }}</p>
   </div>
 
   <div class="ap-m-copy ap-m-copy-right-small">
-    <h2>Font triggering must be efficient</h2>
-    <p>Web fonts are super large, so <a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens. </p>
-    <p>The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts.</p>
+    <h2>{{ _('Font triggering must be efficient') }}</h2>
+    <p>{{ _('Web fonts are super large, so <a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens.') }}</p>
+    <p>{{ _('The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts.') }}</p>
   </div>
 
   <div class="ap-m-copy ap-m-copy-left-small">
-    <h2>Minimize style recalculations</h2>
-    <p>Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. </p>
-    <p>Learn more about impact of style and layout recalculations on <a href="https://developers.google.com/web/fundamentals/performance/rendering/">rendering performance</a>.</p>
+    <h2>{{ _('Minimize style recalculations') }}</h2>
+    <p>{{ _('Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. ') }}</p>
+    <p>{{ _('Learn more about impact of style and layout recalculations on <a href="https://developers.google.com/web/fundamentals/performance/rendering/">rendering performance</a>.') }}</p>
   </div>
 
   <div class="ap-m-copy ap-m-copy-center-small">
-    <h2>Only run GPU-accelerated animations</h2>
-    <p>The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good. </p>
-    <p>The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href="https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count">using transform and opacity for animation changes</a>.</p>
+    <h2>{{ _('Only run GPU-accelerated animations') }}</h2>
+    <p>{{ _('The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good.') }}</p>
+    <p>{{ _('The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href="https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count">using transform and opacity for animation changes</a>.') }}</p>
   </div>
 
   <div class="ap-m-copy ap-m-copy-left-small">
-    <h2>Prioritize resource loading</h2>
-    <p>AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources. </p>
-    <p>When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them. </p>
-    <p>AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users.</p>
+    <h2>{{ _('Prioritize resource loading') }}</h2>
+    <p>{{ _('AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources.') }}</p>
+    <p>{{ _('When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them.') }}</p>
+    <p>{{ _('AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users.') }}</p>
   </div>
 
   <div class="ap-m-copy ap-m-copy-right-small">
-    <h2>Load pages in an instant</h2>
-    <p>The new <a href="http://www.w3.org/TR/resource-hints/#dfn-preconnect">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading. </p>
-    <p>While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU. </p>
-    <p>When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded. </p>
-    <p>Learn more about <a href="https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e">why AMP HTML doesn’t take full advantage of the preload scanner</a>.</p>
+    <h2>{{ _('Load pages in an instant') }}</h2>
+    <p>{{ _('The new <a href="http://www.w3.org/TR/resource-hints/#dfn-preconnect">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading.') }}</p>
+    <p>{{ _('While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU.') }}</p>
+    <p>{{ _('When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded.') }}</p>
+    <p>{{ _('Learn more about <a href="https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e">why AMP HTML doesn’t take full advantage of the preload scanner</a>.') }}</p>
   </div>
 
 </section>

--- a/pages/content/amp-dev/about/mission-and-vision.html
+++ b/pages/content/amp-dev/about/mission-and-vision.html
@@ -1,7 +1,7 @@
 ---
-$title: Vision and Mission
+$title: Vision & Mission
 $order: 1
-description: Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it.
+description: Ourljhasdfbh vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it.
 $view: /views/overview/custom-content.j2
 ---
 {% do doc.styles.addCssFile('css/components/templates/custom-content.css') %}
@@ -14,28 +14,28 @@ $view: /views/overview/custom-content.j2
 <section class="ap--container mission">
 
   <div class="ap-m-copy ap-m-copy-center-small ap-m-biggy-background">
-    <h1>Vision & Mission</h1>
-    <p>Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it.</p>
+    <h1>{{ _('Vision & Mission') }}</h1>
+    <p>{{ _('Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it.') }}</p>
   </div>
 
   {% do doc.styles.addCssFile('/css/components/molecules/copy.css') %}
   <div class="ap-m-copy ap-m-copy-left-xsmall ap-m-biggy-background">
     <h2 class="ap-m-biggy-headline ap-m-biggy-background-headline">
-      Vision
+      {{ _('Vision') }}
     </h2>
-    <h3>Vision</h3>
+    <h3>{{ _('Vision') }}</h3>
     <p>
-      A strong, user-first open web forever.
+    {{ _('A strong, user-first open web forever.') }}
     </p>
 
   </div>
 
   <div class="ap-m-copy no-margin ap-m-copy-right-xsmall ap-m-biggy-background">
     <h2 class="ap-m-biggy-headline ap-m-biggy-background-headline">
-      &amp;&nbsp;Mission
+      &amp;&nbsp;{{ _('Mission') }}
     </h2>
-    <h3>Mission</h3>
-    <p>Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser.</p>
+    <h3>{{ _('Mission') }}</h3>
+    <p>{{ _('Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser.') }}</p>
   </div>
 
   <div class="ap--divider"></div>
@@ -48,8 +48,8 @@ $view: /views/overview/custom-content.j2
   {% do doc.styles.addCssFile('/css/components/organisms/benefits-overview.css') %}
 
   <div class="ap-m-copy no-margin ap-m-copy-center-small ap-m-biggy-background">
-    <h1>Design Principles</h1>
-    <p>These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions.</p>
+    <h1>{{ _('Design Principles') }}</h1>
+    <p>{{ _('These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions.') }}</p>
   </div>
 
   <div class="ap--video ap-m-copy-center-small">
@@ -67,8 +67,8 @@ $view: /views/overview/custom-content.j2
           <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ux"></use></svg>
         </div>
         <div class="ap-m-benefit-text">
-          <span class="ap-m-benefit-text-headline">User Experience > Developer Experience > Ease of Implementation.</span>
-          <span class="ap-m-benefit-text-copy">When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement.</span>
+          <span class="ap-m-benefit-text-headline">{{ _('User Experience > Developer Experience > Ease of Implementation.') }}</span>
+          <span class="ap-m-benefit-text-copy">{{ _('When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement.') }}</span>
         </div>
       </div>
 
@@ -78,8 +78,8 @@ $view: /views/overview/custom-content.j2
           <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#time-principle"></use></svg>
         </div>
         <div class="ap-m-benefit-text">
-          <span class="ap-m-benefit-text-headline">Don’t design for a hypothetical faster future browser.</span>
-          <span class="ap-m-benefit-text-copy">We’ve chosen to build AMP as a library in the spirit of the <a href="https://github.com/extensibleweb/manifesto/blob/master/README.md">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today's browsers. When certain optimizations aren't possible with today's platform, AMP developers should participate in standards development to get these added to the web platform.</span>
+          <span class="ap-m-benefit-text-headline">{{ _('Don’t design for a hypothetical faster future browser.') }}</span>
+          <span class="ap-m-benefit-text-copy">{{ _('We’ve chosen to build AMP as a library in the spirit of the <a href="https://github.com/extensibleweb/manifesto/blob/master/README.md">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>') }}
         </div>
       </div>
 
@@ -89,8 +89,8 @@ $view: /views/overview/custom-content.j2
           <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#components"></use></svg>
         </div>
         <div class="ap-m-benefit-text">
-          <span class="ap-m-benefit-text-headline">Don’t break the web.</span>
-          <span class="ap-m-benefit-text-copy">Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache.</span>
+          <span class="ap-m-benefit-text-headline">{{ _('Don’t break the web.') }}</span>
+          <span class="ap-m-benefit-text-copy">{{ _('Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache.') }}</span>
         </div>
       </div>
     </div>
@@ -103,8 +103,8 @@ $view: /views/overview/custom-content.j2
           <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#layers"></use></svg>
         </div>
         <div class="ap-m-benefit-text">
-          <span class="ap-m-benefit-text-headline">Solve problems on the right layer.</span>
-          <span class="ap-m-benefit-text-copy">E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration.</span>
+          <span class="ap-m-benefit-text-headline">{{ _('Solve problems on the right layer.') }}</span>
+          <span class="ap-m-benefit-text-copy">{{ _('E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration.') }}</span>
         </div>
       </div>
       <div class="ap-m-benefit principles">
@@ -113,8 +113,8 @@ $view: /views/overview/custom-content.j2
           <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#fast-loading"></use></svg>
         </div>
         <div class="ap-m-benefit-text">
-          <span class="ap-m-benefit-text-headline">Only do things if they can be made fast.</span>
-          <span class="ap-m-benefit-text-copy">Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices.</span>
+          <span class="ap-m-benefit-text-headline">{{ _('Only do things if they can be made fast.') }}</span>
+          <span class="ap-m-benefit-text-copy">{{ _('Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices.') }}</span>
         </div>
       </div>
       <div class="ap-m-benefit principles">
@@ -123,8 +123,8 @@ $view: /views/overview/custom-content.j2
           <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#priority"></use></svg>
         </div>
         <div class="ap-m-benefit-text">
-          <span class="ap-m-benefit-text-headline">Prioritise things that improve the user experience – but compromise when needed.</span>
-          <span class="ap-m-benefit-text-copy">Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed.</span>
+          <span class="ap-m-benefit-text-headline">{{ _('Prioritise things that improve the user experience – but compromise when needed.') }}</span>
+          <span class="ap-m-benefit-text-copy">{{ _('Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed.') }}</span>
         </div>
       </div>
 
@@ -134,8 +134,8 @@ $view: /views/overview/custom-content.j2
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#list"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline">No whitelists.</span>
-            <span class="ap-m-benefit-text-copy">We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons.</span>
+            <span class="ap-m-benefit-text-headline">{{ _('No whitelists.') }}</span>
+            <span class="ap-m-benefit-text-copy">{{ _('We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons.') }}</span>
           </div>
         </div>
 
@@ -148,7 +148,7 @@ $view: /views/overview/custom-content.j2
 
 <section class="ap--container">
   <div class="ap-m-copy ap-m-copy-center-large">
-    <h2>Get Started with Tutorials</h2>
+    <h2>{{ _('Get Started with Tutorials') }}</h2>
     <div class="ap-o-teaser-grid">
       <div class="ap-o-teaser-grid-list">
         {% with %}

--- a/pages/content/amp-dev/about/stories.html
+++ b/pages/content/amp-dev/about/stories.html
@@ -87,12 +87,12 @@ templates:
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bolt-solid"></use></svg>
           </div>
 
-          <h2 class="ap-o-stage-content-subline">AMP Stories</h2>
-          <h1 class="ap-o-stage-content-headline">Use AMP to create visual stories on the web.</h1>
+          <h2 class="ap-o-stage-content-subline">{{ _('AMP Stories') }}</h2>
+          <h1 class="ap-o-stage-content-headline">{{ _('Use AMP to create visual stories on the web.') }}</h1>
 
           {% do doc.styles.addCssFile('/css/components/atoms/button.css') %}
-          <a href="../documentation/guides-and-tutorials/start/visual_story/index.md?format=stories" class="ap-o-stage-content-button ap-a-btn">Start developing</a>
-          <a href="#tools" class="ap-o-stage-content-button ap-a-btn">Tell a story</a>
+          <a href="../documentation/guides-and-tutorials/start/visual_story/index.md?format=stories" class="ap-o-stage-content-button ap-a-btn">{{ _('Start developing') }}</a>
+          <a href="#tools" class="ap-o-stage-content-button ap-a-btn">{{ _('Tell a story') }}</a>
         </div>
     </div>
   </div>
@@ -103,10 +103,10 @@ templates:
 <section class="ap--content">
   <div class="ap--container-fluid">
     <div class="ap-m-copy ap-m-copy-left-small" amp-fx="fade-in fly-in-left" data-margin-start="5%" data-duration="1s" data-fly-in-distance="5%">
-      <h1>AMP<br> Stories</h1>
-      <h5>visual storytelling for the open web</h5>
-      <p>AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform.</p>
-      <p>AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences.</p>
+      <h1>{{ _('AMP<br> Stories') }}</h1>
+      <h5>{{ _('visual storytelling for the open web') }}</h5>
+      <p>{{ _('AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform.') }}</p>
+      <p>{{ _('AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences.') }}</p>
     </div>
 
     <div class="ap--component-visual-container">
@@ -116,7 +116,7 @@ templates:
             {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Build your first story</span>
+          <span class="ap-m-lnk-text">{{ _('Build your first story') }}</span>
         </a>
       </div>
        <div class="ap-o-component-visual-link">
@@ -125,7 +125,7 @@ templates:
             {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Learn about story ads</span>
+          <span class="ap-m-lnk-text">{{ _('Learn about story ads') }}</span>
         </a>
       </div>
     </div>
@@ -147,16 +147,16 @@ templates:
     </div>
     <div class="ap-m-quote-quote">
       <blockquote>
-        <p class="ap-a-txt">As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage.<p>
+        <p class="ap-a-txt">{{ _('As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage.') }}<p>
       </blockquote>
-      <p>Greg Manifold, Design Director of The Washington Post</p>
+      <p>{{ _('Greg Manifold, Design Director of The Washington Post') }}</p>
 
       <a href="success-stories/washingtonpost.yaml" class="ap-m-lnk">
         <div class="ap-a-ico ap-m-lnk-icon">
           {% do doc.icons.useIcon('icons/internal.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Read Success Story</span>
+        <span class="ap-m-lnk-text">{{ _('Read Success Story') }}</span>
       </a>
     </div>
   </div>
@@ -172,7 +172,7 @@ templates:
           {% do doc.icons.useIcon('icons/exclamation.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#exclamation"></use></svg>
         </div>
-        <h1 class="ap-m-headline-icon-hl">The benefits of AMP stories</h1>
+        <h1 class="ap-m-headline-icon-hl">{{ _('The benefits of AMP stories') }}</h1>
       </div>
     </div>
 
@@ -186,8 +186,8 @@ templates:
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ benefit.icon }}"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline">{{ benefit.headline }}</span>
-            <span class="ap-m-benefit-text-copy"> {{ benefit.text }} </span>
+            <span class="ap-m-benefit-text-headline">{{ _(benefit.headline) }}</span>
+            <span class="ap-m-benefit-text-copy"> {{ _(benefit.text) }} </span>
           </div>
         </div>
 
@@ -205,8 +205,8 @@ templates:
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ benefit.icon }}"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline">{{ benefit.headline }}</span>
-            <span class="ap-m-benefit-text-copy"> {{ benefit.text }} </span>
+            <span class="ap-m-benefit-text-headline">{{ _(benefit.headline) }}</span>
+            <span class="ap-m-benefit-text-copy"> {{ _(benefit.text) }} </span>
           </div>
         </div>
 
@@ -220,7 +220,7 @@ templates:
           {% do doc.icons.useIcon('icons/internal.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Read on how AMP works</span>
+        <span class="ap-m-lnk-text">{{ _('Read on how AMP works') }}</span>
       </a>
     </div>
 
@@ -231,18 +231,18 @@ templates:
     <div class="ap--container-fluid">
 
       <div class="ap-m-copy ap-m-copy-left-small" amp-fx="fade-in fly-in-left" data-margin-start="5%" data-duration="1s" data-fly-in-distance="5%">
-        <h2>Images, videos and GIFs</h2>
-        <p>AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities.</p>
+        <h2>{{ _('Images, videos and GIFs') }}</h2>
+        <p>{{ _('AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities.') }}</p>
       </div>
 
       <div class="ap-m-copy ap-m-copy-right-small" amp-fx="fade-in fly-in-left" data-margin-start="5%" data-duration="1s" data-fly-in-distance="5%">
-        <h2>Text and audio</h2>
-        <p>Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music.</p>
+        <h2>{{ _('Text and audio') }}</h2>
+        <p>{{ _('Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music.') }}</p>
       </div>
 
       <div class="ap-m-copy ap-m-copy-left-small" amp-fx="fade-in fly-in-left" data-margin-start="5%" data-duration="1s" data-fly-in-distance="5%">
-        <h2>Animations and interactions</h2>
-        <p>It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site.</p>
+        <h2>{{ _('Animations and interactions') }}</h2>
+        <p>{{ _('It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site.') }}</p>
       </div>
 
     </div>
@@ -252,7 +252,7 @@ templates:
 <section class="ap--story-carousel ap--container-fluid">
 
   <div class="ap-m-copy ap-m-copy-center">
-    <h2 id="check-out-amp-stories-on-the-web">Check out AMP stories on the web</h2>
+    <h2 id="check-out-amp-stories-on-the-web">{{ _('Check out AMP stories on the web') }}</h2>
   </div>
 
   <div class="ap-o-story-carousel">
@@ -322,10 +322,9 @@ templates:
 
 <section class="ap--content ap--stories-monetize ap--container-fluid" id="monetization">
   <div class="ap-m-copy ap-m-copy-left-small">
-    <h1>AMP Stories <br />Monetization Options</h1>
-    <h4>Single Page Story Ad</h4>
-    <p>Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.
-    Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!</p>
+    <h1>{{ _('AMP Stories <br />Monetization Options') }}</h1>
+    <h4>{{ _('Single Page Story Ad') }}</h4>
+    <p>{{ _('Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!') }}</p>
   </div>
 </section>
 
@@ -406,27 +405,27 @@ templates:
   </div>
 
   <div class="ap-m-copy ap-m-copy-right-centered">
-    <h4>Get Started with our Story Ads Templates</h4>
+    <h4>{{ _('Get Started with our Story Ads Templates') }}</h4>
     <div class="ap-o-component-visual-link">
       <a href="../documentation/templates/index.html" class="ap-m-lnk ap-m-lnk-square">
         <div class="ap-a-ico ap-m-lnk-icon">
           {% do doc.icons.useIcon('icons/internal.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Discover All Templates</span>
+        <span class="ap-m-lnk-text">{{ _('Discover All Templates') }}</span>
       </a>
     </div>
   </div>
 
   <div class="ap-m-copy ap-m-copy-left-small">
-    <h4>Affliate Links</h4>
-    <p>Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages.</p>
+    <h4>{{ _('Affliate Links') }}</h4>
+    <p>{{ _('Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages.') }}</p>
     <a href="../documentation/guides-and-tutorials/develop/story_ads_best_practices.md" class="ap-m-lnk">
       <div class="ap-a-ico ap-m-lnk-icon">
         {% do doc.icons.useIcon('icons/internal.svg') %}
         <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
       </div>
-      <span class="ap-m-lnk-text">Read Best Practices Guide</span>
+      <span class="ap-m-lnk-text">{{ _('Read Best Practices Guide') }}</span>
     </a>
   </div>
 </section>

--- a/pages/content/amp-dev/about/success-stories/index.html
+++ b/pages/content/amp-dev/about/success-stories/index.html
@@ -92,7 +92,7 @@ stage:
   {% set categories = g.categories('/content/amp-dev/about/success-stories', locale=doc.locale) %}
   <section class="ap--intro ap--container">
     <div class="ap--content">
-      <p>Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of.</p>
+      <p>{{ _('Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of.') }}</p>
     </div>
 
     {% do doc.styles.addCssFile('css/components/organisms/filter-bubbles-list.css') %}
@@ -104,7 +104,7 @@ stage:
         class="ap-m-filter-bubble"
         [% endif %]
         name="all">
-        All
+        {{ _('All') }}
       </button>
       {% for category, stories in categories %}
       <button
@@ -115,7 +115,7 @@ stage:
           [% endif %]
           on="tap:AMP.navigateTo(url='{{ g.doc('/content/amp-dev/about/success-stories/index.html', locale=doc.locale).url.path }}?category={{ category|slug }}')"
           name="{{ category|slug }}">
-          {{ category }}
+          {{ _(category) }}
       </button>
       {% endfor %}
     </div>

--- a/pages/content/amp-dev/about/websites.html
+++ b/pages/content/amp-dev/about/websites.html
@@ -37,11 +37,11 @@ kpis:
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bolt-solid"></use></svg>
           </div>
 
-          <h2 class="ap-o-stage-content-subline">Compelling, smooth and instant</h2>
-          <h1 class="ap-o-stage-content-headline">Easily create user first websites with AMP.</h1>
+          <h2 class="ap-o-stage-content-subline">{{ _('Compelling, smooth and instant') }}</h2>
+          <h1 class="ap-o-stage-content-headline">{{ _('Easily create user first websites with AMP.') }}</h1>
 
           {% do doc.styles.addCssFile('/css/components/atoms/button.css') %}
-          <a href="../documentation/guides-and-tutorials/start/create/index.md?format=websites" class="ap-o-stage-content-button ap-a-btn">Get started</a>
+          <a href="../documentation/guides-and-tutorials/start/create/index.md?format=websites" class="ap-o-stage-content-button ap-a-btn">{{ _('Get started') }}</a>
       </div>
     </div>
   </div>
@@ -52,8 +52,8 @@ kpis:
 <section class="ap--content">
   <div class="ap--container-fluid">
     <div class="ap-m-copy ap-m-copy-left-small">
-      <h1>What is<br> AMP?</h1>
-      <h5>Web pages that are compelling, smooth, and load near instantaneously</h5>
+      <h1>{{ _('What is<br> AMP?') }}</h1>
+      <h5>{{ _('Web pages that are compelling, smooth, and load near instantaneously') }}</h5>
     </div>
   </div>
 </section>
@@ -61,14 +61,14 @@ kpis:
 <section class="ap--component-visual">
   <div class="ap-o-component-visual ap--container-fluid">
     <div class="ap-o-component-visual-copy ap-m-copy ap-m-copy-left-small" amp-fx="fade-in fly-in-left" data-duration="1s" data-fly-in-distance="5%" data-margin-start="0%">
-      <p>AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs.</p>
+      <p>{{ _('AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs.') }}</p>
       <div class="ap-o-component-visual-link">
         <a href="../documentation/guides-and-tutorials/index.html" class="ap-m-lnk ap-m-lnk-square">
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Get Started</span>
+          <span class="ap-m-lnk-text">{{ _('Get Started') }}</span>
         </a>
       </div>
     </div>
@@ -98,8 +98,8 @@ kpis:
 <section class="ap--case-band">
   <div class="ap--container-fluid">
     <div class="ap-m-copy ap-m-copy-left-small" amp-fx="fade-in fly-in-left" data-duration="1s" data-fly-in-distance="5%">
-      <h3>Create great web experiences for users across the open web</h3>
-      <p>AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience.</p>
+      <h3>{{ _('Create great web experiences for users across the open web') }}</h3>
+      <p>{{ _('AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience.') }}</p>
     </div>
 
     {% with %}
@@ -131,8 +131,8 @@ kpis:
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ benefit.icon }}"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline"> {{ benefit.headline }}</span>
-            <span class="ap-m-benefit-text-copy">{{ benefit.text }}</span>
+            <span class="ap-m-benefit-text-headline"> {{ _(benefit.headline) }}</span>
+            <span class="ap-m-benefit-text-copy">{{ _(benefit.text) }}</span>
           </div>
         </div>
 
@@ -149,8 +149,8 @@ kpis:
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ benefit.icon }}"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline"> {{ benefit.headline }}</span>
-            <span class="ap-m-benefit-text-copy">{{ benefit.text }}</span>
+            <span class="ap-m-benefit-text-headline"> {{ _(benefit.headline) }}</span>
+            <span class="ap-m-benefit-text-copy">{{ _(benefit.text) }}</span>
           </div>
         </div>
 
@@ -164,7 +164,7 @@ kpis:
           {% do doc.icons.useIcon('icons/internal.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Get started with AMP</span>
+        <span class="ap-m-lnk-text">{{ _('Get started with AMP') }}</span>
       </a>
     </div>
 
@@ -185,23 +185,23 @@ kpis:
     </div>
     <div class="ap-m-quote-quote">
       <blockquote>
-        <p class="ap-a-txt">We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there.<p>
+        <p class="ap-a-txt">{{ _('We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there.') }}<p>
       </blockquote>
-      <p>David Merrell, Senior Product Manager</p>
+      <p>{{ _('David Merrell, Senior Product Manager') }}</p>
 
       <a href="success-stories/washingtonpost.yaml" class="ap-m-lnk">
         <div class="ap-a-ico ap-m-lnk-icon">
           {% do doc.icons.useIcon('icons/internal.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Read Success Story</span>
+        <span class="ap-m-lnk-text">{{ _('Read Success Story') }}</span>
       </a>
     </div>
   </div>
 </section>
 
 <div class="ap--container">
-  <h1 class="ap--made-of-headline">What AMP HTML is made of</h1>
+  <h1 class="ap--made-of-headline">{{ _('What AMP HTML is made of') }}</h1>
 </div>
 
 {% do doc.styles.addCssFile('/css/components/molecules/biggy.css') %}
@@ -220,34 +220,33 @@ kpis:
 <section class="ap--content">
   <div class="ap--container">
     <div class="ap-m-copy ap-m-copy-left">
-      <h2>Built-in components</h2>
-      <p>AMP HTML is HTML with some restrictions for reliable performance.</p>
+      <h2>{{ _('Built-in components') }}</h2>
+      <p>{{ _('AMP HTML is HTML with some restrictions for reliable performance.') }}</p>
 
-      <p>Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way.</p>
+      <p>{{ _('Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way.') }}</p>
 
-      <p>For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page.</p>
+      <p>{{ _('For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page.') }}</p>
 
-      <p>AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. </p>
+      <p>{{ _('AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. ') }}</p>
       <div class="ap-m-copy-left-link">
         <a href="../documentation/guides-and-tutorials/optimize-measure/discovery.md?format=websites" class="ap-m-lnk ap-m-lnk-square">
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Learn more in  Make Your Page Discoverable.</span>
+          <span class="ap-m-lnk-text">{{ _('Learn more in Make Your Page Discoverable.') }}</span>
         </a>
       </div>
     </div>
 
     <div class="ap-m-copy ap-m-copy-right">
-      <h2>AMP Caches</h2>
+      <h2>{{ _('AMP Caches') }}</h2>
 
-      <p>AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service.</p>
+      <p>{{ _('AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service.') }}</p>
 
-      <p>The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency.
-        The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification.</p>
+      <p>{{ _('The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn\'t depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification.') }}</p>
 
-      <p>Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience.</p>
+      <p>{{ _('Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience.') }}</p>
 
       <div class="ap-m-copy-right-link">
         <a href="../documentation/guides-and-tutorials/learn/amp-caches-and-cors/how_amp_pages_are_cached.md" class="ap-m-lnk ap-m-lnk-square">
@@ -255,7 +254,7 @@ kpis:
             {% do doc.icons.useIcon('icons/internal.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Learn more about caching in AMP</span>
+          <span class="ap-m-lnk-text">{{ _('Learn more about caching in AMP') }}</span>
         </a>
       </div>
     </div>
@@ -265,7 +264,7 @@ kpis:
 
 <section class="ap--case-grid">
   <div class="ap--container">
-    <h1 class="ap-o-case-grid-headline">Explore use cases of AMP websites</h1>
+    <h1 class="ap-o-case-grid-headline">{{ _('Explore use cases of AMP websites') }}</h1>
   </div>
 
   <div class="ap--container-fluid">

--- a/pages/content/amp-dev/community/roadmap.html
+++ b/pages/content/amp-dev/community/roadmap.html
@@ -22,11 +22,11 @@ roadmap: !g.json /content/amp-dev/community/roadmap.json
       {% do doc.styles.addCssFile('css/components/organisms/filter-bubbles-list.css') %}
 
       <section class="ap--content">
-        <h1>The AMP Project Roadmap</h1>
+        <h1>{{ _('The AMP Project Roadmap') }}</h1>
         <div class="ap-m-tip ap-m-tip-note">
           <div class="ap-m-tip-content">
             {% do doc.styles.addCssFile('css/components/molecules/tip.css') %}
-            <p>This is a high level overview suitable for all audiences. For a more detailed developer view, <a href="https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a></p>
+            <p>{{ _('This is a high level overview suitable for all audiences. For a more detailed developer view, <a href="https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>') }}</p>
           </div>
         </div>
 
@@ -38,7 +38,7 @@ roadmap: !g.json /content/amp-dev/community/roadmap.json
 
           <button class="ap-m-filter-bubble {{ label | slug}} active" on="tap:AMP.setState({roadmapfilter: {activefilter: '{{ label | slug}}' } })"
           [class]="roadmapfilter.activefilter == 'all' || roadmapfilter.activefilter == '{{label|slug}}' ? 'ap-m-filter-bubble {{ label | slug}} active' : 'ap-m-filter-bubble {{ label | slug}}'">
-            {{ label }}
+            {{ _(label) }}
             <span tabindex="-1" role="reset" class="ap-m-filter-bubble-reset" [class]="roadmapfilter.activefilter == '{{ label | slug}}' ? 'ap-m-filter-bubble-reset show': 'ap-m-filter-bubble-reset'" on="tap:AMP.setState({roadmapfilter: {activefilter: 'all' }})">
                 <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close"></use></svg>
             </span>
@@ -59,7 +59,7 @@ roadmap: !g.json /content/amp-dev/community/roadmap.json
           <div class="ap-a-ico">
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{% if loop.index == 1 %}notepad{% elif loop.index == 2 %}wrench{% elif loop.index == 3 %}dolly{% endif %}"></use></svg>
           </div>
-          <h4>{{ column.name }}</h4>
+          <h4>{{ _(column.name) }}</h4>
           <ul>
             {% for card in column.cards %}
             <li class="ap-o-roadmap-tiles-item ap-m-copy active {% if card.issue.labels[0] %}{% for label in card.issue.labels %}{{ label.name | slug}} {% endfor %}{% endif %}"
@@ -68,11 +68,11 @@ roadmap: !g.json /content/amp-dev/community/roadmap.json
               <a class="ap-o-roadmap-tiles-link" href="{{ card.issue.url }}">
                 <div class="ap-o-roadmap-tiles-title">{{ card.issue.title }}</div>
               </a>
-              <div class="ap-o-roadmap-tiles-description">{{ card.issue.description|markdown|safe }}</div>
+              <div class="ap-o-roadmap-tiles-description">{{ _(card.issue.description|markdown|safe) }}</div>
               <div class="ap-o-roadmap-tiles-categories">
                 {% if card.issue.labels[0] %}
                   {% for label in card.issue.labels %}
-                  <button class="ap-m-filter-bubble {{ label.name | slug }} active" on="tap:AMP.setState({roadmapfilter: {activefilter: '{{ label.name | slug}}' }})">{{ label.name }}</button>
+                  <button class="ap-m-filter-bubble {{ label.name | slug }} active" on="tap:AMP.setState({roadmapfilter: {activefilter: '{{ label.name | slug}}' }})">{{ _(label.name) }}</button>
                   {% endfor %}
                 {% endif %}
               </div>

--- a/pages/content/amp-dev/documentation/courses/index.html
+++ b/pages/content/amp-dev/documentation/courses/index.html
@@ -19,17 +19,17 @@ flyout:
 {% do doc.styles.addCssFile('css/components/molecules/copy.css') %}
 
 <section class="ap--section ap--intro">
-  <h1>Learn Web Development with AMP</h1>
+  <h1>{{ _('Learn Web Development with AMP') }}</h1>
   <p>
-    AMP can help you create fast websites more quickly!
+  {{ _('AMP can help you create fast websites more quickly!') }}
     <ul>
-      <li>If you're <b>an experienced web developer</b>, you can create rich, fast sites with less code. </li>
-      <li>If you're <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!</li>
+      <li>{{ _('If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code.') }}</li>
+      <li>{{ _('If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!') }}</li>
     </ul>
   </p>
   <div class="ap-m-copy ap-m-copy-center">
     <a href="https://amp.dev/documentation/courses/beginning-course/course-introduction/?format=websites&amp;level=beginner" class="ap-a-btn">
-      Get started
+      {{ _('Get started') }}
     </a>
   </div>
 </section>
@@ -60,14 +60,9 @@ flyout:
     ></amp-img>
   </div>
   <div class="ap--section">
-    <h2>About the courses</h2>
-    <p> These three free courses are in use in schools and training programs around the world.
-        Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike,
-        they will take you from zero to AMP!
-    </p>
-    <p>
-        During this course, you'll build a sample site for Chico's famous, and fictional, Cheese Bicycles.
-    </p>
+    <h2>{{ _('About the courses') }}</h2>
+    <p>{{ _('These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!') }}</p>
+    <p>{{ _('During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles.') }}</p>
   </div>
 </section>
 
@@ -104,17 +99,17 @@ flyout:
   <div class="ap--section">
     <h4>Requirements</h4>
     <ul>
-      <li>Internet connection</li>
-      <li><a href="https://www.google.com/chrome/" target="_blank">Chrome browser</a>, ideally, to use the <a href="https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc" target="_blank">AMP Validator extension</a></li>
-      <li>We use the online editor <a href="https://glitch.com/" target="_blank">Glitch</a>. No IDE or local web server needed!</li>
+      <li>{{ _('Internet connection') }}</li>
+      <li>{{ _('<a href="https://www.google.com/chrome/" target="_blank">Chrome browser</a>, ideally, to use the <a href="https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc" target="_blank">AMP Validator extension</a>') }}</li>
+      <li>{{ _('We use the online editor <a href="https://glitch.com/" target="_blank">Glitch</a>. No IDE or local web server needed!') }}</li>
     </ul>
   </div>
 
   <div class="ap--section">
-    <h4>Prerequisites</h4>
+    <h4>{{ _('Prerequisites') }}</h4>
     <ul>
-      <li>basic knowledge of HTML and CSS</li>
-      <li>for the advanced course, JavaScript expressions and simple JSON</li>
+      <li>{{ _('basic knowledge of HTML and CSS') }}</li>
+      <li>{{ _('for the advanced course, JavaScript expressions and simple JSON') }}</li>
     </ul>
   </div>
 </section>
@@ -122,8 +117,8 @@ flyout:
 
 {% do doc.styles.addCssFile('/css/components/organisms/video-slider.css') %}
 <section class="ap--video-slider">
-  <h2 class="ap-o-video-slider-text">Take the Video Courses</h2>
-  <p class="ap-o-video-slider-text">All three courses can be now be taken by video on <a href="https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_" target="_blank">our YouTube channel!</a></p>
+  <h2 class="ap-o-video-slider-text">{{ _('Take the Video Courses') }}</h2>
+  <p class="ap-o-video-slider-text">{{ _('All three courses can be now be taken by video on <a href="https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_" target="_blank">our YouTube channel!</a>') }}</p>
   {% with %}
   {% set youtube_video_ids = [
     'qWpZbADJlgE',

--- a/pages/content/amp-dev/documentation/examples/index.html
+++ b/pages/content/amp-dev/documentation/examples/index.html
@@ -173,7 +173,7 @@ recent_examples:
       {% include '/views/partials/sidebar-toggle-button.j2' %}
       {% include '/views/partials/breadcrumbs.j2' %}
 
-      <h1>{{ doc.title }}</h1>
+      <h1>{{ _(doc.title) }}</h1>
 
       {% do doc.styles.addCssFile('/css/components/organisms/card-grid.css') %}
       <section class="ap--card-grid">
@@ -193,10 +193,8 @@ recent_examples:
       {% do doc.styles.addCssFile('/css/components/molecules/teaser-info.css') %}
       <section class="ap-m-teaser-info">
         <div class="ap-m-teaser-info-text">
-          <h2>AMP Playground</h2>
-          <p>
-            Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback.
-          </p>
+          <h2>{{ _('AMP Playground') }}</h2>
+          <p>{{ _('Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback.') }}</p>
           <a class="ap-m-lnk ap-m-lnk-square"
              [% if format == 'websites' %]
              href="https://playground.amp.dev/"
@@ -212,7 +210,7 @@ recent_examples:
               {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
             </div>
-            <span class="ap-m-lnk-text">Open in AMP Playground</span>
+            <span class="ap-m-lnk-text">{{ _('Open in AMP Playground') }}</span>
           </a>
         </div>
         <div class="ap-m-teaser-info-image">
@@ -234,7 +232,7 @@ recent_examples:
         {% do doc.styles.addCssFile('css/components/organisms/teaser-grid.css') %}
         {% do doc.styles.addCssFile('/css/components/molecules/table-component.css') %}
 
-        <h2>Filter by category</h2>
+        <h2>{{ _('Filter by category') }}</h2>
         {% include '/views/partials/category-filter.j2'%}
 
         {% for category, documents in categories %}
@@ -278,14 +276,14 @@ recent_examples:
                 </div>
                 {% endif %}
                 <div class="ap-m-table-component-name ap-m-table-component-name-example">
-                  <span class="ap-m-table-component-name-title">{{ document.titles('teaser') }}</span>
+                  <span class="ap-m-table-component-name-title">{{ _(document.titles('teaser')) }}</span>
                 </div>
                 {% if category_name != 'components' %}
                 <div class="ap-m-table-component-info">
                   <div class="ap-m-table-component-used-components">
                     {% if document.used_components %}
                     {% for component in document.used_components %}
-                    <code>{{ component }}</code>
+                    <code>{{ _(component) }}</code>
                     {% endfor %}
                     {% else %}
                     <p> </p>

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/index.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/index.html
@@ -164,7 +164,7 @@ guides:
         {% do doc.icons.useIcon('icons/internal.svg') %}
         <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
       </div>
-      <span class="ap-m-lnk-text">Style & layout</span>
+      <span class="ap-m-lnk-text">{{ _('Style & layout') }}</span>
     </a>
   </div>
   {% do doc.styles.addCssFile('/css/components/molecules/tip.css') %}
@@ -240,7 +240,7 @@ guides:
         {% do doc.icons.useIcon('icons/internal.svg') %}
         <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
       </div>
-      <span class="ap-m-lnk-text">Style & layout</span>
+      <span class="ap-m-lnk-text">{{ _('Style & layout') }}</span>
     </a>
   </div>
   [% endif %]
@@ -307,7 +307,7 @@ guides:
         {% do doc.icons.useIcon('icons/internal.svg') %}
         <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
       </div>
-      <span class="ap-m-lnk-text">Style & layout</span>
+      <span class="ap-m-lnk-text">{{ _('Style & layout') }}</span>
     </a>
   </div>
   [% endif %]

--- a/pages/content/amp-dev/documentation/index.html
+++ b/pages/content/amp-dev/documentation/index.html
@@ -80,8 +80,8 @@ resources_cards:
           <div class="ap--overview-title">
             <div class="ap-m-overview-title">
               {% include '/views/partials/breadcrumbs.j2' %}
-              <h1>{{ doc.title }}</h1>
-              <p>Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:</p>
+              <h1>{{ _(doc.title) }}</h1>
+              <p>{{ _('Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:') }}</p>
             </div>
           </div>
         </section>
@@ -98,8 +98,8 @@ resources_cards:
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#amp-{{ card.type }}"></use>
                     </svg>
                   </div>
-                  <h4 class="ap-o-format-cards-card-headline">{{ card.title }}</h4>
-                  <p class="ap-o-format-cards-card-copy">{{ card.description }}</p>
+                  <h4 class="ap-o-format-cards-card-headline">{{ _(card.title) }}</h4>
+                  <p class="ap-o-format-cards-card-copy">{{ _(card.description) }}</p>
                 </div>
                 <div class="ap-o-format-cards-card-link ap-m-lnk">
                   <div class="ap-a-ico ap-m-lnk-icon">
@@ -108,7 +108,7 @@ resources_cards:
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use>
                     </svg>
                   </div>
-                  <span class="ap-m-lnk-text">{{ card.link.text }}</span>
+                  <span class="ap-m-lnk-text">{{ _(card.link.text) }}</span>
                 </div>
               </a>
               {% endfor %}
@@ -141,8 +141,8 @@ resources_cards:
               <div class="ap-format-content">
                 <div class="ap-info-box">
                   <div class="ap-info-box-text">
-                    <h4>Choose your destination</h4>
-                    <p>Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on.</p>
+                    <h4>{{ _('Choose your destination') }}</h4>
+                    <p>{{ _('Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on.') }}</p>
                   </div>
                   <div class="ap-format-toggle">
                     {% for format in doc.resources_formats %}
@@ -154,7 +154,7 @@ resources_cards:
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#amp-{{ format }}"></use>
                         </svg>
                       </span>
-                      <span>{{ format }}</span>
+                      <span>{{ _(format) }}</span>
                     </button>
                     {% endfor %}
                   </div>
@@ -171,18 +171,15 @@ resources_cards:
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ card.icon }}"></use>
                         </svg>
                       </div>
-                      <h4 class="ap-o-resources-grid-card-headline">{{ card.title }}</h4>
-                      <p class="ap-o-resources-grid-card-copy">{{ card.description }}</p>
+                      <h4 class="ap-o-resources-grid-card-headline">{{ _(card.title) }}</h4>
+                      <p class="ap-o-resources-grid-card-copy">{{ _(card.description) }}</p>
                     </a>
                     {% endfor %}
 
                     <div class="ap-o-resources-grid-card-tip">
                       <div class="ap-m-tip-content">
-                        <h4>CMS User?</h4>
-                        <p>AMP integrates with many publishing platforms and content management systems! Find the full list under <a
-                          href="../support/faq/platform-and-vendor-partners.md">Platform
-                          and Vendor Partners.</a>
-                        </p>
+                        <h4>{{ _('CMS User?') }}</h4>
+                        <p>{{ _('AMP integrates with many publishing platforms and content management systems! Find the full list under <a href="../support/faq/platform-and-vendor-partners.md">Platform and Vendor Partners.</a>') }}</p>
                       </div>
                     </div>
                   </div>
@@ -195,8 +192,8 @@ resources_cards:
         {% do doc.styles.addCssFile('/css/components/organisms/video-slider.css') %}
         <section class="ap--section">
           <div class="ap--video-slider">
-            <h2 class="ap-o-video-slider-text">Featured Videos</h2>
-            <p class="ap-o-video-slider-text">See the latest videos about AMP and find out more on our <a href="https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a></p>
+            <h2 class="ap-o-video-slider-text">{{ _('Featured Videos') }}</h2>
+            <p class="ap-o-video-slider-text">{{ _('See the latest videos about AMP and find out more on our <a href="https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>') }}</p>
             {% with %}
             {% set youtube_video_ids = [
             '4f9KU5VJpOU',
@@ -213,9 +210,8 @@ resources_cards:
         <section class="ap--section-fullscreen">
           <div class="ap--banner">
             <div class="ap-o-banner">
-              <h2 class="ap-o-banner-headline">Get Involved</h2>
-              <p class="ap-o-banner-copy">AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission.
-              </p>
+              <h2 class="ap-o-banner-headline">{{ _('Get Involved') }}</h2>
+              <p class="ap-o-banner-copy">{{ _('AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission.') }}</p>
             </div>
           </div>
         </section>

--- a/pages/content/amp-dev/documentation/templates/index.html
+++ b/pages/content/amp-dev/documentation/templates/index.html
@@ -117,13 +117,13 @@ stage:
       <button class="ap-m-filter-bubble filtered"
         [class]="activeFilter.chosenFilter == 'none' ? 'ap-m-filter-bubble filtered' : 'ap-m-filter-bubble'"
         on="tap:AMP.setState({ activeFilter: {chosenFilter: 'none' } })">
-        All
+        {{ _('All') }}
       </button>
       {% for category, stories in categories %}
       <button class="ap-m-filter-bubble"
         [class]="activeFilter.chosenFilter == '{{ category|slug }}' && chosenFilter != 'none' ? 'ap-m-filter-bubble filtered' : 'ap-m-filter-bubble'"
         on="tap:AMP.setState({ activeFilter: {chosenFilter: '{{ category|slug }}' } })">
-        {{ category }}
+        {{ _(category) }}
       </button>
       {% endfor %}
     </div>

--- a/pages/content/amp-dev/documentation/tools.html
+++ b/pages/content/amp-dev/documentation/tools.html
@@ -45,10 +45,7 @@ tools: !g.yaml /shared/data/tools.yaml
 
   <div class="ap-o-stage">
     <div class="ap--container-fluid">
-      <div class="ap-o-stage-content">
-          <h1 class="ap-o-stage-content-headline">Tools</h1>
-          <h2 class="ap-o-stage-content-subline">for creation, design and development</h2>
-      </div>
+      <div class="ap-o-stage-content">{{ _('<h1 class="ap-o-stage-content-headline">Tools</h1> <h2 class="ap-o-stage-content-subline">for creation, design and development</h2>') }}</div>
     </div>
   </div>
 
@@ -59,7 +56,7 @@ tools: !g.yaml /shared/data/tools.yaml
 {% do doc.styles.addCssFile('css/components/organisms/filter-bubbles-list.css') %}
 
 <section class="ap-o-tool-section ap-o-tool-format-filter-container ap--container">
-  <p class="ap-o-tool-format-filter-caption">Find the right tools to build</p>
+  <p class="ap-o-tool-format-filter-caption">{{ _('Find the right tools to build') }}</p>
   {% do doc.icons.useIcon('icons/close.svg') %}
   <ul class="ap-o-tool-format-filter none" [class]="activeFilter.chosenFilter != 'none' ? 'ap-o-tool-format-filter filtered' : 'ap-o-tool-format-filter none' ">
     {% for link in doc.filters %}
@@ -69,7 +66,7 @@ tools: !g.yaml /shared/data/tools.yaml
           <div class="ap-m-filter-bubble-icon ap-a-ico {{link|lower}}">
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#amp-{{link|lower}}"></use></svg>
           </div>
-          <span class="ap-m-filter-bubble-link">{{ link }}</span>
+          <span class="ap-m-filter-bubble-link">{{ _(link) }}</span>
           <div tabindex="-1" role="reset"
             class="ap-m-filter-bubble-reset ap-a-ico [% if requestedFormat == '{{link}}'|lower %]show[% endif %]"
             on="tap:AMP.navigateTo(url='{{ g.doc('/content/amp-dev/documentation/tools.html', locale=doc.locale).url.path }}')">
@@ -91,13 +88,13 @@ tools: !g.yaml /shared/data/tools.yaml
 
       <h2 id="{{ category }}">
         {% if category == 'creation' %}
-        Creation &amp; Design
+        {{ _('Creation &amp; Design') }}
         {% elif category == 'platforms'  %}
-        CMS &amp; Platforms
+        {{ _('CMS &amp; Platforms') }}
         {% elif category == 'developer' %}
-        Developer Tools
+        {{ _('Developer Tools') }}
         {% elif category == 'providers' %}
-        Service providers
+        {{ _('Service providers') }}
         {% endif %}
       </h2>
     </div>

--- a/pages/content/amp-dev/events/amp-roadshow.html
+++ b/pages/content/amp-dev/events/amp-roadshow.html
@@ -23,10 +23,10 @@ section_links:
     <div class="ap-o-stage ap-o-stage-websites all">
       <div class="ap--container-fluid">
         <div class="ap-o-stage-content ap-o-stage-content-roadshow">
-          <h1 class="ap-o-stage-content-headline">AMP Roadshow</h1>
-          <h2 class="ap-o-stage-content-subline">Come join us in your city for a free, inclusive dev workshop with the AMP team.</h2>
+          <h1 class="ap-o-stage-content-headline">{{ _('AMP Roadshow') }}</h1>
+          <h2 class="ap-o-stage-content-subline">{{ _('Come join us in your city for a free, inclusive dev workshop with the AMP team.') }}</h2>
           {% do doc.styles.addCssFile('/css/components/atoms/button.css') %}
-          <a href="#Cities" class="ap-o-stage-content-button ap-a-btn">Sign Up</a>
+          <a href="#Cities" class="ap-o-stage-content-button ap-a-btn">{{ _('Sign Up') }}</a>
         </div>
       </div>
     </div>
@@ -50,7 +50,7 @@ section_links:
   {% do doc.styles.addCssFile('css/components/molecules/visited-city.css') %}
 
   <div class="ap-o-cities ap--content-wide">
-    <h3 class="ap-o-cities-headline">Cities</h3>
+    <h3 class="ap-o-cities-headline">{{ _('Cities') }}</h3>
 
     {% if doc.pod.env.dev %}
     {% do doc.styles.addCssFile('css/components/molecules/tip.css') %}
@@ -106,7 +106,7 @@ section_links:
               {% do doc.icons.useIcon('/icons/cities-map-pin.svg') %}
               <div class="ap-a-ico ap-o-cities-map-icon"><svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#cities-map-pin"></use></svg></div>
             </div>
-            <div class="ap-o-cities-map-tooltip">{{ place.title }}</div>
+            <div class="ap-o-cities-map-tooltip">{{ _(place.title) }}</div>
           </div>
           {% endif %}
         {% endfor %}
@@ -117,7 +117,7 @@ section_links:
           {% set row = place.coords.split('x')[1]|int + 1 %}
           <div class="ap-o-cities-map-grid-cell" style="grid-column: {{col}}; grid-row: {{row}};">
             <div class="ap-o-cities-map-pin ap-o-cities-map-pin-past"></div>
-            <div class="ap-o-cities-map-tooltip">{{ place.title }}</div>
+            <div class="ap-o-cities-map-tooltip">{{ _(place.title) }}</div>
           </div>
           {% endif %}
         {% endfor %}
@@ -131,7 +131,7 @@ section_links:
     </div>
 
     {% if doc.roadshow.nextstop %}
-    <span class="ap-o-cities-sub-headline">Where we're going next</span>
+    <span class="ap-o-cities-sub-headline">{{ _('Where we’re going next') }}</span>
     {% endif %}
 
     <div class="ap-o-cities-next-events">
@@ -165,7 +165,7 @@ section_links:
                 {% do doc.icons.useIcon('/icons/map.svg') %}
                 <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#map"></use></svg>
               </div>
-              {{ nextstop.location }}
+              {{ _(nextstop.location) }}
             </div>
           </div>
         </div>
@@ -174,27 +174,21 @@ section_links:
       {% endif %}
 
       <div class="ap-o-cities-next-events-checkback">
-        <p>Your city isn't on the list? Check back soon for additional dates and cities. Or...</p>
-        <h4>Want the AMP Roadshow to visit your area?</h4>
-        <p>That's very kind. Fill out
-            <a href="https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform" target="_blank">this form</a>
-            and we’ll see what we can do!
-        </p>
-        <h4>Want to host your own AMP Roadshow?</h4>
-        <p>Why not? Fill out
-          <a href="https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform" target="_blank">this form</a>,
-          and we’ll share with you our talks and all the materials you need to do it yourself!
-        </p>
+        <p>{{ _('Your city isn’t on the list? Check back soon for additional dates and cities. Or...') }}</p>
+        <h4>{{ _('Want the AMP Roadshow to visit your area?') }}</h4>
+        <p>{{ _('That’s very kind. Fill out <a href="https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform" target="_blank">this form</a> and we’ll see what we can do!') }}</p>
+        <h4>{{ _('Want to host your own AMP Roadshow?') }}</h4>
+        <p>{{ _('Why not? Fill out <a href="https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform" target="_blank">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!') }}</p>
       </div>
     </div>
 
-    <h4 class="ap-o-cities-sub-headline">Where we've been</h4>
+    <h4 class="ap-o-cities-sub-headline">{{ _('Where we’ve been') }}</h4>
     <ul class="ap-o-cities-visited-list">
 
       {% for visited in doc.roadshow.past|sort(True, attribute='date') %}
         <li class="ap-m-visited-city">
           <div class="ap-m-visited-city-group">
-            <div class="ap-m-visited-city-title">{{ visited.title }}</div>
+            <div class="ap-m-visited-city-title">{{ _(visited.title) }}</div>
             <div class="ap-m-visited-city-date">{{ visited.date|datetime('MMM d, Y') }}</div>
           </div>
         </li>
@@ -212,9 +206,8 @@ section_links:
   <div class="ap-o-agenda">
     <div class="ap-o-agenda-block">
       <div class="ap-o-agenda-content">
-        <h3 class="ap-o-agenda-content-headline">Agenda</h3>
-        <p class="ap-o-agenda-content-sub-text">The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages.
-        <span>This is a sample agenda – schedule varies based on the city.</span>
+        <h3 class="ap-o-agenda-content-headline">{{ _('Agenda') }}</h3>
+        <p class="ap-o-agenda-content-sub-text">{{ _('The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>') }}
         <p>
 
         <ul class="ap-o-agenda-content-list">
@@ -231,13 +224,13 @@ section_links:
                   {% endif %}
                   <div class="ap-m-agenda-item-time">{{ agenda_item.time }}</div>
                   <div class="ap-m-agenda-item-description  {% if agenda_item.type %}{{ agenda_item.type }}{% endif %}">
-                  <div class="ap-m-agenda-item-description-title  {% if agenda_item.type %}{{ agenda_item.type }}{% endif %}">{{ agenda_item.title }}</div>
+                  <div class="ap-m-agenda-item-description-title  {% if agenda_item.type %}{{ agenda_item.type }}{% endif %}">{{ _(agenda_item.title) }}</div>
                   {% if speaker %}
                     <div class="ap-m-agenda-item-description-speaker">{{ speaker.name }}</div>
                   {% endif %}
 
                   {% if agenda_item.description %}
-                    <div class="ap-m-agenda-item-description-text">{{ agenda_item.description }}</div>
+                    <div class="ap-m-agenda-item-description-text">{{ _(agenda_item.description) }}</div>
                   {% endif %}
                   </div>
                 </li>
@@ -254,18 +247,18 @@ section_links:
   {% do doc.styles.addCssFile('css/components/molecules/roadshow-pillar.css') %}
 
   <div class="ap-o-roadshow-content">
-    <div class="ap-o-roadshow-content-headline">Content</div>
-    <div class="ap-o-roadshow-content-description">We'll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:</div>
+    <div class="ap-o-roadshow-content-headline">{{ _('Content') }}</div>
+    <div class="ap-o-roadshow-content-description">{{ _('We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:') }}</div>
     <div class="ap-o-roadshow-content-pillar-list">
 
       {% for pillar in doc.roadshow.pillars %}
         <div class="ap-m-roadshow-pillar">
           <div class="ap-m-roadshow-pillar-headline">
-            {{ pillar.pillar }}
+            {{ _(pillar.pillar) }}
           </div>
           {% for content in pillar.contents %}
           <div class="ap-m-roadshow-pillar-points">
-            {{ content }}
+            {{ _(content) }}
           </div>
           {% endfor %}
         </div>
@@ -280,8 +273,8 @@ section_links:
 
   <div class="ap-m-amplify">
     <div class="ap-m-amplify-content">
-      <h3 class="ap-m-amplify-content-headline">Amplify Live!</h3>
-      <div class="ap-m-amplify-content-subline">During "Amplify live!", we'll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!</div>
+      <h3 class="ap-m-amplify-content-headline">{{ _('Amplify Live!') }}</h3>
+      <div class="ap-m-amplify-content-subline">{{ _('During "Amplify live!", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!') }}</div>
     </div>
   </div>
 
@@ -290,14 +283,14 @@ section_links:
 <section id="FAQ" class="ap--container">
   {% do doc.styles.addCssFile('css/components/molecules/faq.css') %}
   <div class="ap-m-faq">
-    <h3 class="ap-m-faq-headline">Frequently Asked Questions</h3>
+    <h3 class="ap-m-faq-headline">{{ _('Frequently Asked Questions') }}</h3>
     <div class="ap-m-faq-content">
-      <div class="ap-m-faq-content-question">Does it cost anything?</div>
-      <div class="ap-m-faq-content-answer">No - tickets are free of charge.</div>
-       <div class="ap-m-faq-content-question">Who is the event for?</div>
-      <div class="ap-m-faq-content-answer">Web developers and designers with an interest in AMP--whether you've had experience using AMP and want to create better experiences, you're curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone.</div>
-       <div class="ap-m-faq-content-question">Am I all set after registering?</div>
-      <div class="ap-m-faq-content-answer">We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis.</div>
+      <div class="ap-m-faq-content-question">{{ _('Does it cost anything?') }}</div>
+      <div class="ap-m-faq-content-answer">{{ _('No - tickets are free of charge.') }}</div>
+      <div class="ap-m-faq-content-question">{{ _('Who is the event for?') }}</div>
+      <div class="ap-m-faq-content-answer">{{ _('Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone.') }}</div>
+      <div class="ap-m-faq-content-question">{{ _('Am I all set after registering?') }}</div>
+      <div class="ap-m-faq-content-answer">{{ _('We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis.') }}</div>
     </div>
   </div>
 </section>

--- a/pages/content/amp-dev/index.html
+++ b/pages/content/amp-dev/index.html
@@ -62,8 +62,8 @@ success_stories:
     <div class="ap-o-stage">
       <div class="ap--container-fluid">
         <div class="ap-o-stage-content">
-            <h1 class="ap-o-stage-content-headline">AMP is a web component framework to easily create <span style="white-space: nowrap;">user-first</span><br> {% include 'views/partials/rolling-formats.j2' %}</h1>
-            <a href="documentation/index.html" class="ap-o-stage-content-button ap-a-btn">Get started</a>
+          <h1 class="ap-o-stage-content-headline">{{ _('AMP is a web component framework to easily create <span style="white-space: nowrap;">user-first</span><br>') }} {% include 'views/partials/rolling-formats.j2' %}</h1>
+          <a href="documentation/index.html" class="ap-o-stage-content-button ap-a-btn">{{ _('Get started') }}</a>
         </div>
       </div>
     </div>
@@ -88,15 +88,15 @@ success_stories:
     {% do doc.styles.addCssFile('css/components/molecules/copy.css') %}
 
     <div class="ap-m-copy">
-      <h2>The latest news</h2>
-      <p>Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!</p>
+      <h2>{{ _('The latest news') }}</h2>
+      <p>{{ _('Don\'t want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!') }}</p>
 
       <a class="ap-m-lnk ap-m-lnk-square ap--newsletter-double" href="https://services.google.com/fb/forms/ampnewsletter-doubleopt-in/">
         <div class="ap-a-ico ap-m-lnk-icon">
           {% do doc.icons.useIcon('icons/external.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#external"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Subscribe</span>
+        <span class="ap-m-lnk-text">{{ _('Subscribe') }}</span>
       </a>
 
       <a class="ap-m-lnk ap-m-lnk-square ap--newsletter" href="https://services.google.com/fb/forms/ampnewsletter/">
@@ -104,7 +104,7 @@ success_stories:
           {% do doc.icons.useIcon('icons/external.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#external"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">Subscribe</span>
+        <span class="ap-m-lnk-text">{{ _('Subscribe') }}</span>
       </a>
     </div>
 
@@ -133,8 +133,8 @@ success_stories:
               </div>
               {% endif %}
             </div>
-            <h5 class="ap-o-news-headline">{{ news.headline|safe }}</h5>
-            <div class="ap-o-news-date">{{ news.date }}</div>
+            <h5 class="ap-o-news-headline">{{ _(news.headline|safe) }}</h5>
+            <div class="ap-o-news-date">{{ _(news.date) }}</div>
           </div>
         </a>
         {% endfor %}
@@ -211,8 +211,8 @@ success_stories:
         {% for format in doc.format_explainer %}
         <div class="ap-o-format-explainer-content-{{ format.name }} ap-m-copy {{ 'active' if loop.index == 1 }}"
           [class]="chosenFormat.activeFormat == '{{ format.name }}' ? 'ap-o-format-explainer-content-{{ format.name }} ap-m-copy active' : 'ap-o-format-explainer-content-{{ format.name }} ap-m-copy'">
-          <h2 class="ap-o-format-explainer-headline">{{ format.headline }}</h2>
-          <p class="ap-o-format-explainer-copy">{{ format.description }}</p>
+          <h2 class="ap-o-format-explainer-headline">{{ _(format.headline) }}</h2>
+          <p class="ap-o-format-explainer-copy">{{ _(format.description) }}</p>
         </div>
         {% endfor %}
       </div>
@@ -227,7 +227,7 @@ success_stories:
             {% do doc.icons.useIcon('icons/amp-' + format.name + '.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#amp-{{ format.name }}"></use></svg>
           </div>
-          <span class="ap-o-format-explainer-button-text">AMP {{ format.name }}</span>
+          <span class="ap-o-format-explainer-button-text">AMP {{ _(format.name) }}</span>
         </button>
         {% endfor %}
       </div>
@@ -241,7 +241,7 @@ success_stories:
               {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
             </div>
-            <span class="ap-m-lnk-text">Learn more about AMP {{ format.name }}</span>
+            <span class="ap-m-lnk-text">{{ _('Learn more about AMP {{ format.name }}') }}</span>
           </a>
         </div>
         {% endfor %}
@@ -280,13 +280,13 @@ success_stories:
           {% do doc.icons.useIcon('icons/logo.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#logo"></use></svg>
         </div>
-        <h2>AMP in action</h2>
+        <h2>{{ _('AMP in action') }}</h2>
       </div>
     </div>
 
     <div class="ap--container-fluid">
       <div class="ap-m-copy">
-        <p>AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:</p>
+        <p>{{ _('AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can\'t believe it? Try it out for yourself in the playground below:') }}</p>
       </div>
 
       <div class="ap-o-sampler">
@@ -334,7 +334,7 @@ success_stories:
               {% do doc.icons.useIcon('icons/internal.svg') %}
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
             </div>
-            <span class="ap-m-lnk-text">Open in AMP Playground</span>
+            <span class="ap-m-lnk-text">{{ _('Open in AMP Playground') }}</span>
           </a>
         </div>
       </div>
@@ -347,7 +347,7 @@ success_stories:
 
       <div class="ap-o-benefits-overview-list ap-o-benefits-overview-list-developers">
 
-        <h2>Business Benefits</h2>
+        <h2>{{ _('Business Benefits') }}</h2>
 
         {% for benefit in doc.benefits.home.business %}
 
@@ -357,8 +357,8 @@ success_stories:
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ benefit.icon }}"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline">{{ benefit.headline }}</span>
-            <span class="ap-m-benefit-text-copy">{{ benefit.text }}</span>
+            <span class="ap-m-benefit-text-headline">{{ _(benefit.headline) }}</span>
+            <span class="ap-m-benefit-text-copy">{{ _(benefit.text) }}</span>
           </div>
         </div>
 
@@ -367,7 +367,7 @@ success_stories:
 
       <div class="ap-o-benefits-overview-list ap-o-benefits-overview-list-business">
 
-        <h2>Developer Benefits</h2>
+        <h2>{{ _('Developer Benefits') }}</h2>
 
         {% for benefit in doc.benefits.home.developer %}
 
@@ -377,8 +377,8 @@ success_stories:
             <svg class="ap-m-benefit-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ benefit.icon }}"></use></svg>
           </div>
           <div class="ap-m-benefit-text">
-            <span class="ap-m-benefit-text-headline">{{ benefit.headline }}</span>
-            <span class="ap-m-benefit-text-copy">{{ benefit.text }}</span>
+            <span class="ap-m-benefit-text-headline">{{ _(benefit.headline) }}</span>
+            <span class="ap-m-benefit-text-copy">{{ _(benefit.text) }}</span>
           </div>
         </div>
 
@@ -391,7 +391,7 @@ success_stories:
             {% do doc.icons.useIcon('icons/internal.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Get started with AMP</span>
+          <span class="ap-m-lnk-text">{{ _('Get started with AMP') }}</span>
         </a>
       </div>
 
@@ -411,16 +411,16 @@ success_stories:
       </div>
       <div class="ap-m-quote-quote">
         <blockquote>
-          <p class="ap-a-txt">As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage.</p>
+          <p class="ap-a-txt">{{ _('As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage.') }}</p>
         </blockquote>
-        <p>Greg Manifold, Design Director of The Washington Post</p>
+        <p>{{ _('Greg Manifold, Design Director of The Washington Post') }}</p>
 
         <a href="about/success-stories/washingtonpost.yaml" class="ap-m-lnk">
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>
-          <span class="ap-m-lnk-text">Read Success Story</span>
+          <span class="ap-m-lnk-text">{{ _('Read Success Story') }}</span>
         </a>
       </div>
     </div>
@@ -428,7 +428,8 @@ success_stories:
 
   <section class="ap--case-grid">
     <div class="ap--container">
-      <h1 class="ap-o-case-grid-headline">Build anything with AMP.</h1>
+      <h1 class="ap-o-case-grid-headline">{{ _('Build anything with AMP.') }}</h1>
+
     </div>
 
     <div class="ap--container-fluid">
@@ -459,15 +460,15 @@ success_stories:
     </div>
 
     <div class="ap-m-copy">
-      <h2>Explore AMP<br/> success stories</h2>
-      <p>Don't take our word for it - read case studies from your industry and see how AMP has produced positive results.</p>
+      <h2>{{ _('Explore AMP<br/> success stories') }}</h2>
+      <p>{{ _('Don\'t take our word for it - read case studies from your industry and see how AMP has produced positive results.') }}</p>
 
       <a href="about/success-stories/index.html" class="ap-m-lnk ap-m-lnk-square">
         <div class="ap-a-ico ap-m-lnk-icon">
           {% do doc.icons.useIcon('icons/internal.svg') %}
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
         </div>
-        <span class="ap-m-lnk-text">See all success stories</span>
+        <span class="ap-m-lnk-text">{{ _('See all success stories') }}</span>
       </a>
     </div>
   </section>
@@ -475,7 +476,7 @@ success_stories:
   {% do doc.styles.addCssFile('css/components/molecules/shift-card.css') %}
   <section class="ap--shift-cards">
     <div class="ap--container">
-      <h2 class="ap--shift-cards-headline">By the community,<br/>for the community</h2>
+      <h2 class="ap--shift-cards-headline">{{ _('By the community,<br/>for the community') }}</h2>
     </div>
 
     <div class="ap--shift-cards-grid ap--container">
@@ -491,8 +492,8 @@ success_stories:
               height="9">
             </amp-img>
           </div>
-          <h3 class="ap-m-shift-card-headline">Many ways for you to contribute</h3>
-          <p class="ap-m-shift-card-copy">The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP.</p>
+          <h3 class="ap-m-shift-card-headline">{{ _('Many ways for you to contribute') }}</h3>
+          <p class="ap-m-shift-card-copy">{{ _('The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP.') }}</p>
         </a>
       </div>
 
@@ -507,8 +508,8 @@ success_stories:
               height="9">
             </amp-img>
           </div>
-          <h3 class="ap-m-shift-card-headline">Reporting issues with AMP</h3>
-          <p class="ap-m-shift-card-copy">If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker.</p>
+          <h3 class="ap-m-shift-card-headline">{{ _('Reporting issues with AMP') }}</h3>
+          <p class="ap-m-shift-card-copy">{{ _('If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker.') }}</p>
         </a>
       </div>
 
@@ -518,9 +519,9 @@ success_stories:
   <section class="ap--get-started ap--container">
     {% do doc.styles.addCssFile('css/components/atoms/button.css') %}
     <div class="ap-m-copy ap-m-copy-center">
-      <h2>Build your first AMP page now</h2>
-      <p>You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!</p>
-      <a href="documentation/guides-and-tutorials/index.html" class="ap-a-btn">Get started</a>
+      <h2>{{ _('Build your first AMP page now') }}</h2>
+      <p>{{ _('You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!') }}</p>
+      <a href="documentation/guides-and-tutorials/index.html" class="ap-a-btn">{{ _('Get started') }}</a>
     </div>
   </section>
 </main>

--- a/pages/content/amp-dev/offline.html
+++ b/pages/content/amp-dev/offline.html
@@ -16,7 +16,7 @@ $sitemap:
         {% do doc.icons.useIcon('/icons/bolt-broken-solid.svg') %}
         <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bolt-broken-solid"></use></svg>
       </div>
-      <h1 class="ap-m-biggy-headline">offline</h1>
+      <h1 class="ap-m-biggy-headline">{{ _('offline') }}</h1>
       <h2 class="ap-m-jumbo-subline">{{ _('Something cut the line.') }}</h2>
       <p class="ap-m-jumbo-copy">{{ _('You\'re currently not connected to the internet.') }}</p>
     </div>

--- a/pages/shared/data/amp-conf.yaml
+++ b/pages/shared/data/amp-conf.yaml
@@ -329,7 +329,7 @@ agenda:
       speakers:
         - leviclancy
         - ballakhadang
-    - title: "What's next in AMP"
+    - title: "What’s next in AMP"
       description: "In this presentation, we wrap up the day with a summary of all of the key focus areas for AMP and talk about what the extended roadmap looks like."
       time: "1715"
       type: session

--- a/pages/shared/data/blog.yaml
+++ b/pages/shared/data/blog.yaml
@@ -1,6 +1,12 @@
 entries:
 
 - title: "Blog"
+  image: "https://blog.amp.dev/wp-content/uploads/2020/01/AMP_Blog_Square_smaller.jpg"
+  headline: "Helping to fund our open-source dependencies"
+  date: "January 29, 2020"
+  url: "https://blog.amp.dev/2020/01/29/helping-to-fund-our-open-source-dependencies/"
+
+- title: "Blog"
   image: "https://blog.amp.dev/wp-content/uploads/2019/11/AMP_Blog_Square.jpg"
   headline: "Cookie classification on AMP"
   date: "January 27, 2020"
@@ -23,9 +29,3 @@ entries:
   headline: "Our 2019 Contributions to Web Platform Interoperability"
   date: "December 16, 2019"
   url: "https://blog.amp.dev/2019/12/16/our-2019-contributions-to-web-platform-interoperability/"
-
-- title: "Blog"
-  image: "https://blog.amp.dev/wp-content/uploads/2019/11/AMP_Blog_Square.jpg"
-  headline: "From Static to Interactive: Adobe Campaign Brings Email to Life with AMP for Email"
-  date: "December 9, 2019"
-  url: "https://blog.amp.dev/2019/12/09/from-static-to-interactive-adobe-campaign-brings-email-to-life-with-amp-for-email/"

--- a/pages/shared/data/recent-guides.yaml
+++ b/pages/shared/data/recent-guides.yaml
@@ -1,22 +1,22 @@
-- path: /content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule-accessible.html
-  date: '2020-01-29 01:53:40 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule.html
+  date: '2020-01-29 01:53:40 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule-accessible.html
   date: '2020-01-29 01:53:40 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/spec/release-schedule.md
   date: '2020-01-27 09:36:52 +0100'
-- path: /content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/ad-integration-guide.md
-  date: '2019-11-08 10:50:46 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/index.md
+  date: '2019-11-08 10:50:46 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/ad-integration-guide.md
   date: '2019-11-08 10:50:46 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/testing_amp_emails.md
   date: '2019-09-13 11:02:43 +0100'
-- path: /content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/documentation-types.md
-  date: '2019-08-09 15:54:37 -0700'
-- path: /content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting.md
-  date: '2019-08-09 15:54:37 -0700'
 - path: /content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/index.md
   date: '2019-08-09 15:54:37 -0700'
 - path: /content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/terminology.md
+  date: '2019-08-09 15:54:37 -0700'
+- path: /content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting.md
+  date: '2019-08-09 15:54:37 -0700'
+- path: /content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/documentation-types.md
   date: '2019-08-09 15:54:37 -0700'
 - path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/secure-pages.md
   date: '2019-08-07 11:33:54 -0700'
@@ -24,13 +24,13 @@
   date: '2019-07-15 07:52:06 -0700'
 - path: /content/amp-dev/documentation/guides-and-tutorials/contribute/email-viewer.md
   date: '2019-07-10 10:52:18 -0400'
-- path: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-components.md
-  date: '2019-06-27 08:15:24 +0200'
-- path: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-css.md
-  date: '2019-06-27 08:15:24 +0200'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-html.md
   date: '2019-06-27 08:15:24 +0200'
+- path: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-components.md
+  date: '2019-06-27 08:15:24 +0200'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure.md
+  date: '2019-06-27 08:15:24 +0200'
+- path: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-css.md
   date: '2019-06-27 08:15:24 +0200'
 - path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/server-side-rendering.md
   date: '2019-06-05 18:32:02 +0200'
@@ -64,19 +64,19 @@
   date: '2019-03-25 11:17:23 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp_to_pwa.md
   date: '2019-02-21 14:31:13 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/learn/common_attributes.md
-  date: '2019-02-07 19:57:26 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/experimental.md
+  date: '2019-02-07 19:57:26 +0100'
+- path: /content/amp-dev/documentation/guides-and-tutorials/learn/common_attributes.md
   date: '2019-02-07 19:57:26 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/layouts_demonstrated.html
   date: '2019-02-05 15:42:29 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/integrate/amp-in-pwa.md
   date: '2019-02-04 18:46:52 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-as-pwa.md
+  date: '2019-02-04 18:46:52 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/integrate/amp-to-pwa.md
   date: '2019-02-04 18:46:52 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/combine-amp-pwa.md
-  date: '2019-02-04 18:46:52 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-as-pwa.md
   date: '2019-02-04 18:46:52 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/index.md
   date: '2019-02-03 12:25:13 -0800'
@@ -88,24 +88,28 @@
   date: '2019-02-02 16:23:14 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/interactive_widget/index.md
   date: '2019-01-30 17:55:15 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/learn/limitations_of_amp_ads.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/create_shell.md
   date: '2019-01-29 18:01:38 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/limitations_of_amp_email.md
   date: '2019-01-29 18:01:38 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/validate.md
+  date: '2019-01-29 18:01:38 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/learn/limitations_of_amp_ads.md
+  date: '2019-01-29 18:01:38 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/limitations_of_amp_story.md
-  date: '2019-01-29 18:01:38 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/create_shell.md
-  date: '2019-01-29 18:01:38 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/image_ad.md
-  date: '2019-01-29 18:01:38 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/index.md
-  date: '2019-01-29 18:01:38 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/summary.md
   date: '2019-01-29 18:01:38 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/track_views.md
   date: '2019-01-29 18:01:38 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/validate.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/summary.md
   date: '2019-01-29 18:01:38 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/index.md
+  date: '2019-01-29 18:01:38 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/image_ad.md
+  date: '2019-01-29 18:01:38 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/iframes.md
+  date: '2019-01-29 17:38:27 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/third_party_components.md
+  date: '2019-01-29 17:38:27 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/contribute/integrate-amphtml-email.md
   date: '2019-01-29 17:38:27 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/contribute/integrate-your-analytics-tools.md
@@ -120,10 +124,6 @@
   date: '2019-01-29 17:38:27 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/interactivity_data/state_binding.md
   date: '2019-01-29 17:38:27 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/iframes.md
-  date: '2019-01-29 17:38:27 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/third_party_components.md
-  date: '2019-01-29 17:38:27 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/how_amp_is_different.md
   date: '2019-01-28 20:36:41 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/seatmap.md
@@ -134,6 +134,12 @@
   date: '2018-12-20 15:37:11 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/amp_story_best_practices.md
   date: '2018-12-20 14:59:36 +0100'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/create_cover_page.md
+  date: '2018-12-07 16:50:58 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/start_story.md
+  date: '2018-12-07 16:50:58 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/validation.md
+  date: '2018-12-07 16:50:58 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/add_more_pages.md
   date: '2018-12-07 16:50:58 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/animating_elements.md
@@ -142,23 +148,15 @@
   date: '2018-12-07 16:50:58 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/create_bookend.md
   date: '2018-12-07 16:50:58 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/create_cover_page.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/setting_up.md
   date: '2018-12-07 16:50:58 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/index.md
   date: '2018-12-07 16:50:58 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/parts_of_story.md
   date: '2018-12-07 16:50:58 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/setting_up.md
-  date: '2018-12-07 16:50:58 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/start_story.md
-  date: '2018-12-07 16:50:58 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/visual_story/validation.md
-  date: '2018-12-07 16:50:58 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/engagement.md
   date: '2018-12-01 15:24:25 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/optimize_amp.md
-  date: '2018-12-01 15:24:25 +0100'
-- path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics_basics.md
   date: '2018-12-01 15:24:25 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/deep_dive_analytics.md
   date: '2018-12-01 15:24:25 +0100'
@@ -166,93 +164,103 @@
   date: '2018-12-01 15:24:25 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/use_cases.md
   date: '2018-12-01 15:24:25 +0100'
+- path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics_basics.md
+  date: '2018-12-01 15:24:25 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/discovery.md
   date: '2018-12-01 11:59:57 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/contribute/index.md
   date: '2018-12-01 10:52:54 +0100'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/index.md
+  date: '2018-12-01 06:19:16 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state.md
   date: '2018-12-01 06:19:16 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/ads_vendors.md
-  date: '2018-12-01 06:19:16 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/monetization/index.md
   date: '2018-12-01 06:19:16 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/integrate/integrate-with-apps.md
   date: '2018-12-01 05:42:08 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/advertise_amp_stories.md
   date: '2018-12-01 03:07:18 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/live_blog.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/summary.md
+  date: '2018-12-01 03:04:02 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout.md
   date: '2018-12-01 03:04:02 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/story_ads_best_practices.md
   date: '2018-12-01 03:04:02 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/art_direction.md
+  date: '2018-12-01 03:04:02 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/add_comment.md
+  date: '2018-12-01 03:04:02 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/interactivity/advanced-interactivity.md
+  date: '2018-12-01 03:04:02 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/custom_fonts.md
   date: '2018-12-01 03:04:02 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/interactivity/get-familiar.md
   date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/interactivity/index.md
-  date: '2018-12-01 03:04:02 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/interactivity/prereqs-setup.md
   date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/interactivity/remote-data.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/index.md
   date: '2018-12-01 03:04:02 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/interactivity/wrapping-up.md
   date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/add_comment.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/logout.md
+  date: '2018-12-01 03:04:02 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/live_blog.md
+  date: '2018-12-01 03:04:02 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages.md
+  date: '2018-12-01 03:04:02 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/responsive_design.md
+  date: '2018-12-01 03:04:02 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/placeholders.md
   date: '2018-12-01 03:04:02 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/index.md
   date: '2018-12-01 03:04:02 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/login.md
   date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/logout.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/interactivity/remote-data.md
   date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/summary.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/develop/interactivity/index.md
   date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/art_direction.md
-  date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout.md
-  date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/custom_fonts.md
-  date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/index.md
-  date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/placeholders.md
-  date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/responsive_design.md
-  date: '2018-12-01 03:04:02 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages.md
-  date: '2018-12-01 03:04:02 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors.md
+  date: '2018-12-01 02:17:35 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/index.md
+  date: '2018-12-01 02:17:35 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cache-debugging.md
   date: '2018-12-01 02:17:35 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests.md
   date: '2018-12-01 02:17:35 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/index.md
-  date: '2018-12-01 02:17:35 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors.md
-  date: '2018-12-01 02:17:35 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md
-  date: '2018-12-01 01:12:23 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate.md
   date: '2018-12-01 01:12:23 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/adding_carousels.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md
+  date: '2018-12-01 01:12:23 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/tracking_data.md
   date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/adding_components.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/publish.md
   date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/congratulations.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/congratulations.md
   date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts.md
   date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/index.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/setting_up.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/congratulations.md
   date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/navigating.md
   date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/adding_components.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/basic_markup.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/adding_carousels.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/index.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/setting-up.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/presentation_layout.md
+  date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/review_code.md
   date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/setting_up.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/tracking_data.md
-  date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/building-page.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/congratulations.md
   date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/discoverable.md
   date: '2018-11-30 08:03:59 -0800'
@@ -260,19 +268,11 @@
   date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/resolving-errors.md
   date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/setting-up.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/basic_markup.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/include_image.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/index.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/prepare_for_discovery.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/presentation_layout.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/index.md
   date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/create/preview_and_validate.md
   date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/publish.md
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/prepare_for_discovery.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/create/include_image.md
   date: '2018-11-30 08:03:59 -0800'

--- a/pages/shared/data/roadshow.yaml
+++ b/pages/shared/data/roadshow.yaml
@@ -170,7 +170,7 @@ agenda:
   - title: AMP everywhere
     time: "14:10"
     type: session
-  - title: What's next in AMP
+  - title: What’s next in AMP
     time: "14:40"
     type: session
   - title: Coffee break

--- a/pages/translations/ar/LC_MESSAGES/messages.po
+++ b/pages/translations/ar/LC_MESSAGES/messages.po
@@ -86,10 +86,6 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr ""
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr ""
@@ -112,16 +108,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +203,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
@@ -268,12 +248,6 @@ msgstr ""
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +270,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +373,6 @@ msgid "Overview"
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -558,14 +523,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +545,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +625,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr ""
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,8 +1045,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "لم تتم ترجمة هذه الصفحة حتى الآن، لكننا نرحّب ببعض المساعدة لتنفيذ ذلك. يمكنك الاطّلاع على <a href="/documentation/guides-and-tutorials/contribute/translations">دليل الترجمة</a> لمعرفة كيفية المساهمة في ذلك."
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "لم تتم ترجمة هذه الصفحة حتى الآن، لكننا نرحّب ببعض المساعدة لتنفيذ ذلك. يمكنك الاطّلاع على <a href=\"/documentation/guides-and-tutorials/contribute/translations\"> دليل الترجمة </a> لمعرفة كيفية المساهمة في ذلك."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1092,2020 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "Find the right tools to build"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""

--- a/pages/translations/en/LC_MESSAGES/messages.po
+++ b/pages/translations/en/LC_MESSAGES/messages.po
@@ -86,8 +86,20 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
+#: /content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
 msgstr ""
 
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
@@ -112,16 +124,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +219,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
@@ -268,12 +264,6 @@ msgstr ""
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +286,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +389,6 @@ msgid "Overview"
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -488,8 +469,40 @@ msgstr ""
 msgid "Select a language"
 msgstr ""
 
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
 #: /content/amp-dev/index.html:257
 msgid "Show everything"
+msgstr ""
+
+#: /views/partials/search.j2:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: /content/amp-dev/index.html:431
+msgid "Build anything with AMP."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
@@ -518,10 +531,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/start/_blueprint.yaml
 msgid "Start"
-msgstr ""
-
-#: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/_blueprint.yaml
-msgid "Style & Layout"
 msgstr ""
 
 #: /views/partials/footer.j2:76
@@ -558,14 +567,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +589,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +669,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr ""
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,7 +1089,7 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
 msgstr ""
 
 #: frontend/templates/views/examples/documentation.j2:206
@@ -1147,7 +1132,1885 @@ msgstr ""
 msgid "Important  this component does not support your currently selected format"
 msgstr ""
 
-#: pages/content/amp-dev/documentation/templates/index.html:112
+#: /content/amp-dev/documentation/templates/index.html:112
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: /content/amp-dev/index.html:20
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: /content/amp-dev/index.html:25
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: /content/amp-dev/index.html:30
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: /content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: /content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: /content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: /content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: /content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: /content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: /content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: /content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: /content/amp-dev/index.html:462
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: /content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: /content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: /content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: /content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: /content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: /content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: /content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: /content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: /content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "Start sending AMP Emails"
+msgstr ""
+
+msgid "Start creating ads"
+msgstr ""
+
+msgid "Start creating stories"
+msgstr ""
+
+msgid "Start creating websites"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Discover all tools"
+msgstr ""
+
+msgid "Send emails"
+msgstr ""
+
+msgid "AMP<br> Email"
+msgstr ""
+
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+msgid "Modern app functionality for email"
+msgstr ""
+
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+msgid "Supported Email Clients"
+msgstr ""
+
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+msgid "Read on about AMP email"
+msgstr ""
+
+msgid "The benefits of AMP email"
+msgstr ""
+
+msgid "AMP for advertisers"
+msgstr ""
+
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Vision & Mission"
+msgstr ""
+
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+msgid "Design Principles"
+msgstr ""
+
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+msgid "Don’t break the web."
+msgstr ""
+
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+msgid "Solve problems on the right layer."
+msgstr ""
+
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+msgid "No whitelists."
+msgstr ""
+
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+msgid "Discover more..."
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "Get Started with Tutorials"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+msgid "Magazine article"
+msgstr ""
+
+msgid "Breaking the status quo"
+msgstr ""
+
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+msgid "Experience Demo"
+msgstr ""
+
+msgid "Band page"
+msgstr ""
+
+msgid "Olga and the kings"
+msgstr ""
+
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+msgid "E-Commerce"
+msgstr ""
+
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+msgid "See on GitHub"
+msgstr ""
+
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "AMP Roadshow"
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+msgid "Current Issues"
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Members"
+msgstr ""
+
+msgid "Communication Channels"
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+msgid "Contribute to AMP"
+msgstr ""
+
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+msgid "Governance Body"
+msgstr ""
+
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "View all"
+msgstr ""
+
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+msgid "Where we’ve been"
+msgstr ""
+
+msgid "Where we’re going next"
+msgstr ""
+
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+msgid "Agenda"
+msgstr ""
+
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Content"
+msgstr ""
+
+msgid "Amplify Live!"
+msgstr ""
+
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+msgid "Frequently Asked Questions"
+msgstr ""
+
+msgid "Does it cost anything?"
+msgstr ""
+
+msgid "No - tickets are free of charge."
+msgstr ""
+
+msgid "Who is the event for?"
+msgstr ""
+
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+msgid "Am I all set after registering?"
+msgstr ""
+
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "Cities"
+msgstr ""
+
+msgid "Sign Up"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/pages/translations/es/LC_MESSAGES/messages.po
+++ b/pages/translations/es/LC_MESSAGES/messages.po
@@ -86,10 +86,6 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr ""
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr ""
@@ -112,16 +108,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +203,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "Eventos"
@@ -268,12 +248,6 @@ msgstr "Empezar"
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +270,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +373,6 @@ msgid "Overview"
 msgstr "Descripción general"
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -558,14 +523,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +545,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +625,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr ""
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,8 +1045,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "Desafortunadamente, esta página todavía no está traducida, pero puedes ayudarnos a conseguir que lo esté. Consulta la <a href="/documentation/guides-and-tutorials/contribute/translations">guía de traducción</a> sobre cómo puedes colaborar."
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "Desafortunadamente, esta página todavía no está traducida, pero puedes ayudarnos a conseguir que lo esté. Consulta la <a href=\"/documentation/guides-and-tutorials/contribute/translations\"> guía de traducción </a> sobre cómo puedes colaborar."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1092,2019 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/pages/translations/fr/LC_MESSAGES/messages.po
+++ b/pages/translations/fr/LC_MESSAGES/messages.po
@@ -1,4 +1,3 @@
-#: /views/partials/case-band.j2:6 /views/partials/case-band.j2:7
 msgid "A screenshot of a website using AMP."
 msgstr ""
 
@@ -86,10 +85,6 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr ""
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr ""
@@ -112,16 +107,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +202,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
@@ -268,12 +247,6 @@ msgstr ""
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +269,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +372,6 @@ msgid "Overview"
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -558,14 +522,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +544,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +624,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr ""
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,8 +1044,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "Cette page n'est malheureusement pas traduite pour le moment. Si vous souhaitez nous aider à la traduire, consultez le <a href="/documentation/guides-and-tutorials/contribute/translations">guide de traduction</a> pour savoir comment apporter votre contribution."
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "Cette page n'est malheureusement pas traduite pour le moment. Si vous souhaitez nous aider à la traduire, consultez le <a href=\"/documentation/guides-and-tutorials/contribute/translations\"> guide de traduction </a> pour savoir comment apporter votre contribution."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1091,2022 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/pages/translations/id/LC_MESSAGES/messages.po
+++ b/pages/translations/id/LC_MESSAGES/messages.po
@@ -86,10 +86,6 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr ""
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr ""
@@ -112,16 +108,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +203,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "Acara"
@@ -268,12 +248,6 @@ msgstr "Mulai"
 msgid "Get started"
 msgstr "Mulai"
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +270,6 @@ msgstr "Panduan & Tutorial"
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +373,6 @@ msgid "Overview"
 msgstr "Ringkasan"
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -558,14 +523,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +545,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +625,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr ""
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,8 +1045,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "Sayangnya, halaman ini belum diterjemahkan, tetapi kita dapat menggunakan bantuan untuk melakukannya. Lihat <a href="/documentation/guides-and-tutorials/contribute/translations">panduan terjemahan</a> untuk mengetahui caranya jika Anda ingin berkontribusi."
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "Sayangnya, halaman ini belum diterjemahkan, tetapi kita dapat menggunakan bantuan untuk melakukannya. Lihat <a href=\"/documentation/guides-and-tutorials/contribute/translations\"> panduan terjemahan </a> untuk mengetahui caranya jika Anda ingin berkontribusi."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1092,2020 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/pages/translations/it/LC_MESSAGES/messages.po
+++ b/pages/translations/it/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-    #: /views/partials/case-band.j2:6 /views/partials/case-band.j2:7
+#: /views/partials/case-band.j2:6 /views/partials/case-band.j2:7
 msgid "A screenshot of a website using AMP."
 msgstr ""
 
@@ -86,10 +86,6 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr ""
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr ""
@@ -112,16 +108,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +203,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "Eventi"
@@ -268,12 +248,6 @@ msgstr "Inizia"
 msgid "Get started"
 msgstr "Inizia"
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +270,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +373,6 @@ msgid "Overview"
 msgstr "Panoramica"
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -558,14 +523,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +545,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +625,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr ""
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,8 +1045,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "Purtroppo questa pagina non è ancora stata tradotta, ma potrebbe servirci una mano a farlo. Consulta la <a href="/documentation/guides-and-tutorials/contribute/translations">guida alla traduzione</a> su come puoi contribuire."
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "Purtroppo questa pagina non è ancora stata tradotta, ma potrebbe servirci una mano a farlo. Consulta la <a href=\"/documentation/guides-and-tutorials/contribute/translations\"> guida alla traduzione </a> su come puoi contribuire."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1092,2020 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/pages/translations/ja/LC_MESSAGES/messages.po
+++ b/pages/translations/ja/LC_MESSAGES/messages.po
@@ -86,10 +86,6 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr ""
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr ""
@@ -112,16 +108,6 @@ msgstr "ブログ"
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr "CNN"
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +203,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "イベント"
@@ -268,12 +248,6 @@ msgstr "スタートガイド"
 msgid "Get started"
 msgstr "スタートガイド"
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +270,6 @@ msgstr "ガイドとチュートリアル"
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +373,6 @@ msgid "Overview"
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -558,14 +523,6 @@ msgstr "サポートされるパートナーと統合"
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +545,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +625,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr "Wired"
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,8 +1045,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "このページはまだ翻訳されていません。本サイトでは、翻訳のご協力をお待ちしています。翻訳を提出する方法については、<a href="/documentation/guides-and-tutorials/contribute/translations">翻訳ガイド</a>をご覧ください。"
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "このページはまだ翻訳されていません。本サイトでは、翻訳のご協力をお待ちしています。翻訳を提出する方法については、<a href=\"/documentation/guides-and-tutorials/contribute/translations\"> 翻訳ガイド </a>をご覧ください。"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1092,2020 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/pages/translations/ko/LC_MESSAGES/messages.po
+++ b/pages/translations/ko/LC_MESSAGES/messages.po
@@ -86,10 +86,6 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr ""
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr ""
@@ -112,16 +108,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr "CNN"
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +203,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "이벤트"
@@ -268,12 +248,6 @@ msgstr "시작하기"
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +270,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +373,6 @@ msgid "Overview"
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -558,14 +523,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +545,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +625,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr "Wired"
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,8 +1045,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "죄송하지만 이 페이지는 아직 번역되지 않았습니다. 이 페이지를 번역하는 데 도움을 주고 싶다면 참여해 주세요. <a href="/documentation/guides-and-tutorials/contribute/translations">번역 가이드</a>에서 어떻게 참여할 수 있는지 알아보세요."
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "죄송하지만 이 페이지는 아직 번역되지 않았습니다. 이 페이지를 번역하는 데 도움을 주고 싶다면 참여해 주세요. <a href=\"/documentation/guides-and-tutorials/contribute/translations\"> 번역 가이드 </a>에서 어떻게 참여할 수 있는지 알아보세요."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1092,2024 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+#: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/_blueprint.yaml
+msgid "Style & Layout"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/pages/translations/messages.po
+++ b/pages/translations/messages.po
@@ -86,8 +86,20 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
+#: /content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
 msgstr ""
 
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
@@ -112,16 +124,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +219,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
@@ -268,12 +264,6 @@ msgstr ""
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +286,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +389,6 @@ msgid "Overview"
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -488,8 +469,40 @@ msgstr ""
 msgid "Select a language"
 msgstr ""
 
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
 #: /content/amp-dev/index.html:257
 msgid "Show everything"
+msgstr ""
+
+#: /views/partials/search.j2:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: /content/amp-dev/index.html:431
+msgid "Build anything with AMP."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
@@ -518,10 +531,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/guides-and-tutorials/start/_blueprint.yaml
 msgid "Start"
-msgstr ""
-
-#: /content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/_blueprint.yaml
-msgid "Style & Layout"
 msgstr ""
 
 #: /views/partials/footer.j2:76
@@ -558,14 +567,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +589,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +669,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr ""
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -758,7 +743,7 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-sticky-ad-v1.0.md
 #: /content/amp-dev/documentation/components/reference/amp-user-location-v0.1.md
 msgid "ads-analytics"
-msgstr ""
+msgstr "Advertising & Analytics"
 
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay-v0.2.md
 #: /content/amp-dev/documentation/components/reference/amp-access-laterpay-v0.2@ar.md
@@ -867,7 +852,7 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-viewer-assistance-v0.1.md
 #: /content/amp-dev/documentation/components/reference/amp-web-push-v0.1.md
 msgid "dynamic-content"
-msgstr ""
+msgstr "Dynamic Content"
 
 #: /content/amp-dev/documentation/components/reference/amp-accordion-v0.1.md
 #: /content/amp-dev/documentation/components/reference/amp-accordion-v0.1@ar.md
@@ -953,7 +938,7 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-sidebar-v0.1@zh_cn.md
 #: /content/amp-dev/documentation/components/reference/amp-sidebar-v1.0.md
 msgid "layout"
-msgstr ""
+msgstr "Layout"
 
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf-v0.1.md
 #: /content/amp-dev/documentation/components/reference/amp-3d-gltf-v0.1@ar.md
@@ -1038,7 +1023,7 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-youtube-v0.1@tr.md
 #: /content/amp-dev/documentation/components/reference/amp-youtube-v0.1@zh_cn.md
 msgid "media"
-msgstr ""
+msgstr "Media"
 
 #: /content/amp-dev/documentation/components/reference/amp-animation-v0.1.md
 #: /content/amp-dev/documentation/components/reference/amp-animation-v0.1@ar.md
@@ -1069,7 +1054,7 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-truncate-text-v0.1.md
 #: /content/amp-dev/documentation/components/reference/amp-viz-vega-v0.1.md
 msgid "presentation"
-msgstr ""
+msgstr "Presentation"
 
 #: /content/amp-dev/documentation/components/reference/amp-addthis-v0.1.md
 #: /content/amp-dev/documentation/components/reference/amp-addthis-v0.1@ar.md
@@ -1097,15 +1082,15 @@ msgstr ""
 #: /content/amp-dev/documentation/components/reference/amp-vine-v0.1.md
 #: /content/amp-dev/documentation/components/reference/amp-vk-v0.1.md
 msgid "social"
-msgstr ""
+msgstr "Social"
 
 #: /views/partials/search.j2:153
 msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "很遗憾，此页面尚未翻译，但我们可以凭借一些帮助将其翻译出来。请参阅<a href="/documentation/guides-and-tutorials/contribute/translations">翻译指南</a>，了解您可以如何做贡献。"
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr ""
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1147,7 +1132,1879 @@ msgstr ""
 msgid "Important  this component does not support your currently selected format"
 msgstr ""
 
-#: pages/content/amp-dev/documentation/templates/index.html:112
+#: /content/amp-dev/documentation/templates/index.html:112
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: /content/amp-dev/index.html:20
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: /content/amp-dev/index.html:25
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: /content/amp-dev/index.html:30
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: /content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: /content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: /content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: /content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: /content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: /content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: /content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: /content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: /content/amp-dev/index.html:462
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: /content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: /content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: /content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: /content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: /content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: /content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: /content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: /content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: /content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "Start sending AMP Emails"
+msgstr ""
+
+msgid "Start creating ads"
+msgstr ""
+
+msgid "Start creating stories"
+msgstr ""
+
+msgid "Start creating websites"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Discover all tools"
+msgstr ""
+
+msgid "Send emails"
+msgstr ""
+
+msgid "AMP<br> Email"
+msgstr ""
+
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+msgid "Modern app functionality for email"
+msgstr ""
+
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+msgid "Supported Email Clients"
+msgstr ""
+
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+msgid "Read on about AMP email"
+msgstr ""
+
+msgid "The benefits of AMP email"
+msgstr ""
+
+msgid "AMP for advertisers"
+msgstr ""
+
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Vision & Mission"
+msgstr ""
+
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+msgid "Design Principles"
+msgstr ""
+
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+msgid "Don’t break the web."
+msgstr ""
+
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+msgid "Solve problems on the right layer."
+msgstr ""
+
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+msgid "No whitelists."
+msgstr ""
+
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+msgid "Discover more..."
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "Get Started with Tutorials"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+msgid "Magazine article"
+msgstr ""
+
+msgid "Breaking the status quo"
+msgstr ""
+
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+msgid "Experience Demo"
+msgstr ""
+
+msgid "Band page"
+msgstr ""
+
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+msgid "E-Commerce"
+msgstr ""
+
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+msgid "See on GitHub"
+msgstr ""
+
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "AMP Roadshow"
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+msgid "Current Issues"
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Members"
+msgstr ""
+
+msgid "Communication Channels"
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+msgid "Contribute to AMP"
+msgstr ""
+
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+msgid "Governance Body"
+msgstr ""
+
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "View all"
+msgstr ""
+
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+msgid "Where we’ve been"
+msgstr ""
+
+msgid "Where we’re going next"
+msgstr ""
+
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+msgid "Agenda"
+msgstr ""
+
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Content"
+msgstr ""
+
+msgid "Amplify Live!"
+msgstr ""
+
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+msgid "Frequently Asked Questions"
+msgstr ""
+
+msgid "Does it cost anything?"
+msgstr ""
+
+msgid "No - tickets are free of charge."
+msgstr ""
+
+msgid "Who is the event for?"
+msgstr ""
+
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+msgid "Am I all set after registering?"
+msgstr ""
+
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "Cities"
+msgstr ""
+
+msgid "Sign Up"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""

--- a/pages/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/pages/translations/pt_BR/LC_MESSAGES/messages.po
@@ -86,10 +86,6 @@ msgstr "Animações & Transições"
 msgid "App Install"
 msgstr "Instalar App"
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr "BBC"
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr "Voltar para home"
@@ -112,16 +108,6 @@ msgstr "Blog"
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr "CNN"
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +203,6 @@ msgstr "Editar exemplos do GitHub"
 msgid "Editorial AMP Article"
 msgstr "Editorial de artigos do AMP"
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "Eventos"
@@ -268,12 +248,6 @@ msgstr "Primeiros passos"
 msgid "Get started"
 msgstr "Primeiros passos"
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -297,12 +271,6 @@ msgstr "Guias e tutoriais"
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
 msgstr "Como trabalhar com AMP sem saber programar?"
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
-msgstr ""
 
 #: /views/partials/search.j2:186
 msgid "Important Components"
@@ -405,9 +373,6 @@ msgid "Overview"
 msgstr "Visão geral"
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr "PCGamesN"
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr "Parallax Storytelling com AMP"
@@ -558,14 +523,6 @@ msgstr "Plataformas Suportadas"
 msgid "Table of contents"
 msgstr "Tabela de conteúdo"
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr "The Amazon Gold Rush"
@@ -589,12 +546,6 @@ msgstr "Os melhores jogos de battle royale no PC"
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
 msgstr "A página que você solicitou não pode ser encontrada. Por que você não continua navegando?"
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
-msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
 msgid "This example uses the following experimental feature:"
@@ -674,9 +625,6 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr "Who runs the world? ... Beyoncé ao longo dos anos."
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr "Wired"
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr "Grupos de trabalho"
@@ -684,13 +632,6 @@ msgstr "Grupos de trabalho"
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
 msgstr "Você não está conectado a internet no momento."
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
-msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
 #: /content/amp-dev/documentation/components/reference/amp-ad-v0.1.md
@@ -1104,8 +1045,8 @@ msgid "…while trying to load the search results."
 msgstr "...enquanto tenta carregar os resultados da pesquisa."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "Infelizmente, esta página ainda não foi traduzida, mas você pode nos ajudar a fazer isso. Veja o <a href="/documentation/guides-and-tutorials/contribute/translations">guia de tradução</a> para saber como você pode contribuir."
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "Infelizmente, esta página ainda não foi traduzida, mas você pode nos ajudar a fazer isso. Veja o <a href=\"/documentation/guides-and-tutorials/contribute/translations\"> guia de tradução </a> para saber como você pode contribuir."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1092,2020 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/pages/translations/ru/LC_MESSAGES/messages.po
+++ b/pages/translations/ru/LC_MESSAGES/messages.po
@@ -86,10 +86,6 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr ""
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr ""
@@ -112,16 +108,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +203,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
@@ -268,12 +248,6 @@ msgstr ""
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +270,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +373,6 @@ msgid "Overview"
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -558,14 +523,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +545,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +625,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr ""
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,8 +1045,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "Эта страница пока не переведена, но вы можете помочь нам в этом. Чтобы узнать больше, ознакомьтесь с <a href="/documentation/guides-and-tutorials/contribute/translations">руководством по переводу.</a>"
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "Эта страница пока не переведена, но вы можете помочь нам в этом. Чтобы узнать больше, ознакомьтесь с <a href=\"/documentation/guides-and-tutorials/contribute/translations\"> руководством по переводу.</a>"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1092,2020 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/pages/translations/tr/LC_MESSAGES/messages.po
+++ b/pages/translations/tr/LC_MESSAGES/messages.po
@@ -1,4 +1,3 @@
-#: /views/partials/case-band.j2:6 /views/partials/case-band.j2:7
 msgid "A screenshot of a website using AMP."
 msgstr ""
 
@@ -86,10 +85,6 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr ""
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr ""
@@ -112,16 +107,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +202,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr ""
@@ -268,12 +247,6 @@ msgstr ""
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +269,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +372,6 @@ msgid "Overview"
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -558,14 +522,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +544,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +624,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr ""
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,8 +1044,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr "Maalesef bu sayfa henüz çevrilmedi, ancak bunun için yardım almak isteriz. Nasıl katkıda bulunabileceğinizi öğrenmek için <a href="/documentation/guides-and-tutorials/contribute/translations">çeviri kılavuzuna</a> bakın."
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "Maalesef bu sayfa henüz çevrilmedi, ancak bunun için yardım almak isteriz. Nasıl katkıda bulunabileceğinizi öğrenmek için <a href=\"/documentation/guides-and-tutorials/contribute/translations\"> çeviri kılavuzuna </a> bakın."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1091,2020 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/pages/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/pages/translations/zh_CN/LC_MESSAGES/messages.po
@@ -86,10 +86,6 @@ msgstr ""
 msgid "App Install"
 msgstr ""
 
-#: /content/amp-dev/about/stories.html
-msgid "BBC"
-msgstr ""
-
 #: /content/amp-dev/404.html:18 /content/amp-dev/500.html:18
 msgid "Back to home"
 msgstr ""
@@ -112,16 +108,6 @@ msgstr ""
 
 #: /views/partials/burger-menu.j2:8
 msgid "Burger Menu"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid "CNN"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"Camp Fire Visual Essay - A ballet rises from the ashes in a fire scarred "
-"paradise"
 msgstr ""
 
 #: /content/amp-dev/community/_blueprint.yaml /views/partials/footer.j2:61
@@ -217,12 +203,6 @@ msgstr ""
 msgid "Editorial AMP Article"
 msgstr ""
 
-#: /views/partials/experiments/experiments.j2:4
-msgid ""
-"Enable the experiment via the button below. Some components require the AMP "
-"Dev Channel to be enabled as well."
-msgstr ""
-
 #: /content/amp-dev/events/_blueprint.yaml /views/partials/footer.j2:69
 msgid "Events"
 msgstr "活动"
@@ -268,12 +248,6 @@ msgstr "开始使用"
 msgid "Get started"
 msgstr ""
 
-#: /content/amp-dev/documentation/templates/index.html:70
-msgid ""
-"Get started quickly with a ready-made design. Templates designed to work with"
-" all devices - mobile, tablet and desktop."
-msgstr ""
-
 #: /content/amp-dev/documentation/courses/teachers.md:9
 msgid "Get the courses"
 msgstr ""
@@ -296,12 +270,6 @@ msgstr ""
 
 #: /content/amp-dev/documentation/templates/index.html:19
 msgid "How to build AMP without knowing how to code?"
-msgstr ""
-
-#: /views/examples/documentation.j2:206
-msgid ""
-"If the explanations on this page don't cover all of your questions feel free "
-"to reach out to other AMP users to discuss your exact use case."
 msgstr ""
 
 #: /views/partials/search.j2:186
@@ -405,9 +373,6 @@ msgid "Overview"
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "PCGamesN"
-msgstr ""
-
 #: /views/partials/case-grid.j2:14
 msgid "Parallax Storytelling in AMP"
 msgstr ""
@@ -558,14 +523,6 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: /views/detail/component-detail.j2:40 /views/examples/documentation.j2:213
-msgid ""
-"The AMP project strongly encourages your participation and contributions! We "
-"hope you'll become an ongoing participant in our open source community but we"
-" also welcome one-off contributions for the issues you're particularly "
-"passionate about."
-msgstr ""
-
 #: /content/amp-dev/about/stories.html
 msgid "The Amazon Gold Rush"
 msgstr ""
@@ -588,12 +545,6 @@ msgstr ""
 
 #: /content/amp-dev/404.html:15
 msgid "The page you've requested can't be found. Why don't you browse around?"
-msgstr ""
-
-#: /content/amp-dev/about/stories.html
-msgid ""
-"These photos capture how members of Congress reacted to Trump’s State of the "
-"Union"
 msgstr ""
 
 #: /views/partials/experiments/experiments.j2:4
@@ -674,22 +625,12 @@ msgid "Who runs the world? ... Beyoncé over the years."
 msgstr ""
 
 #: /content/amp-dev/about/stories.html
-msgid "Wired"
-msgstr ""
-
 #: /content/amp-dev/community/working-groups/_blueprint.yaml
 msgid "Working Groups"
 msgstr ""
 
 #: /content/amp-dev/offline.html:15
 msgid "You're currently not connected to the internet."
-msgstr ""
-
-#: /views/detail/component-detail.j2:33
-msgid ""
-"You've read this document a dozen times but it doesn't really cover all of "
-"your questions? Maybe other people felt the same: reach out to them on Stack "
-"Overflow."
 msgstr ""
 
 #: /content/amp-dev/documentation/components/reference/amp-ad-exit-v0.1.md
@@ -1104,8 +1045,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations">translation guide</a> on how you can contribute."
-msgstr ""
+msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgstr "很遗憾，此页面尚未翻译，但我们可以凭借一些帮助将其翻译出来。请参阅<a href=\"/documentation/guides-and-tutorials/contribute/translations\"> 翻译指南 </a>，了解您可以如何做贡献。"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."
@@ -1151,3 +1092,2020 @@ msgstr ""
 msgid "Get started quickly with a ready-made design. Templates designed to work with all devices - mobile, tablet and desktop."
 msgstr ""
 
+#: pages/content/amp-dev/index.html:65
+msgid "AMP is a web component framework to easily create <span style=\"white-space: nowrap;\">user-first</span><br>"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:91
+msgid "The latest news"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:92
+msgid "Don't want to miss any of the great stuff that happens around AMP? Then always be first in line and subscribe to our newsletter!"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:99
+msgid "Subscribe"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:244
+msgid "Learn more about AMP {{ format.name }}"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:350
+msgid "Business Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:394
+msgid "Get started with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:414
+msgid "As a source for breaking news and information, AMP stories allows us to showcase our quality journalism when there are multiple elements we want to bring together. Combining reporting, photography, videos and motion graphics, this gives readers a more visual entry point when they are searching for our coverage."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:416
+msgid "Greg Manifold, Design Director of The Washington Post"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Don't take our word for it - read case studies from your industry and see how AMP has produced positive results."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:470
+msgid "See all success stories"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:478
+msgid "By the community,<br/>for the community"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:494
+msgid "Many ways for you to contribute"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:495
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:510
+msgid "Reporting issues with AMP"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:511
+msgid "If you have feedback or are experiencing technical issues with AMP, please file it using the issue tracker."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:521
+msgid "Build your first AMP page now"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:522
+msgid "You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:90
+msgid "AMP Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:91
+msgid "Use AMP to create visual stories on the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:94
+msgid "Start developing"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:95
+msgid "Tell a story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:106
+msgid "AMP<br> Stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:107
+msgid "visual storytelling for the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:108
+msgid "AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:109
+msgid "AMP stories provides content publishers with a mobile-focused format for delivering news and information as visually rich, tap-through stories. AMP Stories offers a robust set of advertising opportunities for advertisers and publishers to reach a unique audience on the web with immersive experiences."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:119
+msgid "Build your first story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:128
+msgid "Learn about story ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:159
+msgid "Read Success Story"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:175
+msgid "The benefits of AMP stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:223
+msgid "Read on how AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:235
+msgid "AMP stories are built with visually rich media, and whether you utilize pictures, videos or GIF assets is up to you. Images and videos expand to visually fill the readers’ screens, providing a smooth and fully engaging experience. AMP allows you to specify the file type to account for the user’s network connection and browser capabilities."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:240
+msgid "Convey facts and figures via bite-sized chunks of one or two sentences – ideal for mobile devices. Choose from different font colors for basic readability. Or add visual elements like subtle black transparent gradient overlays to ensure readability even on random background imagery, for example user generated content. On top of this, you can use short audio files on every page to provide spoken information or background music."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:245
+msgid "It’s easy to create visual effects and tappable interactions that keep readers engaged. Titles can fly  drop, fade in, or animate onto the page. Configure your story to automatically progress to the next page when a video snippet is finished. Provide social sharing and related links at the end of your story, so users can share it or dive further into other content on your site."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:325
+msgid "AMP Stories <br />Monetization Options"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:326
+msgid "Single Page Story Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:408
+msgid "Get Started with our Story Ads Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:421
+msgid "Affliate Links"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:422
+msgid "Publishers can use affiliate links as a form of monetization by placing outlinks in organic story pages."
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:428
+msgid "Read Best Practices Guide"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:41
+msgid "AMP Ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:42
+msgid "Use AMP to build and serve lightning fast, safe ads to pages and stories."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:46
+msgid "Explore tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:58
+msgid "These days, if it isn’t instant - it’s not fast enough. Even the most memorable creative won’t serve its purpose if the ad is slow and disruptive for a user."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:60
+msgid "Advertising continues to be the cornerstone of every publisher’s business model; AMP is fundamentally changing the way ads are built and delivered on the web by supporting ads that are fast, safe, compelling and effective for users."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:77
+msgid "A faster way to grow your business"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:78
+msgid "A growing number of publishers and advertisers are adopting AMP to deliver faster and more engaging content to their users. As your clients embrace the speed of AMP and more users consume content on AMP pages, ensure that your business is positioned for the future and integrate your technology with AMP. Speeding up ads is the fastest way to boost performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:79
+msgid "AMP ads greatly improve the mobile internet through their intelligent design and pre-loading features. This leads to increased traffic, higher sales conversion rates and more pages per visit - delivering the value you’re looking for in your ads."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:80
+msgid "Although AMP pages support traditional HTML ads, these ads can be slow to load. To make ads themselves as fast as the rest of the AMP page, you can build ads in AMPHTML."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:81
+msgid "AMPHTML ads load as fast as content, increasing viewability and enticing engagement. AMPHTML ads are only delivered after being validated, ensuring that the ads are free of malware."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:82
+msgid "Ads created with AMPHTML are served on both AMP and non-AMP pages. By building an ad with AMP, you can deliver a memorable brand experience everywhere without worrying about speed and platform compatibility."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:125
+msgid "The benefits of AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:171
+msgid "Read on about AMP ads"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:188
+msgid "They load way faster. Users pick up on every small delay, and when the ads load fast, this has a very positive impact on their perception and advertiser performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:190
+msgid "Shaun Zacharia, President & Co-Founder, Triplelift."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:208
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things  speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:209
+msgid "AMP offers a way for you to give users a faster experience everywhere  on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:228
+msgid "What’s the difference between an AMPHTML ad and a regular ad? Seconds."
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:234
+msgid "AMPHTML Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:40
+msgid "Compelling, smooth and instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:41
+msgid "Easily create user first websites with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:55
+msgid "What is<br> AMP?"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:56
+msgid "Web pages that are compelling, smooth, and load near instantaneously"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:64
+msgid "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:101
+msgid "Create great web experiences for users across the open web"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:102
+msgid "AMP enables the creation of websites and ads that are consistently fast, beautiful and high-performing across devices and distribution platforms. Publishers and advertisers can decide how to present their content that emphasizes a user-first experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:188
+msgid "We are committed to improving speed across the board. If our site takes a long time to load, it doesn’t matter how great our journalism is, some people will leave the page before they see what’s there."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:190
+msgid "David Merrell, Senior Product Manager"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:223
+msgid "Built-in components"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:224
+msgid "AMP HTML is HTML with some restrictions for reliable performance."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:228
+msgid "For example, the amp-img tag provides full srcset support even in browsers that don’t support it yet. Learn how to create your first AMP HTML page."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:230
+msgid "AMP pages are discovered by search engines and other platforms through the HTML tag. You can choose to have a non-AMP version and an AMP version of your page, or just an AMP version. "
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:245
+msgid "AMP pages can be cached for near instantaneous loading on the web. Platforms like Google run AMP caches to enable fast loading of your content from their service."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:250
+msgid "Another version of the validator comes bundled with every AMP page. This version can log validation errors directly to the browser’s console when the page is rendered, allowing you to see how complex changes in your code might impact performance and user experience."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:258
+msgid "Learn more about caching in AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:268
+msgid "Explore use cases of AMP websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:11
+msgid "Start creating ads"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:14
+msgid "Start sending AMP Emails"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:17
+msgid "Start creating stories"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:20
+msgid "Start creating websites"
+msgstr ""
+
+#: frontend/templates/views/partials/tools-widget.j2:47
+msgid "Discover all tools"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:44
+msgid "Use AMP to send interactive, dynamic emails."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:48
+msgid "Send emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:59
+msgid "AMP<br> Email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:60
+msgid "A whole new world of possibilities for content engagement"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:67
+msgid "AMP for email allows senders to include AMP components inside rich engaging emails, making modern app functionality available within email. The AMP email format provides a subset of AMPHTML components for use in email messages, that allows recipients of AMP emails to interact dynamically with content directly in the message."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:68
+msgid "More than 270 billion emails are sent every day, it is the pillar of many consumer and enterprise workflows. However the content that is sent in an email message is still limited – messages are static, can become out of date, and are not actionable without opening a browser. AMP email seeks to enhance and modernize the email experience through added support for dynamic content and interactivity while keeping users safe."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:92
+msgid "It’s the biggest thing happening to email since the creation of email."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:94
+msgid "Antony Malone, Senior Product Owner Direct Marketing at Booking.com"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:103
+msgid "Modern app functionality for email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:104
+msgid "Modernize email with the power of AMP"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:105
+msgid "AMP email is an expansion of the already existing blazingly fast and high-performing AMP project.   Expand your business through unprecedented features."
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:122
+msgid "Supported Email Clients"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:123
+msgid "These email clients currently support receiving AMP Emails"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:144
+msgid "The benefits of AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/email.html:192
+msgid "Read on about AMP email"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:18
+msgid "How AMP works"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:19
+msgid "The following optimizations combined are the reason AMP pages are so fast they appear to load instantly. There are 7 reasons in total - but if that’s still too much to read, simply watch the explainer video:"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:29
+msgid "Execute all AMP JavaScript asynchronously"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:31
+msgid "AMP components may have JavaScript under the hood, but they’re carefully designed to make sure they don’t cause performance degradation. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:32
+msgid "While custom JS is allowed in <a href=\"../documentation/components/reference/amp-script.md\"><code>amp-script</code></a>, and third-party JS is allowed in iframes, it cannot block rendering. For example, if third-party JS uses the <a href=\"http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/\">super-bad-for-performance <code>document.write</code> API</a>, it does not block rendering the main page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:36
+msgid "Size all resources statically"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:37
+msgid "External resources such as images, ads or iframes must state their size in the HTML so that AMP can determine each element’s size and position before resources are downloaded. AMP loads the layout of the page without waiting for any resources to download. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:42
+msgid "Don’t let extension mechanisms block rendering"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:43
+msgid "AMP doesn’t let extension mechanisms block page rendering. AMP supports extensions for things like <a href=\"../documentation/components/reference/amp-lightbox.md\">lightboxes</a>, <a href=\"../documentation/components/reference/amp-instagram.md\">instagram embeds</a>, <a href=\"../documentation/components/reference/amp-twitter.md\">tweets</a>, etc. While these require additional HTTP requests, those requests do not block page layout and rendering."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:53
+msgid "Keep all third-party JavaScript out of the critical path"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:54
+msgid "Third-party JS likes to use synchronous JS loading. They also like to <code>document.write</code> more sync scripts. For example, if you have five ads on your page, and each of them cause three synchronous loads, each with a 1 second latency connection, you’re in 15 seconds of load time just for JS loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:55
+msgid "AMP pages allow third-party JavaScript but only in sandboxed iframes. By restricting them to iframes, they can’t block the execution of the main page. Even if they trigger multiple style re-calculations, their tiny iframes have very little DOM. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:56
+msgid "The time it takes to do style-recalculations and layouts are restricted by DOM size, so the iframe recalculations are very fast compared to recalculating styles and layout for the page."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:60
+msgid "All CSS must be inline and size-bound"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:61
+msgid "CSS blocks all rendering, it blocks page load, and it tends to get bloated. In AMP HTML pages, only inline styles are allowed. This removes 1 or often more HTTP requests from the critical rendering path compared to most web pages. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:62
+msgid "Also, the inline style sheet has a maximum size of 50 kilobytes. While this size is big enough for very sophisticated pages, it still requires the page author to practice good CSS hygiene."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:66
+msgid "Font triggering must be efficient"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:67
+msgid "Web fonts are super large, so <a href=\"https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization\">web font optimization</a> is crucial to performance. On a typical page that has a few sync scripts and a few external style sheets, the browser waits and waits to start downloading these huge fonts until all this happens."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:68
+msgid "The AMP system declares zero HTTP requests until fonts start downloading. This is only possible because all JS in AMP has the async attribute and only inline style sheets are allowed; there’s no HTTP requests blocking the browser from downloading fonts."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:72
+msgid "Minimize style recalculations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:73
+msgid "Each time you measure something, it triggers style recalculations which are expensive because the browser has to layout the entire page. In AMP pages, all DOM reads happen first before all the writes. This ensures there’s the max of one recalc of styles per frame. "
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:74
+msgid "Learn more about impact of style and layout recalculations on <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/\">rendering performance</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:78
+msgid "Only run GPU-accelerated animations"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:79
+msgid "The only way to have fast optimizations is to run them on the GPU. GPU knows about layers, it knows how to perform some things on these layers, it can move them, it can fade them, but it can’t update the page layout; it will hand that task over to the browser, and that’s not good."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:80
+msgid "The rules for animation-related CSS ensure that animations can be GPU-accelerated. Specifically, AMP only allows animating and transitioning on transform and opacity so that page layout isn’t required. Learn more about <a href=\"https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count\">using transform and opacity for animation changes</a>."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:84
+msgid "Prioritize resource loading"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:85
+msgid "AMP controls all resource downloads  it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:86
+msgid "When AMP downloads resources, it optimizes downloads so that the currently most important resources are downloaded first. Images and ads are only downloaded if they are likely to be seen by the user, above the fold, or if the user is likely to quickly scroll to them."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:87
+msgid "AMP also prefetches lazy-loaded resources. Resources are loaded as late as possible, but prefetched as early as possible. That way things load very fast but CPU is only used when resources are actually shown to users."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:91
+msgid "Load pages in an instant"
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:92
+msgid "The new <a href=\"http://www.w3.org/TR/resource-hints/#dfn-preconnect\">preconnect API</a> is used heavily to ensure HTTP requests are as fast as possible when they are made. With this, a page can be rendered before the user explicitly states they’d like to navigate to it; the page might already be available by the time the user actually selects it, leading to instant loading."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:93
+msgid "While prerendering can be applied to all web content, it can also use up a lot of bandwidth and CPU. AMP is optimized to reduce both of these factors. Prerendering only downloads resources above the fold and prerendering doesn’t render things that might be expensive in terms of CPU."
+msgstr ""
+
+#: pages/content/amp-dev/about/how-amp-works.html:95
+msgid "Learn more about <a href=\"https://medium.com/@cramforce/why-amp-html-does-not-take-full-advantage-of-the-preload-scanner-7e7f788aa94e\">why AMP HTML doesn’t take full advantage of the preload scanner</a>."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:283
+msgid "AMP in action"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:337
+msgid "Open in AMP Playground"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:370
+msgid "Developer Benefits"
+msgstr ""
+
+#: pages/content/amp-dev/index.html:431
+msgid "Build anything with AMP."
+msgstr ""
+
+#: pages/content/amp-dev/index.html:463
+msgid "Explore AMP<br/> success stories"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:234
+msgid "Images, videos and GIFs"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:239
+msgid "Text and audio"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:244
+msgid "Animations and interactions"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:255
+msgid "Check out AMP stories on the web"
+msgstr ""
+
+#: pages/content/amp-dev/about/stories.html:415
+msgid "Discover All Templates"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:206
+msgid "AMP for advertisers"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:207
+msgid "Grow engagement and increase conversions with faster experiences"
+msgstr ""
+
+#: pages/content/amp-dev/about/ads.html:250
+msgid "Regular Ad"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:204
+msgid "What AMP HTML is made of"
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:237
+msgid "Learn more in Make Your Page Discoverable."
+msgstr ""
+
+#: pages/content/amp-dev/about/websites.html:247
+msgid "The Google AMP Cache is a proxy-based content delivery network for delivering all valid AMP documents. It fetches AMP HTML pages, caches them, and improves page performance automatically. When using the Google AMP Cache, the document, all JS files and all images load from the same origin that is using HTTP 2.0 for maximum efficiency. <br> The cache also comes with a built-in validation system which confirms that the page is guaranteed to work, and that it doesn't depend on external resources. The validation system runs a series of  assertions confirming the page’s markup meets the AMP HTML specification."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:20
+msgid "Encouraging More Voices in AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:44
+msgid "An AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP. Working Groups are created by AMP’s Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:45
+msgid "Most Working Groups provide bi-weekly status updates and present quarterly high-level updates in round-robin fashion at Design Reviews."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:76
+msgid "Current Issues"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:105
+msgid "View all"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:112
+msgid "Members"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:149
+msgid "Communication Channels"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:184
+msgid "Other ways to get involved with AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:186
+msgid "Contribute to AMP"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:187
+msgid "The AMP Project would not be possible without help from all members of the community whether you are a developer, content creator or provider of services relevant to AMP There are many ways for you to contribute."
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:199
+msgid "Governance Body"
+msgstr ""
+
+#: frontend/templates/views/detail/working-group-detail.j2:200
+msgid "Learn more about the Advisory Committee and Technical Steering Committee."
+msgstr ""
+
+#: frontend/templates/views/partials/teaser.j2:209
+msgid "Discover more..."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:5
+msgid "E-Commerce"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:9
+msgid "AMP shines for content pages. But it can also power e-commerce experiences."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:10
+msgid "To learn more, we built a simple yet fully functional e-commerce site of our very own! Check out the site, and look at the code to learn about the best practices we discovered to build a great interactive experience on your domain and on AMP caches alike."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:24
+msgid "Experience Demo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:32
+msgid "See on GitHub"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:38
+msgid "Magazine article"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:39
+msgid "Breaking the status quo"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:42
+msgid "This example of magazine article demonstrates how to build an immersive reading experience by adding animations that enhance the written content on the page."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:44
+msgid "<code>amp-position-observer</code> in combination with <code>amp-animation</code> allows a smooth \"scrolly-telling\" experience with minimal effort and without any custom JavaScript."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:73
+msgid "Band page"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:74
+msgid "Olga and the kings"
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:77
+msgid "Always thought that all AMP pages look the same? Checkout this incredible band website featuring various AMP components to create a vivid and enjoyable experience."
+msgstr ""
+
+#: frontend/templates/views/partials/fragment-slider-texts.j2:79
+msgid "The use of <code>amp-sidebar</code> gives you the same feeling as if you are in a single page app."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:17
+msgid "Vision & Mission"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:18
+msgid "Our vision is our north star we use to orient ourselves, and our mission describes the way we move into the direction of it."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:28
+msgid "A strong, user-first open web forever."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:38
+msgid "Provide a user-first format for web content, supporting the long-term success of every web publisher, merchant, and advertiser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:51
+msgid "Design Principles"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:52
+msgid "These design principles are meant to guide the ongoing design and development of AMP. They should help us make internally consistent decisions."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:70
+msgid "User Experience > Developer Experience > Ease of Implementation."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:71
+msgid "When in doubt, do what’s best for the end user experience, even if it means that it’s harder for the page creator to build or for the library developer to implement."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:81
+msgid "Don’t design for a hypothetical faster future browser."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:82
+msgid "We’ve chosen to build AMP as a library in the spirit of the <a href=\"https://github.com/extensibleweb/manifesto/blob/master/README.md\">EXTENSIBLE WEB MANIFESTO</a> to be able to fix the web of today, not the web of tomorrow. AMP should be fast in today’s browsers. When certain optimizations aren’t possible with today’s platform, AMP developers should participate in standards development to get these added to the web platform.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:92
+msgid "Don’t break the web."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:93
+msgid "Ensure that if AMP has outages or problems it doesn’t hurt the rest of the web. That means if the Google AMP Cache, the URL API or the library fails it should be possible for websites and consumption apps to gracefully degrade. If something works with an AMP cache it should also work without a cache."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:106
+msgid "Solve problems on the right layer."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:107
+msgid "E.g. don’t integrate things on the client side, just because that is easier, when the user experience would be better with a server side integration."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:116
+msgid "Only do things if they can be made fast."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:117
+msgid "Don’t introduce components or features to AMP that can’t reliably run at 60fps or hinder the instant load experience on today’s most common mobile devices."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:126
+msgid "Prioritise things that improve the user experience – but compromise when needed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:127
+msgid "Some things can be made fast and are still a terrible user experience. AMPs should deliver a fantastic user experience and speed is just one part of that. Only compromise when lack of support for something would stop AMP from being widely used and deployed."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:137
+msgid "No whitelists."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:138
+msgid "We won’t give any special treatment to specific sites, domains or origins except where needed for security or performance reasons."
+msgstr ""
+
+#: pages/content/amp-dev/about/mission-and-vision.html:151
+msgid "Get Started with Tutorials"
+msgstr ""
+
+#: pages/content/amp-dev/about/success-stories/index.html:95
+msgid "Here we feature interesting and outstanding pages that have been published using AMP. We kindly invite you to look through them to see what AMP is capable of."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:26
+msgid "AMP Roadshow"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:27
+msgid "Come join us in your city for a free, inclusive dev workshop with the AMP team."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:29
+msgid "Sign Up"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:53
+msgid "Cities"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:133
+msgid "Where we’re going next"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:173
+msgid "Your city isn’t on the list? Check back soon for additional dates and cities. Or..."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:174
+msgid "Want the AMP Roadshow to visit your area?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:175
+msgid "That’s very kind. Fill out <a href=\"https://docs.google.com/forms/d/14B75eV89S1KaceNTG46ranAOPCj3wCLzgD3mxuGeUtU/viewform\" target=\"_blank\">this form</a> and we’ll see what we can do!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:176
+msgid "Want to host your own AMP Roadshow?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:177
+msgid "Why not? Fill out <a href=\"https://docs.google.com/forms/d/1PMWCq1MTqg-AslvBMvMlU_ozjyZK7WZ-4fUVs0UlheE/viewform\" target=\"_blank\">this form</a>, and we’ll share with you our talks and all the materials you need to do it yourself!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:181
+msgid "Where we’ve been"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:205
+msgid "Agenda"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:206
+msgid "The agenda is designed to enable you to build even more beautiful, interactive and canonical AMP pages. We welcome both newcomers to AMP and those who already ship AMP pages. <span>This is a sample agenda – schedule varies based on the city.</span>"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:246
+msgid "Content"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:272
+msgid "Amplify Live!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:273
+msgid "During \"Amplify live!\", we’ll be on stage exploring the most interesting AMP challenges, allowing you to either follow along or do your own thing, like one of the many AMP codelabs. Bring your laptop!"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:282
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:284
+msgid "Does it cost anything?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:285
+msgid "No - tickets are free of charge."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:286
+msgid "Who is the event for?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:287
+msgid "Web developers and designers with an interest in AMP--whether you’ve had experience using AMP and want to create better experiences, you’re curious about how you can use AMP to improve your site, or you want to contribute to AMP to make it better for everyone."
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:288
+msgid "Am I all set after registering?"
+msgstr ""
+
+#: pages/content/amp-dev/events/amp-roadshow.html:289
+msgid "We expect that in some cities more people will be interested in attending than we can accommodate, so we will be confirming attendees on a case-by-case basis."
+msgstr ""
+
+msgid "Help"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "websites"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "stories"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "ads"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "emails"
+msgstr ""
+
+#: /views/partials/rolling-formats.j2:3
+msgid "email"
+msgstr ""
+
+#: /content/amp-dev/index.html:31
+msgid "Whether you are a publisher, e-commerce company, storyteller, advertiser or email sender, AMP makes it easy to create great experiences on the web. Use AMP to build:"
+msgstr ""
+
+#: /content/amp-dev/index.html:14
+msgid "Use AMP to build great experiences across the web"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:3
+msgid "Web page speed improves the user experience and core business metrics"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:6
+msgid "Building AMP pages is easy and reduces developer overhead"
+msgstr ""
+
+msgid "AMP pages load near instantly, enabling you to offer a consistently fast experience across all devices and platforms."
+msgstr ""
+
+msgid "You can often convert your entire archive in days especially if you use a popular CMS such as Wordpress or Drupal."
+msgstr ""
+
+msgid "Used by popular and global platforms like Google, Bing and Twitter, AMP allows you to ensure users from all these surfaces get an unparalleled, often instantaneous and native-feeling experience by defaulting to AMP pages when available."
+msgstr ""
+
+msgid "You can use CSS to customize your styling, dynamic data to fetch the freshest data where needed, to build the best possible userexperience for your customers."
+msgstr ""
+
+msgid "It takes a lot of time and effort to build a great website. AMP components are already optimized for the best performance."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web helping everyone deliver a better, faster more user-friendly experience."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:34
+msgid "Maintain flexibility and control and reduce complexity in your code"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:37
+msgid "Building blocks that ensure performance"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:40
+msgid "Build for a sustainable future in the open web for everyone"
+msgstr ""
+
+msgid "Create flawless web experiences"
+msgstr ""
+
+msgid "Snackable formats for everyone"
+msgstr ""
+
+msgid "Super fast ads on the web"
+msgstr ""
+
+msgid "Next gen email"
+msgstr ""
+
+msgid "Use cases"
+msgstr ""
+
+msgid "Guides & Tutorials"
+msgstr ""
+
+msgid "The complete AMP library"
+msgstr ""
+
+msgid "Hands on Introduction to AMP"
+msgstr ""
+
+msgid "Learn AMP with free courses"
+msgstr ""
+
+msgid "Templates"
+msgstr ""
+
+msgid "Begin building"
+msgstr ""
+
+msgid "Ready to use"
+msgstr ""
+
+msgid "Courses"
+msgstr ""
+
+msgid "Governance"
+msgstr ""
+
+msgid "advertisers"
+msgstr ""
+
+msgid "publishers"
+msgstr ""
+
+msgid "e-commerce"
+msgstr ""
+
+msgid "nonprofit"
+msgstr ""
+
+msgid "social-media"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:17
+msgid "More overall traffic"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:18
+msgid "India Today delights readers and boosts revenue with AMP"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:21
+msgid "Increase in returning users from mobile search"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:22
+msgid "AMP helps the Washington Post increase returning users from mobile search by 23%"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:24
+msgid "Faster page load time"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:25
+msgid "AMP makes Gizmodo 3x faster on mobile"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:30
+msgid "AMP can be applied across various web touch points"
+msgstr ""
+
+msgid "Used by global platforms like Google, Bing and Twitter, AMP allows users a native-feeling experience across all platforms by defaulting to AMP pages when available."
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:226
+msgid "Though most tags in an AMP HTML page are regular HTML tags, some HTML tags are replaced with AMP-specific tags (see also HTML Tags in the AMP spec). These custom elements,  called AMP HTML  components, make common patterns easy to implement in a performant way."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:58
+msgid "Create beautiful and engaging content easily"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:61
+msgid "Creative flexibility for editorial freedom and branding"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:64
+msgid "Sharable and linkable on the open web"
+msgstr ""
+
+msgid "AMP stories make the production of stories as easy as possible from a technical perspective."
+msgstr ""
+
+msgid "The AMP stories format comes with preset but flexible layout templates, standardized UI controls, and components for sharing and adding follow-on content."
+msgstr ""
+
+msgid "AMP stories are part of the open web and can be shared and embedded across sites and apps without being confined to a single ecosystem."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:45
+msgid "Track and measure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:48
+msgid "Fast loading times"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:51
+msgid "Immersive storytelling"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:54
+msgid "Robust Advertising Support"
+msgstr ""
+
+msgid "Supports analytics and bookend capabilities for viral sharing and monetization."
+msgstr ""
+
+msgid "AMP stories are lightening fast so that your audience stays engaged and entertained."
+msgstr ""
+
+msgid "AMP stories is a new and modern way to reach existing readers."
+msgstr ""
+
+msgid "AMP Stories enables monetization capability for publishers using full-screen immersive story ads and using affiliate links. For advertisers, Stories is a way to reach a unique audience within a new storytelling experience."
+msgstr ""
+
+#: /content/amp-dev/about/stories.html:327
+msgid "Story Ads are full screen, single page ads that appear within AMP Stories. Advertisers/ Publishers can invite users to a web page, an AMP page or an App with a single tap. A story ad has a rich, flexible canvas that allows images, videos, animations or a combination of all those elements.<br>  Story ads are supported by Google Ad Manager and Google DV360 (Beta) with additional ad server support coming soon!"
+msgstr ""
+
+msgid "Pick one of several editors to start creating ads without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating email without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating stories without any coding involved."
+msgstr ""
+
+msgid "Pick one of several editors to start creating websites without any coding involved."
+msgstr ""
+
+msgid "WYSIWYG Editor"
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:72
+msgid "Maximize your revenue"
+msgstr ""
+
+msgid "Increase in average clickthrough rate"
+msgstr ""
+
+msgid "Teads brings AMP'd mobile video inventory to nearly 100 publishers"
+msgstr ""
+
+msgid "Increase in ad load speed"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:79
+msgid "End to end experience is controlled"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:82
+msgid "Reduce complexity in your operations"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:85
+msgid "Collaborative community"
+msgstr ""
+
+msgid "As the owner of your AMP websites and ads, no other parties can modify or add things, ensuring you are in control of the user experience and there won’t be any unexpected surprises. AMP ads are part of a user-first ecosystem and function the way a reasonable user would expect them to. Optimized AMP ads don’t drain the battery life of mobile devices, and clicking on them will lead to AMP pages, which are equally as fast and streamlined."
+msgstr ""
+
+msgid "AMP is simple and straightforward and quickly becoming the turnkey solution for building pages. AMP supports both traditional ads, and the faster, more secure AMPHTML ads. Ads on AMP pages are like any external resource and must play within the same constraints placed on all resources in AMP."
+msgstr ""
+
+msgid "The AMP Project has a vast network of resources for getting started in the Documentation section including great-looking ad templates, demos and examples. AMPHTML ads are flexible and dynamic, allowing for many creative formats like carousel, parallax, and lightbox, to name a few."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:69
+msgid "Measurable viewability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:75
+msgid "Maximize your ROI"
+msgstr ""
+
+msgid "AMPHTML ads are 6x faster than regular ads on AMP pages, making them more viewable, more effective and more likely to perform well. You can monitor performance and adjust pricing accordingly, and offer the most engaging ad products to optimize your ad placements. In AMP, tweaking your pages to drive higher viewability rate or views is easy for publishers using the ‘data-loading-strategy’ attribute on the `amp-ad` component."
+msgstr ""
+
+msgid "In order to engage with your brand and improve the performance of your campaigns, you have to speed things up. AMP ads load on average 5x faster than the non-AMP version, leading to higher conversion rates. Because AMPHTML ads are 3x lighter, the AMP framework guarantees that these ads only behave as intended so users always have a positive experience with your brand."
+msgstr ""
+
+msgid "AMP ads are safe from malware because AMPHTML ads are verified before being served, thus, advertisers can ensure a safe user experience and building trust in the brands users are engaging with. Establish yourself as the adtech platform for the fast web and join the hundreds of technology platforms currently supporting the open source AMP ecosystem."
+msgstr ""
+
+msgid "The average mobile site takes 19 seconds to load over a 3G connection. Coupled with the fact that conversions fall by 12% for every additional second a webpage takes to load, you can safely assume two things: speed equals performance, and most advertiser campaigns have room to improve. That’s where you come in. As an SSP, DSP, analytics provider, or anything in between, embracing speed means improving campaign performance, delivering quality user experiences, and establishing yourself as the adtech platform for the fast web. Join the hundreds of technology platforms currently supporting the open source AMP ecosystem. "
+msgstr ""
+
+msgid "AMP offers a way for you to give users a faster experience everywhere: on ads, landing pages or on your entire website. AMP ads help users engage with your brand and improve the performance of your campaigns. When your target audience lands on an AMP page, they get what they’re looking for in the moment they’re looking for it. The net result – they’re more likely to be engaged with and receptive to your brand’s messages, and more likely to take the actions you’re guiding them towards like completing a purchase."
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Google Web Designer"
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:96
+msgid "Increased in-mail capabilities"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:100
+msgid "Safe and secure"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:106
+msgid "Consistency and scalability"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:89
+msgid "Increased personalization"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:90
+msgid "Interactive customer experience"
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:93
+msgid "Improved and smarter services"
+msgstr ""
+
+msgid "Senders can include AMP components inside rich, engaging emails, making them dynamic and interactive. Users can engage with content and quickly take action such as RSVP to events, fill out questionnaires and personalize their content. AMP emails are always up to date and can function like digests, with fewer clicks necessary to achieve efficient results."
+msgstr ""
+
+msgid "AMP for email has no arbitrary 3rd party features to limit security issues, and far surpasses the capabilities currently provided by third party providers. Ad components are not allowed in AMP email, keeping users safe. To maintain users’ expectations of security and privacy, only a conservative subset of AMP functionality will be allowed."
+msgstr ""
+
+msgid "Embedding AMP within an email is simple, add a new MIME part with a content type of text/x-amp-html as a descendant of multipart/alternative. It should live alongside the existing text/html or text/plain parts. This ensures that the email message works on all clients."
+msgstr ""
+
+msgid "AMP for email allows exciting smarter and efficient user engagement, as customers can take action directly within their email such as managing their subscriptions, responding to polls, doodles, and bookings. This is possible because the server retrieves fresh content from remote endpoints, keeping email up to date."
+msgstr ""
+
+msgid "AMP Email’s expanding capabilities allows you to take action right inside your Inbox. This includes carousels and accordions, and taking user input on forms and questionnaires."
+msgstr ""
+
+msgid "AMP email allows an attractive option for promotional and subscriber-list emails. Through smarter engagement you can improve customer satisfaction through hassle-free feedback and subscription management all within their inbox."
+msgstr ""
+
+msgid "JavaScript is powerful, it can modify just about every aspect of the page, but it can also block DOM construction and delay page rendering (see also <a href=\"https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript\">Adding interactivity with JavaScript</a>). To keep JavaScript from delaying page rendering, AMP allows only asynchronous JavaScript."
+msgstr ""
+
+msgid "AMP uncouples document layout from resource layout. Only one HTTP request is needed to layout the entire doc (<a href=\"#font-triggering-must-be-efficient\">+fonts</a>). Since AMP is optimized to avoid expensive style recalculations and layouts in the browser, there won’t be any re-layout when resources load."
+msgstr ""
+
+msgid "Any page that uses a custom script must tell the AMP system that it will eventually have a custom tag. For example, the <a href=\"../documentation/components/reference/amp-iframe.md\"><code>amp-iframe</code></a> script tells the system that there will be an <code>amp-iframe</code> tag. AMP creates the iframe box before it even knows what it will include:"
+msgstr ""
+
+msgid "AMP controls all resource downloads: it prioritizes resource loading, loading only what’s needed, and prefetches lazy-loaded resources."
+msgstr ""
+
+msgid "When AMP documents get prerendered for instant loading, only resources above the fold are actually downloaded. When AMP documents get prerendered for instant loading, resources that might use a lot of CPU (like third-party iframes) do not get downloaded."
+msgstr ""
+
+msgid "Not sure how to get started? In this tutorial, you’ll learn how to create a basic AMP HTML page, how to stage it and validate that it’s AMP compliant, and finally ..."
+msgstr ""
+
+msgid "In this tutorial, you'll learn how to use data binding and expressions to build awesome, interactive AMP pages with amp-bind ..."
+msgstr ""
+
+msgid "Styling and layout on AMP HTML pages is very similar to normal HTML pages – in both cases, you'll use CSS."
+msgstr ""
+
+msgid "The facilitator of {name} is: "
+msgstr ""
+
+msgid "Working Group"
+msgstr ""
+
+msgid "AMP for Email"
+msgstr ""
+
+msgid "wg-amp4email Working Group is responsible for the development and maintenance of the AMP for Email specification and related features."
+msgstr ""
+
+msgid "<a href={{ doc.html_url }} target=\"_blank\" rel=\"noopener\">The GitHub Team</a> also includes { name } WG members."
+msgstr ""
+
+msgid "We’ll cover a lot of ground in the few hours we have together. To enable you to build full-fledged AMP sites, the roadshow will deep dive into four big pillars:"
+msgstr ""
+
+msgid "Learn more"
+msgstr ""
+
+msgid "Design"
+msgstr ""
+
+msgid "AMP as canonical site"
+msgstr ""
+
+msgid "Responsive design"
+msgstr ""
+
+msgid "New AMP Effects"
+msgstr ""
+
+msgid "New AMP UI components"
+msgstr ""
+
+msgid "Interactivity"
+msgstr ""
+
+msgid "State management (amp-bind)"
+msgstr ""
+
+msgid "Live data"
+msgstr ""
+
+msgid "Forms & autocomplete"
+msgstr ""
+
+msgid "Selections"
+msgstr ""
+
+msgid "DevOps"
+msgstr ""
+
+msgid "Deploying AMP"
+msgstr ""
+
+msgid "AMP in your favorite CMS"
+msgstr ""
+
+msgid "SEO & Discovery"
+msgstr ""
+
+msgid "AMP & PWA"
+msgstr ""
+
+msgid "Monetization"
+msgstr ""
+
+msgid "AMP for Landing Pages"
+msgstr ""
+
+msgid "Integrating ads"
+msgstr ""
+
+msgid "Analytics"
+msgstr ""
+
+msgid "Paywalls & Payments"
+msgstr ""
+
+msgid "AMP Websites"
+msgstr ""
+
+msgid "You can use CSS to customize your styling and dynamic data to fetch the freshest data where needed."
+msgstr ""
+
+msgid "AMP pages load near instantly – across all devices and platforms."
+msgstr ""
+
+#: /content/amp-dev/about/ads.html:59
+msgid "AMP is fundamentally changing the way ads are built, delivered and measured on the web, making them faster and minimizing disruptions for users. This increases viewability and click-through rates to improve monetization, making everyone happy: users, publishers and advertisers alike."
+msgstr ""
+
+#: pages/shared/data/benefits.yaml:27
+msgid "Building AMP pages is easy"
+msgstr ""
+
+msgid "Increase in revenue"
+msgstr ""
+
+msgid "Triplelift and Cloudflare boost Time Inc.’s revenue with AMP Ads"
+msgstr ""
+
+msgid "AMP Email"
+msgstr ""
+
+msgid "Create your first AMP page"
+msgstr ""
+
+msgid "Musement’s mobile-first design helps users navigate 70% faster"
+msgstr ""
+
+msgid "To provide their blog content in a more attractive format, Ameba launched their article landing pages as AMP Stories"
+msgstr ""
+
+msgid "Complex Networks drives a 3x revenue increase with AMP"
+msgstr ""
+
+msgid "AARP increases mobile conversion rate by 15% with AMP"
+msgstr ""
+
+msgid "KG Media’s AMP optimizations results"
+msgstr ""
+
+msgid "Asahi.com uses a paired AMP approach for their free articles"
+msgstr ""
+
+msgid "RCS MediaGroup reports good news with AMP and PWA"
+msgstr ""
+
+msgid "Advance Create boosting ads landing pages with AMP"
+msgstr ""
+
+msgid "Times of India reports 1.5X more revenue yields, 3.6X faster load time with AMP"
+msgstr ""
+
+msgid "greenslips.com.au boosts conversions by 12-15%, mobile speed by 15% with AMP"
+msgstr ""
+
+msgid "Tokopedia boosts mobile performance with AMP and PWA"
+msgstr ""
+
+msgid "Readwhere provides seamless mobile content via AMP and PWA"
+msgstr ""
+
+msgid "DiscoverCarHire.com drives conversions with faster mobile page load times via AMP"
+msgstr ""
+
+msgid "Jagran New Media boosts traffic by 115% and revenue by 4.5X by expanding AMP strategy"
+msgstr ""
+
+msgid "Renovation Brands improves speed and site duration with AMP"
+msgstr ""
+
+msgid "Metromile lowers costs, reaches more potential customers with AMP"
+msgstr ""
+
+msgid "Carved increases conversion rate by 75% with AMP and PWA"
+msgstr ""
+
+msgid "TransUnion scores more conversions with faster page loads via AMP"
+msgstr ""
+
+msgid "The story of the all-new BMW.com"
+msgstr ""
+
+msgid "Innkeeper’s Advantage helps B&Bs book guests quicker with AMP"
+msgstr ""
+
+msgid "Grupo Expansión boosts monetization with AMP"
+msgstr ""
+
+msgid "Merchology increases conversions, lowers load times with AMP"
+msgstr ""
+
+msgid "Eski.mobi serves businesses going mobile with AMP"
+msgstr ""
+
+msgid "Faster page loads with AMP deliver truckloads of new drivers to U.S. Xpress"
+msgstr ""
+
+msgid "Event Tickets Center significantly boosts conversions with AMP"
+msgstr ""
+
+msgid "ConsumersAdvocate.org boosts site performance with AMP"
+msgstr ""
+
+msgid "Fastcommerce drives conversions for clients by building AMP-first"
+msgstr ""
+
+msgid "Leading French organic retailer doubles mobile conversions with AMP"
+msgstr ""
+
+msgid "CNBC sees mobile speed and engagement gains with AMP"
+msgstr ""
+
+msgid "Wego.com increases mobile conversion rates 95% with AMP"
+msgstr ""
+
+msgid "India’s leading rental site improved owner-to-renter connections by 77% with AMP"
+msgstr ""
+
+msgid "WompMobile consistently improves e-commerce clients’ conversion rates with AMP sites"
+msgstr ""
+
+msgid "Terra drives mobile viewership up with AMP"
+msgstr ""
+
+msgid "Milestone drives conversions with AMP pages for local hospitality site"
+msgstr ""
+
+msgid "Hearst integrates key partner and product solutions on AMP"
+msgstr ""
+
+msgid "Wired AMP’s its 20+ year archive to meet audiences online"
+msgstr ""
+
+msgid "Slate gets efficient with AMP"
+msgstr ""
+
+msgid "Relay Media helps publishers get AMP’d"
+msgstr ""
+
+msgid "plista grows publisher revenue & user engagement with AMP"
+msgstr ""
+
+msgid "Vision"
+msgstr ""
+
+msgid "Mission"
+msgstr ""
+
+msgid "Choose your destination"
+msgstr ""
+
+msgid "Throughout the AMP documentation you will find a switch on the upper left side to quickly change the AMP format you’re working on."
+msgstr ""
+
+msgid "CMS User?"
+msgstr ""
+
+msgid "AMP integrates with many publishing platforms and content management systems! Find the full list under <a href=\"../support/faq/platform-and-vendor-partners.md\">Platform and Vendor Partners.</a>"
+msgstr ""
+
+msgid "Featured Videos"
+msgstr ""
+
+msgid "Get Involved"
+msgstr ""
+
+msgid "AMP is proudly an open source project with an active community of contributors. We welcome and appreciate documentation and translation contributions! Check out our community section to join our mission."
+msgstr ""
+
+msgid "The AMP Project is an open source initiative to protect the future of the web by delivering a better, faster and more user-friendly experience."
+msgstr ""
+
+msgid "AMP<br> Ads"
+msgstr ""
+
+msgid "Intro + Keynote"
+msgstr ""
+
+msgid "AMP: A library for rich content experiences"
+msgstr ""
+
+msgid "Advanced interactivity with AMP"
+msgstr ""
+
+msgid "Tutorial: Your first AMP site!"
+msgstr ""
+
+msgid "Creating an excellent AMP"
+msgstr ""
+
+msgid "Letting your AMP into the world"
+msgstr ""
+
+msgid "Lunch"
+msgstr ""
+
+msgid "Mystery talk"
+msgstr ""
+
+msgid "AMP everywhere"
+msgstr ""
+
+msgid "What’s next in AMP"
+msgstr ""
+
+msgid "Coffee break"
+msgstr ""
+
+msgid "Q&A with AMP team"
+msgstr ""
+
+msgid "Tutorial: Do more with AMP"
+msgstr ""
+
+msgid "Happy hour"
+msgstr ""
+
+#: /content/amp-dev/about/websites.html:243
+msgid "AMP Caches"
+msgstr ""
+
+msgid "AMP for Email Working Group members will use <code>#wg-amp4email</code> channel on AMP's Slack (<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877\">signup</a>) for real-time discussion. The channel is open to anyone, regardless of membership in AMP for Email working group."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Announcements and Notices</strong> regarding events as an issue labeled with <code>Type: Event</code> in this repository."
+msgstr ""
+
+msgid "AMP for Email Working Group will post <strong>Quarterly Roadmap</strong> as an issue labeled with <code>Type: Roadmap</code> in this repository"
+msgstr ""
+
+#: /content/amp-dev/index.html:289
+msgid "AMP is an open-source HTML framework that provides a straightforward way to create web pages that are fast, smooth-loading and prioritize the user-experience above all else. Can't believe it? Try it out for yourself in the playground below:"
+msgstr ""
+
+msgid "AMP’s Working Groups are:"
+msgstr ""
+
+msgid "Style & layout"
+msgstr ""
+
+msgid "UI Working Group will post <strong>Status Updates</strong> every two weeks as an issue labeled with <code>Type: Status Update</code> in this repository."
+msgstr ""
+
+msgid "offline"
+msgstr ""
+
+msgid "Learn Web Development with AMP"
+msgstr ""
+
+msgid "AMP can help you create fast websites more quickly!"
+msgstr ""
+
+msgid "If you’re <b>an experienced web developer</b>, you can create rich, fast sites with less code."
+msgstr ""
+
+msgid "If you’re <b>a new web developer</b>, AMP helps you learn web development. If you know some HTML and CSS, you can use AMP to make an interactive website!"
+msgstr ""
+
+msgid "About the courses"
+msgstr ""
+
+msgid "These three free courses are in use in schools and training programs around the world. Now you can take them here, online, on our site. Suitable for beginners and experienced web developers alike, they will take you from zero to AMP!"
+msgstr ""
+
+msgid "During this course, you’ll build a sample site for Chico’s famous, and fictional, Cheese Bicycles."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid "Internet connection"
+msgstr ""
+
+msgid "<a href=\"https://www.google.com/chrome/\" target=\"_blank\">Chrome browser</a>, ideally, to use the <a href=\"https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc\" target=\"_blank\">AMP Validator extension</a>"
+msgstr ""
+
+msgid "We use the online editor <a href=\"https://glitch.com/\" target=\"_blank\">Glitch</a>. No IDE or local web server needed!"
+msgstr ""
+
+msgid "Prerequisites"
+msgstr ""
+
+msgid "basic knowledge of HTML and CSS"
+msgstr ""
+
+msgid "for the advanced course, JavaScript expressions and simple JSON"
+msgstr ""
+
+msgid "Take the Video Courses"
+msgstr ""
+
+msgid "All three courses can be now be taken by video on <a href=\"https://www.youtube.com/playlist?list=PLXTOW_XMsIDS45GB-eBV5s_M9EGIXMjI_\" target=\"_blank\">our YouTube channel!</a>"
+msgstr ""
+
+msgid "AMP Websites Examples"
+msgstr ""
+
+msgid "AMP Playground"
+msgstr ""
+
+msgid "Try it yourself with the AMP Playground. Test your ideas directly in the browser and get instant feedback."
+msgstr ""
+
+msgid "Filter by category"
+msgstr ""
+
+msgid "<h1 class=\"ap-o-stage-content-headline\">Tools</h1> <h2 class=\"ap-o-stage-content-subline\">for creation, design and development</h2>"
+msgstr ""
+
+msgid "Creation &amp; Design"
+msgstr ""
+
+msgid "CMS &amp; Platforms"
+msgstr ""
+
+msgid "Developer Tools"
+msgstr ""
+
+msgid "Service providers"
+msgstr ""
+
+msgid "Here you can find everything you need to build AMP experiences."
+msgstr ""
+
+msgid "The complete documented AMP library and its references."
+msgstr ""
+
+msgid "The fastest way to learn is to peak over the tangible examples."
+msgstr ""
+
+msgid "Don't want to start from scratch? Start with a ready-made design."
+msgstr ""
+
+msgid "Begin building for creation, design and development."
+msgstr ""
+
+msgid "Build your first AMP Website"
+msgstr ""
+
+msgid "Build your first AMP Story"
+msgstr ""
+
+msgid "Build your first AMP Ad"
+msgstr ""
+
+msgid "Build your first AMP Email"
+msgstr ""
+
+msgid "Create compelling, silky smooth and instant loading websites."
+msgstr ""
+
+msgid "Create snackable, immersive and tappable stories on your website."
+msgstr ""
+
+msgid "Extend your website with fast and lightweight ad experience."
+msgstr ""
+
+msgid "Create emails that encourage readers to interact dynamically with content."
+msgstr ""
+
+msgid "See the latest videos about AMP and find out more on our <a href=\"https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw">YouTube Channel.</a>"
+msgstr ""
+
+msgid "CMS"
+msgstr ""
+
+msgid "Content Platform"
+msgstr ""
+
+msgid "Debugging"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Email Service"
+msgstr ""
+
+msgid "Email Templates Editor"
+msgstr ""
+
+msgid "Essential"
+msgstr ""
+
+msgid "Landing pages"
+msgstr ""
+
+msgid "Optimization"
+msgstr ""
+
+msgid "Testing"
+msgstr ""
+
+msgid "Allows the creation of rich, eye-catching marketing content with Adobe Animate."
+msgstr ""
+
+msgid "Create interactive email templates fast with Drag-n-Drop & HTML editor. Try free library of ready-to-use modules and templates."
+msgstr ""
+
+msgid "Create AMPHTML-valid and ready to be published individual designs or full sets of static or animated marketing visuals, within minutes."
+msgstr ""
+
+msgid "Online AMPHTML banner maker which allows you to easily create AMP ads without prior coding knowledge."
+msgstr ""
+
+msgid "Create engaging, interactive AMPHTML Ad compliant designs and motion graphics that can run on any device."
+msgstr ""
+
+msgid "Instapage automates the creation, optimization, and personalization of post-click experiences at scale."
+msgstr ""
+
+msgid "WYSIWYG drag and drop editor with templates, illustrations, icons, and the ability to upload your own images and videos."
+msgstr ""
+
+msgid "Newsroom Studio helps you create engaging, instant loading mobile experiences."
+msgstr ""
+
+msgid "Unbounce is a platform to create landing pages, website popups, and sticky bars."
+msgstr ""
+
+msgid "AMP-first content creation with the power and flexibility of WordPress."
+msgstr ""
+
+msgid "Bold by Quintype is a headless CMS built for enterprise publishers with built-in support for AMP."
+msgstr ""
+
+msgid "Helps you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results."
+msgstr ""
+
+msgid "Test if and how your AMP page appears in Google Search."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Build AMP sites, posts, and stories. Win search, social, and email. Fast. Flexible. Secure. Modern."
+msgstr ""
+
+msgid "Platform to share and discover how-to stories that includes a creation tool on your phone to help you create how-to stories."
+msgstr ""
+
+msgid "Essential component for AMP development and available in a variety of versions."
+msgstr ""
+
+msgid "Beta-test new features of AMP before they're available for everyone."
+msgstr ""
+
+msgid "Helps you find out whether your Google Analytics and AdWords tracking is correctly set up."
+msgstr ""
+
+msgid "A collection of AMP tools making it easier to publish and host AMP pages."
+msgstr ""
+
+msgid "Validation tool that offers additional debug information on top of the AMP validator."
+msgstr ""
+
+msgid "Pre-built Google Analytics dashboard template that helps you get to your analytics insights faster."
+msgstr ""
+
+msgid "Chrome extension that helps you understand the feasibility of converting your site to AMP."
+msgstr ""
+
+msgid "Generate custom templates for your AMP websites, stories, emails or ads."
+msgstr ""
+
+msgid "Start prototyping in an interactive online editor with the ability to use templates and our examples."
+msgstr ""
+
+msgid "A prototyping tool that automatically converts a HTML page to AMP for demonstrating performance gains with AMP."
+msgstr ""
+
+msgid "Litmus makes it easy to build, test, and monitor every email for the best results."
+msgstr ""
+
+msgid "Makes authoring AMP easy by validating for errors/warnings as you type within VS Code."
+msgstr ""
+
+msgid "React framework that generates AMP and PWA pages from a single codebase."
+msgstr ""
+
+msgid "A tool to help for prototyping ads to be served in AMP Stories. Choose from pre-existing templates to get started."
+msgstr ""
+
+msgid "NodemailerApp is an email debugging app that includes a local SMTP server and renders AMP for Email emails."
+msgstr ""
+
+msgid "Cloud-based email sending service designed to help digital marketers and application developers send emails."
+msgstr ""
+
+msgid "Aweber's platform and API allows you to create and send emails your customers will love."
+msgstr ""
+
+msgid "Pepipost is an innovative transactional email solution that offers you with a streamlined user experience that you only get from high-end premium software. The software is designed to ensure that your emails are sent to your recipients' inbox and not get mixed and lost in spam and other folders."
+msgstr ""
+
+msgid "Delivery and Analytics for Better Email Performance."
+msgstr ""
+
+msgid "Reach customers using a flexible email API and marketing tools to increase customer engagement."
+msgstr ""
+
+msgid "Mailgun's leading API-based email delivery service allows you to send dynamic email effortlessly."
+msgstr ""
+
+msgid "Clang is a complete omnichannel marketing platform for email marketing and marketing automation."
+msgstr ""
+
+msgid "Effective Newsletter Software for more conversions and revenue"
+msgstr ""
+
+msgid "Send interactive emails using SendPulse email editor or API."
+msgstr ""
+
+msgid "Supercharge conversions of your bulk and triggered campaigns with real-time recommendations in AMP powered emails"
+msgstr ""
+
+msgid "Adobe Campaign Classic brings email to life with AMP"
+msgstr ""
+
+msgid "Copernica is a tool to create automated email campaigns with an powerful drag & drop editor."
+msgstr ""
+
+msgid "WompMobile is an Accelerator Platform to develop, validate, launch and manage AMP experiences. Built-in tools monitor for errors, ensure validation, purge the AMP cache, and create Signed-Exchange and Server-Side-Rendered AMPs."
+msgstr ""
+
+msgid "The AMP Project Roadmap"
+msgstr ""
+
+msgid "This is a high level overview suitable for all audiences. For a more detailed developer view, <a href=\"https://github.com/ampproject/amphtml/projects/43">head to GitHub.</a>"
+msgstr ""
+
+msgid "AMP Story"
+msgstr ""
+
+msgid "Ads"
+msgstr ""
+
+msgid "Audio&Video"
+msgstr ""
+
+msgid "Dynamic/Personalized Content"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "In Development"
+msgstr ""
+
+msgid "Next Up"
+msgstr ""
+
+msgid "PWA"
+msgstr ""
+
+msgid "Runtime"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Tooling"
+msgstr ""
+
+msgid "User Input"
+msgstr ""
+
+msgid "Validator"
+msgstr ""
+
+msgid "You can often convert your entire archive in days – especially when using common CMS like Wordpress or Drupal."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Learn AMP"
+msgstr ""
+
+msgid "Teach AMP"
+msgstr ""
+
+msgid "Stories"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
+msgid "Art & Design"
+msgstr ""
+
+msgid "Food & Drink"
+msgstr ""
+
+msgid "News & Blog"
+msgstr ""
+
+msgid "Story Ads"
+msgstr ""
+
+msgid "AMP for WordPress"
+msgstr ""
+
+msgid "Bold by Quintype"
+msgstr ""
+
+msgid "Google Search Console"
+msgstr ""
+
+msgid "Google AMP Test"
+msgstr ""
+
+msgid "AMP Validator"
+msgstr ""
+
+msgid "Experiment Configurator"
+msgstr ""
+
+msgid "AMP Tag Test"
+msgstr ""
+
+msgid "AMP Toolbox"
+msgstr ""
+
+msgid "AMP Bench"
+msgstr ""
+
+msgid "AMP Insights"
+msgstr ""
+
+msgid "AMP REadiness"
+msgstr ""
+
+msgid "AMP Boilerplate Generator"
+msgstr ""
+
+msgid "AMP Prototyper"
+msgstr ""
+
+msgid "VS Code Extension"
+msgstr ""
+
+msgid "React Storefront"
+msgstr ""
+
+msgid "Access & Subscriptions"
+msgstr ""
+
+msgid "Outreach"
+msgstr ""
+
+msgid "Caching"
+msgstr ""
+
+msgid "Gallery"
+msgstr ""
+
+msgid "Bike Shop"
+msgstr ""
+
+msgid "Travel"
+msgstr ""
+
+msgid "Simple Blog"
+msgstr ""
+
+msgid "Simple Article"
+msgstr ""
+
+msgid "Video"
+msgstr ""
+
+msgid "Text Only"
+msgstr ""
+
+msgid "Select your format for a more streamlined experience"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""
+
+msgid "Code of Conduct"
+msgstr ""
+
+msgid "Performance"
+msgstr ""
+
+msgid "User Interface"
+msgstr ""
+
+msgid "Viewers"
+msgstr ""
+
+msgid "Presentation"
+msgstr ""

--- a/platform/config/build-info.yaml
+++ b/platform/config/build-info.yaml
@@ -1,7 +1,12 @@
 number: null
-at: 2019-07-15T08:03:12.456Z
-by: Sebastian Benz
-environment: production
+at: 2020-02-01T02:26:30.748Z
+by: Patrick Kettner
+environment: local
 commit:
-  sha: 7b1b22b844ec7c04da2e51b8fc6d847959ae9a0a
-  message: "✨ Migrate oauth backend (#2392)\n\n* ✨ Migrate oauth backend\r\n\r\n* ♻️ Merge handlers into one\r\n\r\n* ♻️ Use async/await pattern\r\n\r\n* ♻️ Remove try/catch block"
+  sha: eb0c54d29
+  message: |-
+    Properly extract strings for i18n on non documentation pages
+
+    this ia part of hte ongoing i18n ramp up. this (should) go though
+    everything that is not a part of documentation pages, and ensure that
+    any user visible strings are going through the gettext i18n process


### PR DESCRIPTION
this is part of the ongoing i18n ramp up. this (should) be going though everything that is not a part of documentation pages, and ensure that any user visible strings are going through the gettext i18n process

cc @CrystalOnScript @sebastianbenz 