### PR TITLE
🐛 Build samples when bootstrapping

### DIFF
--- a/gulpfile.js/develop.js
+++ b/gulpfile.js/develop.js
@@ -29,7 +29,8 @@ function bootstrap(done) {
     build.buildComponentVersions,
     build.buildBoilerplate,
     build.buildPlayground,
-    build.importAll
+    build.importAll,
+    samplesBuilder.build
   )(done);
 }
 


### PR DESCRIPTION
First part of #3330. The application relies on `examples/static/samples/samples.json` to exist when starting up.