### PR TITLE
Use fixed-height layout for calendar with desktop/mobile sizes

### DIFF
--- a/frontend/scss/components/organisms/release-schedule.scss
+++ b/frontend/scss/components/organisms/release-schedule.scss
@@ -7,7 +7,12 @@ body.amp-mode-touch .touch-only {
 body.amp-mode-touch .no-touch-only {
   display: none;
 }
-#calendar {
+// The AMP optimizer doesn't support the media attribute, so we hide whichever
+// calendar is not is not displayed with a media query.
+#calendar-container-mobile {
+  display: none;
+}
+.calendar {
   display: grid;
   gap: 10px;
   grid-template-columns: 5em repeat(7, 7.5em);
@@ -136,7 +141,7 @@ body.amp-mode-touch .no-touch-only {
   background-image: linear-gradient(225deg, #25b4ed 0%, #21c1fa 75%);
 }
 @media (max-width: 1465px) {
-  #calendar {
+  .calendar {
     gap: 5px;
     grid-template-columns: 4em repeat(7, 1fr);
   }
@@ -146,7 +151,13 @@ body.amp-mode-touch .no-touch-only {
   }
 }
 @media (max-width: 1101px) {
-  #calendar {
+  #calendar-container {
+    display: none;
+  }
+  #calendar-container-mobile {
+    display: block;
+  }
+  .calendar {
     grid-template-rows: auto 75px auto auto 75px 75px 75px auto auto 75px;
   }
   .box {
@@ -179,7 +190,7 @@ body.amp-mode-touch .no-touch-only {
   }
 }
 @media (max-width: 843px) {
-  #calendar {
+  .calendar {
     gap: 2px;
     grid-template-columns: 3em repeat(7, 1fr);
   }

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/vendor-contributions/release-schedule.html
@@ -7,8 +7,105 @@ $title: Release Schedule
 <p>This interactive calendar visualizes the process via which new code that is merged into the <a href="https://github.com/ampproject/amphtml">amphtml GitHub repository</a> progresses through time to reach publishers, developers, and end-users.</p>
 <p>For a detailed description of the various release channels, see <a href="/content/amp-dev/documentation/guides-and-tutorials/learn/spec/release-schedule.md">AMP Release Schedule</a>. There is also a <a href="./release-schedule-accessible.html">screen-reader accessible</a> version of this page.</p>
 
-<amp-script layout="container" script="calendar-script">
-  <div id="calendar" data-direction="initialized">
+<amp-script id="calendar-container" layout="fixed-height" height="1000" script="calendar-script">
+  <div class="calendar desktop" data-direction="initialized">
+    <div class="box header">Week</div>
+    <div class="box header day-sunday">Sunday</div>
+    <div class="box header day-monday">Monday</div>
+    <div class="box header day-tuesday">Tuesday</div>
+    <div class="box header day-wednesday">Wednesday</div>
+    <div class="box header day-thursday">Thursday</div>
+    <div class="box header day-friday">Friday</div>
+    <div class="box header day-saturday">Saturday</div>
+
+    <div class="box instructions week-1-instructions" data-week="1"><span class="touch-only">Tap</span><span class="no-touch-only">Hover</span> on days above to see when the code merged on that day will be available on each release channel</div>
+    <div class="box instructions week-5-instructions" data-week="5"><span class="touch-only">Tap</span><span class="no-touch-only">Hover</span> on days below to see when the latest code merge occurred so as to be included in each release channel</div>
+
+    <div class="box sidebar week-1" data-week="1">
+      <span class="top">N</span>
+      <span class="bottom">Last week of the previous month</span>
+    </div>
+    <div class="box sidebar week-2" data-week="2">
+      <span class="top">N+1</span>
+      <span class="bottom">N-3</span>
+    </div>
+    <div class="box sidebar week-3" data-week="3">
+      <span class="top">N+2</span>
+      <span class="bottom">N-2</span>
+    </div>
+    <div class="box sidebar week-4" data-week="4">
+      <span class="top">N+3</span>
+      <span class="bottom">N-1</span>
+    </div>
+    <div class="box sidebar week-5" data-week="5">
+      <span class="top">2<sup>nd</sup> week of the next month</span>
+      <span class="bottom">N</span>
+    </div>
+
+    <div class="box sidebar ellipsis ellipsis-top">⋮</div>
+
+    <div class="box ellipsis ellipsis-top">⋮</div>
+    <div class="box ellipsis ellipsis-top">⋮</div>
+    <div class="box ellipsis ellipsis-top">⋮</div>
+    <div class="box ellipsis ellipsis-top">⋮</div>
+    <div class="box ellipsis ellipsis-top">⋮</div>
+    <div class="box ellipsis ellipsis-top">⋮</div>
+    <div class="box ellipsis ellipsis-top">⋮</div>
+
+    <div class="box sidebar ellipsis ellipsis-bottom">⋮</div>
+
+    <div class="box ellipsis ellipsis-bottom">⋮</div>
+    <div class="box ellipsis ellipsis-bottom">⋮</div>
+    <div class="box ellipsis ellipsis-bottom">⋮</div>
+    <div class="box ellipsis ellipsis-bottom">⋮</div>
+    <div class="box ellipsis ellipsis-bottom">⋮</div>
+    <div class="box ellipsis ellipsis-bottom">⋮</div>
+    <div class="box ellipsis ellipsis-bottom">⋮</div>
+
+    <div class="box content week-1 day-sunday" data-week="1" data-day="sunday"></div>
+    <div class="box content week-1 day-monday" data-week="1" data-day="monday"></div>
+    <div class="box content week-1 day-tuesday" data-week="1" data-day="tuesday"></div>
+    <div class="box content week-1 day-wednesday" data-week="1" data-day="wednesday"></div>
+    <div class="box content week-1 day-thursday" data-week="1" data-day="thursday"></div>
+    <div class="box content week-1 day-friday" data-week="1" data-day="friday"></div>
+    <div class="box content week-1 day-saturday" data-week="1" data-day="saturday"></div>
+
+    <div class="box content week-2 day-sunday" data-week="2" data-day="sunday"></div>
+    <div class="box content week-2 day-monday" data-week="2" data-day="monday"></div>
+    <div class="box content week-2 day-tuesday" data-week="2" data-day="tuesday"></div>
+    <div class="box content week-2 day-wednesday" data-week="2" data-day="wednesday"></div>
+    <div class="box content week-2 day-thursday" data-week="2" data-day="thursday"></div>
+    <div class="box content week-2 day-friday" data-week="2" data-day="friday"></div>
+    <div class="box content week-2 day-saturday" data-week="2" data-day="saturday"></div>
+
+    <div class="box content week-3 day-sunday" data-week="3" data-day="sunday"></div>
+    <div class="box content week-3 day-monday" data-week="3" data-day="monday"></div>
+    <div class="box content week-3 day-tuesday" data-week="3" data-day="tuesday"></div>
+    <div class="box content week-3 day-wednesday" data-week="3" data-day="wednesday"></div>
+    <div class="box content week-3 day-thursday" data-week="3" data-day="thursday"></div>
+    <div class="box content week-3 day-friday" data-week="3" data-day="friday"></div>
+    <div class="box content week-3 day-saturday" data-week="3" data-day="saturday"></div>
+
+    <div class="box content week-4 day-sunday" data-week="4" data-day="sunday"></div>
+    <div class="box content week-4 day-monday" data-week="4" data-day="monday"></div>
+    <div class="box content week-4 day-tuesday" data-week="4" data-day="tuesday"></div>
+    <div class="box content week-4 day-wednesday" data-week="4" data-day="wednesday"></div>
+    <div class="box content week-4 day-thursday" data-week="4" data-day="thursday"></div>
+    <div class="box content week-4 day-friday" data-week="4" data-day="friday"></div>
+    <div class="box content week-4 day-saturday" data-week="4" data-day="saturday"></div>
+
+    <div class="box content week-5 day-sunday" data-week="5" data-day="sunday"></div>
+    <div class="box content week-5 day-monday" data-week="5" data-day="monday"></div>
+    <div class="box content week-5 day-tuesday" data-week="5" data-day="tuesday"></div>
+    <div class="box content week-5 day-wednesday" data-week="5" data-day="wednesday"></div>
+    <div class="box content week-5 day-thursday" data-week="5" data-day="thursday"></div>
+    <div class="box content week-5 day-friday" data-week="5" data-day="friday"></div>
+    <div class="box content week-5 day-saturday" data-week="5" data-day="saturday"></div>
+  </div>
+</amp-script>
+
+<amp-script id="calendar-container-mobile" layout="fixed-height" height="550" script="calendar-script">
+  <div class="calendar mobile" data-direction="initialized">
     <div class="box header">Week</div>
     <div class="box header day-sunday">Sunday</div>
     <div class="box header day-monday">Monday</div>
@@ -250,8 +347,11 @@ $title: Release Schedule
 
         const selectedWeek = elm.getAttribute('data-week');
         const selectedDay = elm.getAttribute('data-day');
-        document.querySelector('#calendar')
-          .setAttribute('data-direction', selectedWeek == '1' ? 'top' : 'bottom');
+        document.querySelectorAll('.calendar').forEach(el => {
+          el.setAttribute(
+            'data-direction',
+            selectedWeek == '1' ? 'top' : 'bottom');
+        });
 
         event.currentTarget.textContent = descriptions[selectedWeek].selected;
         for (let [channel, [channelWeek, channelDay]] of Object.entries(channels[selectedWeek][selectedDay])) {


### PR DESCRIPTION
The original implementation used `layout="intrinsic" height="0"` for the `amp-script` container element. A series of recent bug fixes fixed how `amp-script` works with `layout="intrinsic"`, and this broke the page by setting the container's height to 0.

This PR doubles up the `amp-script` tag and defines each as a `fixed-height` layout based on the grid sizes for desktop and mobile views. A CSS media query controls which one is displayed. Tested on desktop and emulated mobile; confirmed valid AMP with AMP Validator Chrome Extension.