### PR TITLE
🎨 Make language selector in header optional

### DIFF
--- a/frontend/scss/components/molecules/language-selector.scss
+++ b/frontend/scss/components/molecules/language-selector.scss
@@ -15,7 +15,6 @@
 
 .#{molecule('language-selector')} {
   position: relative;
-  margin-left: auto;
   margin-right: 20px;
   padding-bottom: 10px;
   display: none;

--- a/frontend/scss/components/organisms/header.scss
+++ b/frontend/scss/components/organisms/header.scss
@@ -65,6 +65,7 @@
     top: 10px;
     display: flex;
     align-items: center;
+    margin-right: auto;
     padding-bottom: 10px;
     overflow: hidden;
 

--- a/frontend/templates/views/partials/header.j2
+++ b/frontend/templates/views/partials/header.j2
@@ -94,6 +94,9 @@
       </div>
     </div>
 
+    {# blog.amp.dev shares the header with amp.dev but isn't localized.
+       Therefore it's nice to have a way to turn off the language selector #}
+    {% if language_selector != False %}
     {% do doc.styles.addCssFile('/css/components/molecules/language-selector.css') %}
     <div class="ap-m-language-selector">
       <span class="ap-m-language-selector-label" aria-label="{{ _('Select a language') }}" tabindex="-1">
@@ -111,5 +114,6 @@
         {% endfor %}
       </div>
     </div>
+    {% endif %}
   </div>
 </header>

--- a/pages/content/shared/header.html
+++ b/pages/content/shared/header.html
@@ -8,6 +8,8 @@ $sitemap:
   </defs>
 </svg>
 
+{% with language_selector = False %}
 {% include 'views/partials/header.j2' %}
+{% endwith %}
 {% include 'views/partials/burger-menu.j2' %}
 {% include 'views/partials/search.j2' %}


### PR DESCRIPTION
Part of the fixes for https://github.com/ampproject/amp.dev/issues/3152#issuecomment-568150532.

The language selector doesn't render for the [shared header fragment](https://amp.dev/shared/header/) and it being absent doesn't interfer with the styling of the other elements anymore.