### PR TITLE
🐛 Fix-up for component intro tables

### DIFF
--- a/frontend/scss/components/organisms/component-intro.scss
+++ b/frontend/scss/components/organisms/component-intro.scss
@@ -46,7 +46,7 @@
           overflow-x: scroll;
           flex: 1 0;
           margin: 6px 8px 6px 0;
-          padding: 2px 4px 4px 2px;
+          padding: 4px 6px;
           white-space: nowrap;
           background: color('gallery');
           font-size: 12.6px;

--- a/pages/content/shared/copy-script.html
+++ b/pages/content/shared/copy-script.html
@@ -35,8 +35,8 @@ $sitemap:
     scriptTag.value = stringToCopy;
 
     document.addEventListener('click', () => {
-      $scriptTag.select();
-      $scriptTag.setSelectionRange(0, 99999);
+      scriptTag.select();
+      scriptTag.setSelectionRange(0, 99999);
       document.execCommand('copy');
     });
   </script>


### PR DESCRIPTION
Part of the fixes for #3540.

- Fixes the misnamed variable in the copy script
- Increases the padding for the code snippet