### PR TITLE
🔧 Fix filter order and quotes

### DIFF
--- a/frontend/templates/views/partials/structured-data.j2
+++ b/frontend/templates/views/partials/structured-data.j2
@@ -103,7 +103,7 @@
 {% if description %}
 <meta name="twitter:description" content="{{ description }}">
 {% endif %}
-<meta name="twitter:title" content="{{ title_prefix|e }}{{ title|e|replace('&lt;'', '')|replace('&gt;'', '') }}">
+<meta name="twitter:title" content="{{ title_prefix|e }}{{ title|replace('<', '')|replace('>', '')|e }}">
 <meta name="twitter:creator" content="@ampproject">
 <meta name="twitter:site" content="@ampproject">
 <meta name="twitter:image" content="{{ base_url }}{{ sharing_images.wide }}">


### PR DESCRIPTION
My mistake, the previous PR's quotes ended up getting repeated and the filter order was causing undesirable results. I've remedied this by changing the order of the filtering — this should be correct.