### PR TITLE
🎨 Ensure shared pages and pages router behave the same

### DIFF
--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -39,7 +39,7 @@ const routers = {
   go: require('@lib/routers/go.js'),
   growSharedPages: require('@lib/routers/growSharedPages.js'),
   growXmls: require('@lib/routers/growXmls.js'),
-  growPages: require('@lib/routers/growPages.js'),
+  growPages: require('@lib/routers/growPages.js').growPages,
   healthCheck: require('@lib/routers/healthCheck.js').router,
   notFound: require('@lib/routers/notFound.js'),
   packager: require('@lib/routers/packager.js'),

--- a/platform/lib/routers/growPages.js
+++ b/platform/lib/routers/growPages.js
@@ -319,4 +319,8 @@ growPages.get(/^(.*\/)?([^\/\.]+|.+\.html|.*\/|$)$/, async (req, res, next) => {
   pageCache.set(req.originalUrl, renderedTemplate);
 });
 
-module.exports = growPages;
+module.exports = {
+  loadTemplate,
+  ensureUrlScheme,
+  growPages,
+};

--- a/platform/lib/routers/growPages.test.js
+++ b/platform/lib/routers/growPages.test.js
@@ -4,7 +4,7 @@ const request = require('supertest');
 const config = require('@lib/config');
 
 const app = express();
-const router = require('./growPages.js');
+const router = require('./growPages.js').growPages;
 app.use(router);
 
 // eslint-disable-next-line new-cap

--- a/platform/lib/routers/growSharedPages.js
+++ b/platform/lib/routers/growSharedPages.js
@@ -17,7 +17,7 @@
 'use strict';
 
 const express = require('express');
-const growPageLoader = require('@lib/common/growPageLoader');
+const {ensureUrlScheme, loadTemplate} = require('./growPages.js');
 
 // eslint-disable-next-line new-cap
 const sharedPages = express.Router();
@@ -28,11 +28,13 @@ const sharedPages = express.Router();
  * and therefore can only be made accessible by their canonical path
  */
 sharedPages.get('/shared/**', async (req, res, next) => {
+  const url = ensureUrlScheme(req.originalUrl);
   try {
-    const result = await growPageLoader.fetchPage(req.path);
-    res.send(result);
+    const template = await loadTemplate(url.pathname);
+    res.send(template.render());
   } catch (e) {
     // page not found
+    console.error(e);
     next();
   }
 });


### PR DESCRIPTION
Successor to #2934 and https://github.com/ampproject/amp.dev/issues/3152#issuecomment-567117739. /shared/header/ and /shared/header.html weren't the same. The first one was served by growPages.js and was hence optimized. The later one was correctly served by growSharedPages.js and wasn't.

Both URLs now return the same, unoptimized result.