### PR TITLE
Fixed spelling/grammar error on home page

### DIFF
--- a/pages/content/amp-dev/index.html
+++ b/pages/content/amp-dev/index.html
@@ -519,7 +519,7 @@ success_stories:
     {% do doc.styles.addCssFile('css/components/atoms/button.css') %}
     <div class="ap-m-copy ap-m-copy-center">
       <h2>{{ _('Build your first AMP page now') }}</h2>
-      <p>{{ _('You don’t need to download AMP and no installation is required.<br/> Because it is a open-source project, it is free!') }}</p>
+      <p>{{ _('You don’t need to download AMP and no installation is required.<br/> Because it is an open-source project, it is free!') }}</p>
       <a href="documentation/guides-and-tutorials/index.html" class="ap-a-btn">{{ _('Get started') }}</a>
     </div>
   </section>


### PR DESCRIPTION
Changed:

> Because it is a open-source project, it is free!

to:

> Because it is an open-source project, it is free!
