### PR TITLE
🚑 Use in operator instead of non-existant includes

### DIFF
--- a/pages/extensions/internal_links/pod_internal_link_rewriter.py
+++ b/pages/extensions/internal_links/pod_internal_link_rewriter.py
@@ -79,7 +79,7 @@ class PodInternalLinkRewriter(object):
     # create virtual docs when calling get_doc with such a path.
     # This will make doc.exists equal True while doc.url.path only returns
     # garbage. To work around this only further check for docs in '/content'
-    if internal_link.startswith(STATIC_PATH) or internal_link.includes('{{') or internal_link.includes('[='):
+    if internal_link.startswith(STATIC_PATH) or '{{' in internal_link or '[=' in internal_link:
       return internal_link
 
     internal_path = internal_link


### PR DESCRIPTION
Fixes #3519.

Wasn't paying attention during the review of #3486. There is no `String.contains` or `String.includes` in Python but only `String.find` and the `in` operator to check for sub-string existance.