### PR TITLE
🐛 Correctly link to amp-script doc from example

### DIFF
--- a/examples/source/1.components/amp-script/index.html
+++ b/examples/source/1.components/amp-script/index.html
@@ -1,5 +1,5 @@
 <!--
-  An [amp-script](content/amp.dev/documentation/components/reference/amp-script.md) hello world example.
+  An [amp-script](/content/amp-dev/documentation/components/reference/amp-script.md) hello world example.
 -->
 <!-- -->
 <!doctype html>
@@ -33,13 +33,13 @@
         }
       </style>
 
-      <!-- 
+      <!--
         For inline scripts you need to generate a CSP header. Read more about this in the [component documentation](/content/amp-dev/documentation/components/reference/amp-script-v0.1.md).
       -->
       <meta name="amp-script-src" content="sha384-X8xW7VFd-a-kgeKjsR4wgFSUlffP7x8zpVmqC6lm2DPadWUnwfdCBJ2KbwQn6ADE sha384-nNFaDRiLzgQEgiC5kP28pgiJVfNLVuw-nP3VBV-e2s3fOh0grENnhllLfygAuU_M sha384-u7NPnrcs7p4vsbGLhlYHsId_iDJbcOWxmBd9bhVuPoA_gM_he4vyK6GsuvFvr2ym">
   </head>
   <body>
-      <!-- 
+      <!--
         ## Basic usage
 
         An amp-script element can load a JavaScript file from a URL. This is usually the best way to integrate a script as the browser needs to download the script only once.
@@ -48,7 +48,7 @@
         <button id="hello">Click!</button>
       </amp-script>
 
-      <!-- 
+      <!--
         This is the script in [hello-world.js](hello-world.js):
 
         ```js
@@ -67,8 +67,8 @@ button.addEventListener('click', () => {
         <button id="hello2">Click!</button>
       </amp-script>
 
-      <!-- 
-        This is the inlined script. Note that the type needs to be `type=text/plain` and the `target=amp-script`. 
+      <!--
+        This is the inlined script. Note that the type needs to be `type=text/plain` and the `target=amp-script`.
 
       -->
       <script id="hello-world" type="text/plain" target="amp-script">


### PR DESCRIPTION
Corrupt references in the examples are not picked up by `GrowReferenceChecker` as the pages are only built from the JSON files. We could think about checking the sample source files though. 🤔 