### PR TITLE
🐛 Use absolute URLs for search API endpoints

### DIFF
--- a/frontend/templates/views/partials/search.j2
+++ b/frontend/templates/views/partials/search.j2
@@ -11,7 +11,9 @@
 {% do doc.amp_dependencies.add('amp-lightbox', '0.1') %}
 {% do doc.amp_dependencies.add('amp-mustache', '0.2', 'template') %}
 
-{% set base_url = podspec.base_urls.platform %}
+{# Do not set absolute URLs for development as binding to [src]
+   explicitly checks for https:// #}
+{% set base_url = podspec.base_urls.platform if podspec.env.name != 'development' else '' %}
 
 <amp-state id="query" src="{{ base_url }}/search/latest-query"></amp-state>
 <amp-state id="clear" [src]="clear ? '{{ base_url }}/search/clear-latest-query' : ''"></amp-state>

--- a/frontend/templates/views/partials/search.j2
+++ b/frontend/templates/views/partials/search.j2
@@ -11,8 +11,10 @@
 {% do doc.amp_dependencies.add('amp-lightbox', '0.1') %}
 {% do doc.amp_dependencies.add('amp-mustache', '0.2', 'template') %}
 
-<amp-state id="query" src="/search/latest-query"></amp-state>
-<amp-state id="clear" [src]="clear ? '/search/clear-latest-query' : ''"></amp-state>
+{% set base_url = podspec.base_urls.platform %}
+
+<amp-state id="query" src="{{ base_url }}/search/latest-query"></amp-state>
+<amp-state id="clear" [src]="clear ? '{{ base_url }}/search/clear-latest-query' : ''"></amp-state>
 
 <amp-lightbox id="searchLightbox"
               class="ap-o-search"
@@ -33,7 +35,7 @@
     </div>
 
     <div class="ap-o-search-field">
-      <form action-xhr="/documentation/examples/api/echo"
+      <form action-xhr="{{ base_url }}/documentation/examples/api/echo"
             class="ap-o-search-form"
             id="searchForm"
             method="POST"
@@ -44,7 +46,7 @@
                           min-characters="1"
                           on="select:AMP.setState({ query: event.value })"
                           submit-on-enter="false"
-                          src="/search/autosuggest"
+                          src="{{ base_url }}/search/autosuggest"
         >
           <div class="ap-a-ico ap-o-search-input-icon">
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#search"></use></svg>
@@ -63,11 +65,11 @@
 
       <div class="ap-o-search-result" id="searchResult" tabindex="-1">
         <amp-state id="search"
-                  src="/search/highlights?locale={{ doc.locale }}"
-                  [src]="query == null || clear ? '/search/highlights?locale={{ doc.locale }}' : '/search/do?q=' + encodeURIComponent(query) + '&locale={{ doc.locale }}'"></amp-state>
+                  src="{{ base_url }}/search/highlights?locale={{ doc.locale }}"
+                  [src]="query == null || clear ? '{{ base_url }}/search/highlights?locale={{ doc.locale }}' : '{{ base_url }}/search/do?q=' + encodeURIComponent(query) + '&locale={{ doc.locale }}'"></amp-state>
         <amp-list id="searchList"
-                  src="/search/highlights?locale={{ doc.locale }}"
-                  [src]="query == null || clear ? '/search/highlights?locale={{ doc.locale }}' : '/search/do?q=' + encodeURIComponent(query) + '&locale={{ doc.locale }}'"
+                  src="{{ base_url }}/search/highlights?locale={{ doc.locale }}"
+                  [src]="query == null || clear ? '{{ base_url }}/search/highlights?locale={{ doc.locale }}' : '{{ base_url }}/search/do?q=' + encodeURIComponent(query) + '&locale={{ doc.locale }}'"
                   binding="no"
                   items="."
                   height="80vh"


### PR DESCRIPTION
To add search to blog.amp.dev beside the endpoints returning absolute URLs the endpoints themselves need to be called by their absolute URLs. See https://github.com/ampproject/amp.dev/issues/3152#issuecomment-568150532 for context.