### PR TITLE
Set release-schedule visualization to layout:container

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule.html
@@ -7,7 +7,7 @@ $title: Release Schedule
 <p>This interactive calendar visualizes the process via which new code that is merged into the <a href="https://github.com/ampproject/amphtml">amphtml GitHub repository</a> progresses through time to reach publishers, developers, and end-users.</p>
 <p>For a detailed description of the various release channels, see <a href="/content/amp-dev/documentation/guides-and-tutorials/learn/spec/release-schedule.md">AMP Release Schedule</a>. There is also a <a href="./release-schedule-accessible.html">screen-reader accessible</a> version of this page.</p>
 
-<amp-script layout="container" width="1050" script="calendar-script">
+<amp-script layout="container" script="calendar-script">
   <div id="calendar" data-direction="initialized">
     <div class="box header">Week</div>
     <div class="box header day-sunday">Sunday</div>

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule.html
@@ -7,7 +7,7 @@ $title: Release Schedule
 <p>This interactive calendar visualizes the process via which new code that is merged into the <a href="https://github.com/ampproject/amphtml">amphtml GitHub repository</a> progresses through time to reach publishers, developers, and end-users.</p>
 <p>For a detailed description of the various release channels, see <a href="/content/amp-dev/documentation/guides-and-tutorials/learn/spec/release-schedule.md">AMP Release Schedule</a>. There is also a <a href="./release-schedule-accessible.html">screen-reader accessible</a> version of this page.</p>
 
-<amp-script layout="intrinsic" width="1050" height="0" script="calendar-script">
+<amp-script layout="container" width="1050" height="0" script="calendar-script">
   <div id="calendar" data-direction="initialized">
     <div class="box header">Week</div>
     <div class="box header day-sunday">Sunday</div>

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule.html
@@ -7,7 +7,7 @@ $title: Release Schedule
 <p>This interactive calendar visualizes the process via which new code that is merged into the <a href="https://github.com/ampproject/amphtml">amphtml GitHub repository</a> progresses through time to reach publishers, developers, and end-users.</p>
 <p>For a detailed description of the various release channels, see <a href="/content/amp-dev/documentation/guides-and-tutorials/learn/spec/release-schedule.md">AMP Release Schedule</a>. There is also a <a href="./release-schedule-accessible.html">screen-reader accessible</a> version of this page.</p>
 
-<amp-script layout="container" width="1050" height="0" script="calendar-script">
+<amp-script layout="container" width="1050" script="calendar-script">
   <div id="calendar" data-direction="initialized">
     <div class="box header">Week</div>
     <div class="box header day-sunday">Sunday</div>


### PR DESCRIPTION
Currently the [release schedule visualization](https://amp.dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule/) is broken. It has `layout="intrinsic" height="0"` which makes the `amp-script` render with a height of 0. This swaps the layout for `layout="container"`, allowing the children to determine the size of the `amp-script` tag. I'm not entirely certain that this is the "correct" use, but it resolves the issue (see below).

![image](https://user-images.githubusercontent.com/6694512/73954234-88df7f00-48cf-11ea-9a00-723d5c0e0edc.png)

> The above was seen by running `npm run develop` on my changes