### PR TITLE
🐛 Fix version toggle issues

### DIFF
--- a/frontend/scss/components/templates/component-detail.scss
+++ b/frontend/scss/components/templates/component-detail.scss
@@ -52,25 +52,28 @@ body {
 
   .#{utility('versions')} {
     position: relative;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     background: color('white');
     border-radius: 3px;
     border: 2px solid #d5d9de;
 
     &-toggle {
-      padding: .1em .25em;
       border: 0;
+      padding: 0 32px 0 8px;
       background: color('white');
       font-family: inherit;
       font-size: inherit;
       font-weight: inherit;
-
+      -moz-appearance: none;
+      -webkit-appearance: none;
+      appearance: none;
     }
+
     &:after {
       content: '';
       position: absolute;
-      top: 8px;
-      right: 4px;
+      right: 8px;
       width: 16px;
       height: 35px;
       background: color('white');

--- a/platform/lib/pipeline/componentReferenceImporter.js
+++ b/platform/lib/pipeline/componentReferenceImporter.js
@@ -208,14 +208,18 @@ class ComponentReferenceImporter {
         return extension.name == script.extensionSpec.name;
       }) || {};
 
-    spec.version = spec.version.filter(version => {
-      return version != LATEST_VERSION;
-    });
+    spec.version = spec.version.filter(version => version != LATEST_VERSION);
     spec.version = spec.version.sort((version1, version2) => {
       return parseFloat(version1) > parseFloat(version2);
     });
 
     const latestVersion = spec.version[spec.version.length - 1];
+
+    // Skip versions for which there is no dedicated doc
+    spec.version = spec.version.filter(version => {
+      return !!this._getGitHubPath(extension, version, latestVersion);
+    });
+
     const extensionMetas = [];
     for (const version of spec.version) {
       extensionMetas.push({


### PR DESCRIPTION
Fixes #3557.

What's a bit unfortunate (also currently is): this hides the fact that there is a deprecated version of for example `amp-experiment` as there is no version toggle. Alternatively, we could copy the "latest" document and show it for both versions - though that might also be confusing UX.