### PR TITLE
🎨 Make Samples Builder non-blocking, always build all on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,6 @@ You can contribute your changes back to the main repository by [creating a pull 
 #### Documents
 Made changes to a lot of Grow documents at once and not quite sure if all references are still valid? You can run `npm run lint:grow` to pick up broken ones.
 
-#### Samples
-Building the samples creates a lot of individual files per sample. In order to still have a quick startup time for development, only changed samples are rebuilt. To freshly build *all* samples you can run `npx gulp develop --clean-samples`.
-
 ### Run a test build
 To run a local test build that does all the minifying and vends the static pages instead of
 proxying them through to Grow you can run:

--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -187,7 +187,7 @@ function buildBoilerplate() {
  * @return {Promise}
  */
 function buildSamples() {
-  return samplesBuilder.build(true);
+  return samplesBuilder.build();
 }
 
 /**

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -80,6 +80,7 @@ class SamplesBuilder {
 
     // Used to cache various properties to save computing time
     this._cache = {};
+    this._cache.categories = {};
     // Holds all relevant sample informations after samplew have been parsed
     this._sitemap = {};
     // Used to gather samples categorized by their used components
@@ -87,121 +88,80 @@ class SamplesBuilder {
   }
 
   /**
+   * Executes all async operations that need to be done
+   * before the samples builder is operational
+   * @return {Promise<void>} Resolves when bootstrapping is done
+   */
+  async _bootstrap() {
+    if (this._bootstrapped) {
+      return;
+    }
+
+    this._log.info('Bootstrapping ...');
+    await Promise.all([
+      readFileAsync(STORY_EMBED_SNIPPET).then((template) => {
+        this._cache[STORY_EMBED_SNIPPET] = template.toString();
+        this._log.success('Loaded story embed template.');
+      }),
+
+      readFileAsync(ADS_EMBED_TEMPLATE).then((template) => {
+        this._cache[ADS_EMBED_TEMPLATE] = template.toString();
+        this._log.success('Loaded ads embed template.');
+      }),
+
+      formatTransform.getInstance().then((instance) => {
+        this._formatTransform = instance;
+        this._log.success('Created format transformer instance.');
+      }),
+
+      del([
+        `${DOCUMENTATION_DEST}/**/*.html`,
+        `${DOCUMENTATION_DEST}/**/*.json`,
+        `${PREVIEW_DEST}/**/*.html`,
+
+        SOURCE_DEST,
+        EMBED_DEST,
+
+        SITEMAP_DEST,
+        COMPONENT_SAMPLES_DEST,
+      ], {
+        'force': true,
+      }).then(() => {
+        this._log.success('Cleaned destination paths.');
+      })
+    ]);
+
+    this._bootstrapped = true;
+  }
+
+  /**
    * Builds samples and previews, optionally watching for changes.
    * @param {boolean} watch  Watch for changes
    * @return {Promise<void>} Resolves when build is done
    */
-  async build(watch) {
-    this._formatTransform = await formatTransform.getInstance();
+  async build(incrementalBuild = false) {
+    await this._bootstrap();
 
-    // Configure cache
-    this._cache[STORY_EMBED_SNIPPET] = await readFileAsync(STORY_EMBED_SNIPPET);
-    this._cache[ADS_EMBED_TEMPLATE] = (await readFileAsync(ADS_EMBED_TEMPLATE)).toString();
-    this._cache.categories = {};
-
-    // If samples should be rebuild (due to architectural changes for example)
-    // then you should be able to clean the sample build destinations
-    if (config.options['clean-samples'] === true) {
-      this._log.info('Cleaning sample destinations for rebuild ...');
-      del.sync([
-        // Clean old structure with multiple collections
-        utils.project.absolute(`/pages/${DOCUMENTATION_POD_PATH}/../**/*`),
-        '!' + utils.project.absolute(`/pages/${DOCUMENTATION_POD_PATH}/../`),
-        '!' + utils.project.absolute(`/pages/${DOCUMENTATION_POD_PATH}/../_blueprint.yaml`),
-        '!' + utils.project.absolute(`/pages/${DOCUMENTATION_POD_PATH}/../index.html`),
-
-        `${DOCUMENTATION_DEST}/**/*`,
-        `!${DOCUMENTATION_DEST}`,
-        `!${DOCUMENTATION_DEST}/_blueprint.yaml`,
-
-        `${PREVIEW_DEST}/**/*`,
-        `!${PREVIEW_DEST}`,
-        `!${PREVIEW_DEST}/_blueprint.yaml`,
-
-        `${SOURCE_DEST}`,
-        `${EMBED_DEST}`,
-        CACHE_DEST,
-      ], {
-        'force': true,
-      });
-    }
-
-    if (!watch && config.isDevMode() && module.parent) {
+    if (config.isDevMode() && module.parent && !incrementalBuild) {
       this._watch();
     }
 
-    this._log.start('Starting to build samples ...');
+    if (!incrementalBuild) {
+      this._log.start('Building samples ...');
+    }
 
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       let stream = gulp.src([
         `${SAMPLE_SRC}/*/*.html`, `${SAMPLE_SRC}/*/*/*.html`], {'read': true});
 
-      // Only build samples changed since last run and if it's not a fresh build
-      if ((config.options['clean-samples'] && watch) || !config.options['clean-samples']) {
-        stream = stream.pipe(once({
-          'context': false,
-          'file': CACHE_DEST,
-        }));
-      }
+      stream = stream.pipe(once({file: false}));
 
-      stream = stream.pipe(through.obj(async (sample, encoding, callback) => {
-        try {
-          this._log.await(`Building sample ${sample.relative} ...`);
-          const { document } = await this._parseSample(sample);
-
-          const isWebSample = document.formats().includes(FORMAT_WEBSITES);
-          const shouldTransform = isWebSample
-              && !document.metadata.disableTransform
-              && !document.metadata.hideCode
-              && !document.metadata.disablePlayground
-              && !document.metadata.hidePreview;
-
-          const samples = [];
-          if (!shouldTransform) {
-            samples.push(sample);
-          } else {
-            for (const format of this._formatTransform.getSupportedFormats()) {
-              const transformed = this._transformSample(sample, format);
-              if (transformed) {
-                samples.push(transformed);
-              }
-            }
-          }
-          await Promise.all(samples.map(async (sample) => {
-            const parsedSample = await this._parseSample(sample);
-
-            // Skip samples that are drafts for all envs except development
-            if (parsedSample.document.metadata.draft && config.environment !== 'development') {
-              return;
-            }
-
-            if (!parsedSample.document.metadata.disablePlayground &&
-                !parsedSample.document.metadata.draft) {
-              this._addToSitemap(sample, parsedSample);
-            }
-
-            // Build various documents and sources that are needed for Grow
-            // to successfully render the example and for the playground
-            const files = [
-              ...this._createDocumentation(sample, parsedSample),
-              ...this._buildRawSources(sample, parsedSample),
-              ...this._createPreview(sample, parsedSample),
-              ...this._renderEmbed(sample, parsedSample),
-            ];
-
-            // Since stream.push doesn't allow to push multiple files at once
-            /* eslint-disable guard-for-in */
-            for (const file of files) {
-              stream.push(file);
-            }
-          }));
-        } catch (error) {
-          this._log.error(error);
-        }
-        callback();
+      const sampleBuilds = [];
+      stream = stream.pipe(through.obj((sample, encoding, callback) => {
+        sampleBuilds.push(this._buildSample(sample, callback, stream));
       }));
 
-      stream.pipe(gulp.dest((file) => {
+      stream = stream.pipe(gulp.dest((file) => {
         file.dirname = `${SAMPLE_SRC}/${this._getCategory(file)}`;
         if (file.isSourceFile) {
           return SOURCE_DEST;
@@ -224,11 +184,76 @@ class SamplesBuilder {
       });
 
       stream.on('end', async () => {
-        this._log.success('Built samples.');
-        await this._writeMetaFiles();
+        if (!incrementalBuild) {
+          // Only write meta files on first build as they rely on all
+          // samples going through the pipeline
+          await this._writeMetaFiles();
+          this._log.complete('Built samples.');
+        } else {
+          this._log.success('Built changed samples.');
+        }
+
         resolve();
       });
     });
+  }
+
+  async _buildSample(sample, callback, stream) {
+    try {
+      this._log.await(`Building sample ${sample.relative} ...`);
+      const { document } = await this._parseSample(sample);
+
+      const isWebSample = document.formats().includes(FORMAT_WEBSITES);
+      const shouldTransform = isWebSample
+          && !document.metadata.disableTransform
+          && !document.metadata.hideCode
+          && !document.metadata.disablePlayground
+          && !document.metadata.hidePreview;
+
+      const samples = [];
+      if (!shouldTransform) {
+        samples.push(sample);
+      } else {
+        for (const format of this._formatTransform.getSupportedFormats()) {
+          const transformed = this._transformSample(sample, format);
+          if (transformed) {
+            samples.push(transformed);
+          }
+        }
+      }
+      await Promise.all(samples.map(async (sample) => {
+        const parsedSample = await this._parseSample(sample);
+
+        // Skip samples that are drafts for all envs except development
+        if (parsedSample.document.metadata.draft && config.environment !== 'development') {
+          return;
+        }
+
+        if (!parsedSample.document.metadata.disablePlayground &&
+            !parsedSample.document.metadata.draft) {
+          this._addToSitemap(sample, parsedSample);
+        }
+
+        // Build various documents and sources that are needed for Grow
+        // to successfully render the example and for the playground
+        const files = [
+          ...this._createDocumentation(sample, parsedSample),
+          ...this._buildRawSources(sample, parsedSample),
+          ...this._createPreview(sample, parsedSample),
+          ...this._renderEmbed(sample, parsedSample),
+        ];
+
+        // Since stream.push doesn't allow to push multiple files at once
+        /* eslint-disable guard-for-in */
+        for (const file of files) {
+          stream.push(file);
+        }
+      }));
+    } catch (error) {
+      this._log.error(error);
+    }
+
+    callback();
   }
 
   /**
@@ -397,20 +422,23 @@ class SamplesBuilder {
     }
 
     try {
-      await writeFileAsync(SITEMAP_DEST, JSON.stringify(this._sitemap), {
-        flag: 'w+',
-      });
+      await Promise.all([
+        writeFileAsync(SITEMAP_DEST, JSON.stringify(this._sitemap), {
+          flag: 'w+',
+        }).then(() => {
+          this._log.success('Wrote sample sitemap.');
+        }),
 
-      await writeFileAsync(COMPONENT_SAMPLES_DEST, JSON.stringify(this._componentSamples), {
-        flag: 'w+',
-      });
-
-      this._log.success('Wrote sample sitemap and component samples file.');
-    } catch (_) {
-      this._log.error('Writing samples builder meta files failed:', e);
+        writeFileAsync(COMPONENT_SAMPLES_DEST, JSON.stringify(this._componentSamples), {
+          flag: 'w+',
+        }).then(() => {
+          this._log.success('Wrote component samples map.');
+        })
+      ]);
+    } catch (e) {
+      this._log.error('Writing samples builder meta files failed', e);
     }
   }
-
 
   /**
    * Parses the category from a sample path which is the first level

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -159,13 +159,13 @@ class SamplesBuilder {
       stream = stream.pipe(once({file: false}));
 
       const sampleBuilds = [];
-      stream.pipe(through.obj((sample, encoding, callback) => {
+      stream = stream.pipe(through.obj((sample, encoding, callback) => {
         sampleBuilds.push(this._buildSample(sample, callback, stream));
       }));
 
       await Promise.all(sampleBuilds);
 
-      stream = stream.pipe(gulp.dest((file) => {
+      stream.pipe(gulp.dest((file) => {
         file.dirname = `${SAMPLE_SRC}/${this._getCategory(file)}`;
         if (file.isSourceFile) {
           return SOURCE_DEST;

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -156,12 +156,14 @@ class SamplesBuilder {
       let stream = gulp.src([
         `${SAMPLE_SRC}/*/*.html`, `${SAMPLE_SRC}/*/*/*.html`], {'read': true});
 
-      stream = stream.pipe(once({file: false}));
+      // stream = stream.pipe(once({file: false}));
 
       const sampleBuilds = [];
-      stream = stream.pipe(through.obj((sample, encoding, callback) => {
+      stream.pipe(through.obj((sample, encoding, callback) => {
         sampleBuilds.push(this._buildSample(sample, callback, stream));
       }));
+
+      await Promise.all(sampleBuilds);
 
       stream = stream.pipe(gulp.dest((file) => {
         file.dirname = `${SAMPLE_SRC}/${this._getCategory(file)}`;
@@ -257,6 +259,7 @@ class SamplesBuilder {
       this._log.error(error);
     }
 
+    this._log.success(`Built sample ${sample.relative}!`);
     callback();
   }
 
@@ -453,12 +456,12 @@ class SamplesBuilder {
    */
   _getCategory(sample, ordered = false) {
     // Check if the category has already been computed
-    let category = this._cache.categories[sample.path];
+    let category = this._cache.categories[sample.realPath];
     if (!category) {
       category = sample.dirname.replace(`${SAMPLE_SRC}/`, '');
       category = category.split('/')[0];
 
-      this._cache.categories[sample.path] = category;
+      this._cache.categories[sample.realPath] = category;
     }
 
     // Check if the category should contain ordinal

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -156,7 +156,7 @@ class SamplesBuilder {
       let stream = gulp.src([
         `${SAMPLE_SRC}/*/*.html`, `${SAMPLE_SRC}/*/*/*.html`], {'read': true});
 
-      // stream = stream.pipe(once({file: false}));
+      stream = stream.pipe(once({file: false}));
 
       const sampleBuilds = [];
       stream.pipe(through.obj((sample, encoding, callback) => {

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -112,6 +112,8 @@ class SamplesBuilder {
       formatTransform.getInstance().then((instance) => {
         this._formatTransform = instance;
         this._log.success('Created format transformer instance.');
+      }).catch((e) => {
+        this._log.warn('Could not create format transformer instance. Samples will only be build for their original format.');
       }),
 
       del([
@@ -204,7 +206,9 @@ class SamplesBuilder {
       const { document } = await this._parseSample(sample);
 
       const isWebSample = document.formats().includes(FORMAT_WEBSITES);
-      const shouldTransform = isWebSample
+      // Only samples that have been originally written for AMP for websites
+      // can be transformed and only if validator.json could be fetched
+      const shouldTransform = this._formatTransform && isWebSample
           && !document.metadata.disableTransform
           && !document.metadata.hideCode
           && !document.metadata.disablePlayground


### PR DESCRIPTION
First part of #3417. Looks hefty but actually isn't, mainly moved code around:

- Instead of sequentially waiting for dependent operations to complete before starting to build I moved them to `_bootstrap` to await them in parallel with `Promise.all`
- The callback for `through` is not blocking anymore, samples build parallelly now
- The first run of the samples builder now always freshly builds all samples and cleans artifacts from previous builds
- Sample maps are only built during that first call to prevent incomplete maps as mentioned in #3540