### PR TITLE
🔥 Escape all HTML inserted into title tags

### DIFF
--- a/frontend/templates/layouts/example-pages/amp-ads-page.j2
+++ b/frontend/templates/layouts/example-pages/amp-ads-page.j2
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
 {% if not example.has_tag_in_head('title') %}
-  <title>{{export.title|e}} - {{_('Example')}} {{example.index}}</title>
+  <title>{{export.title|e}} - {{_('Example')|e}} {{example.index|e}}</title>
 {% else %}
   <title>{{example.get_tag_content(example.head, 'title')|e}}</title>
 {% endif %}

--- a/frontend/templates/layouts/example-pages/amp-stories-page.j2
+++ b/frontend/templates/layouts/example-pages/amp-stories-page.j2
@@ -6,7 +6,7 @@
   <meta charset="utf-8">
 {% endif %}
 {% if not example.has_tag_in_head('title') %}
-  <title>{{export.title|e}} - {{_('Example')}} {{example.index}}</title>
+  <title>{{export.title|e}} - {{_('Example')|e}} {{example.index|e}}</title>
 {% endif %}
 {% if not example.has_amp_script() %}
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/frontend/templates/layouts/example-pages/amp-websites-page.j2
+++ b/frontend/templates/layouts/example-pages/amp-websites-page.j2
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
 {% endif %}
 {% if not example.has_tag_in_head('title') %}
-  <title>{{export.title|e}} - {{_('Example')}} {{example.index}}</title>
+  <title>{{export.title|e}} - {{_('Example')|e}} {{example.index|e}}</title>
 {% endif %}
 {% if not example.has_amp_script() %}
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/frontend/templates/views/examples/embed-ads.j2
+++ b/frontend/templates/views/examples/embed-ads.j2
@@ -14,7 +14,7 @@
       }
     </style>
     <link rel="canonical" href="{{ canonical }}">
-    <title>{{ title }}</title>
+    <title>{{ title|e}}</title>
   </head>
   <body>
     <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>

--- a/frontend/templates/views/partials/structured-data.j2
+++ b/frontend/templates/views/partials/structured-data.j2
@@ -60,7 +60,7 @@
 {% set title_prefix = _('Success Story: ') %}
 {% endif %}
 
-<title>{{ title_prefix }}{{ title }} - amp.dev</title>
+<title>{{title_prefix|e}}{{title|e}} - amp.dev</title>
 
 {% if description %}
 <meta name="description" content="{{ description }}">
@@ -103,7 +103,7 @@
 {% if description %}
 <meta name="twitter:description" content="{{ description }}">
 {% endif %}
-<meta name="twitter:title" content="{{ title_prefix }}{{ title }}">
+<meta name="twitter:title" content="{{ title_prefix|e }}{{ title|e|replace("&lt;", "")|replace("&gt;", "") }}">
 <meta name="twitter:creator" content="@ampproject">
 <meta name="twitter:site" content="@ampproject">
 <meta name="twitter:image" content="{{ base_url }}{{ sharing_images.wide }}">

--- a/frontend/templates/views/partials/structured-data.j2
+++ b/frontend/templates/views/partials/structured-data.j2
@@ -103,7 +103,7 @@
 {% if description %}
 <meta name="twitter:description" content="{{ description }}">
 {% endif %}
-<meta name="twitter:title" content="{{ title_prefix|e }}{{ title|e|replace("&lt;", "")|replace("&gt;", "") }}">
+<meta name="twitter:title" content="{{ title_prefix|e }}{{ title|e|replace('&lt;'', '')|replace('&gt;'', '') }}">
 <meta name="twitter:creator" content="@ampproject">
 <meta name="twitter:site" content="@ampproject">
 <meta name="twitter:image" content="{{ base_url }}{{ sharing_images.wide }}">


### PR DESCRIPTION
Untested, but hopefully the CI will be able to do that.

Fixes: #3472
Refs:
> Escaping works by piping the variable through the |e filter:
>```jinja
> {{ user.username|e }}
> ```
> — [Template Designer Documentation &#8212; Jinja Documentation (2.11.x)](https://jinja.palletsprojects.com/en/2.11.x/templates/#working-with-manual-escaping)