### PR TITLE
🔇 Disable logs during test runs

### DIFF
--- a/platform/lib/config.js
+++ b/platform/lib/config.js
@@ -54,6 +54,10 @@ class Config {
     if (environment === 'test') {
       environment = ENV_DEV;
       this.test = true;
+
+      // Config doesn't use the log util as this relies on config. Therefore
+      // the main signale instance gets disabled here
+      signale.disable();
     } else {
       this.test = false;
     }

--- a/platform/lib/pipeline/componentReferenceDocument.js
+++ b/platform/lib/pipeline/componentReferenceDocument.js
@@ -15,7 +15,7 @@
  */
 const {dirname} = require('path');
 const {resolve} = require('url');
-const {Signale} = require('signale');
+const log = require('@lib/utils/log')('Component Reference Document');
 const MarkdownDocument = require('@lib/pipeline/markdownDocument.js');
 const {FORMAT_WEBSITES} = require('@lib/amp/formatHelper.js');
 
@@ -25,8 +25,6 @@ const EXTENSION_TYPE_TEMPLATE = 'template';
 const RELATIVE_PATH_BASE = 'https://github.com/ampproject/amphtml/blob/master/';
 
 const INTRO_TABLE_PATTERN = /^((?:[^](?!##))*)<table(\s[^>]*)?>[^]*?<\/table>/m;
-
-const LOG = new Signale({'scope': 'Component Reference Documents'});
 
 class ComponentReferenceDocument extends MarkdownDocument {
   constructor(path, contents, extension) {
@@ -44,7 +42,7 @@ class ComponentReferenceDocument extends MarkdownDocument {
     // enable it for the websites runtime
     if (!this.formats.length) {
       this.formats = [FORMAT_WEBSITES];
-      LOG.warn(
+      log.warn(
         `${this.title} doesn't specify any formats in its`,
         `frontmatter and is force-listed for websites.`
       );

--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -16,15 +16,12 @@
 
 const writeFile = require('write');
 const yaml = require('js-yaml');
-const {Signale} = require('signale');
 const utils = require('@lib/utils');
+const log = require('@lib/utils/log')('Markdown Document');
 const SlugGenerator = require('@lib/utils/slugGenerator');
 
 // Inline marker used by Grow to determine if there should be TOC
 const TOC_MARKER = '[TOC]';
-// It doesn't make sense to give every MarkdownDocument their own logger instance
-// therefore have one shared one
-const LOG = new Signale({'scope': 'Markdown Documents'});
 
 // This expression matches a {% raw %}...{% endraw %} block
 const JINJA2_RAW_BLOCK = /\{%\s*raw\s*%\}(?:(?!\{%\s*endraw\s*%\})[\s\S])*\{%\s*endraw\s*%\}/;
@@ -92,17 +89,17 @@ class MarkdownDocument {
       this._frontmatter =
         frontmatter || MarkdownDocument.extractFrontmatter(contents);
     } catch (e) {
-      LOG.error(`Failed to parse frontmatter for ${path}`, e.message);
+      log.error(`Failed to parse frontmatter for ${path}`, e.message);
       this._frontmatter = {
         '$title': '',
       };
     }
 
     if (!this.teaser.text) {
-      LOG.warn(`Auto extracting teaser text for ${path}`);
+      log.warn(`Auto extracting teaser text for ${path}`);
       this.teaser = {text: MarkdownDocument.extractTeaserText(contents)};
       if (!this.teaser.text) {
-        LOG.error(`Failed to extract teaser text for ${path}`);
+        log.error(`Failed to extract teaser text for ${path}`);
       }
     }
 
@@ -218,7 +215,7 @@ class MarkdownDocument {
     }
 
     if (!excerpt) {
-      LOG.error(
+      log.error(
         `Could not parse a teaser text from "${contents.substr(0, 500)}..."`
       );
       return '';
@@ -246,7 +243,7 @@ class MarkdownDocument {
     if (contents.startsWith('---')) {
       let frontmatter = contents.match(FRONTMATTER_PATTERN);
       if (!frontmatter) {
-        LOG.warn(`Unparseable frontmatter "${contents.substr(0, 200)} ..."`);
+        log.warn(`Unparseable frontmatter "${contents.substr(0, 200)} ..."`);
       } else {
         frontmatter = frontmatter[0];
 
@@ -441,10 +438,10 @@ have a look and request a pull request there.
     path = path ? path : this._path;
     return writeFile(path, content)
       .then(() => {
-        LOG.success(`Saved ${path.replace(utils.project.paths.ROOT, '~')}`);
+        log.success(`Saved ${path.replace(utils.project.paths.ROOT, '~')}`);
       })
       .catch(e => {
-        LOG.error(
+        log.error(
           `Couldn't save ${path.replace(utils.project.paths.ROOT, '~')}`,
           e
         );

--- a/platform/lib/utils/grow.js
+++ b/platform/lib/utils/grow.js
@@ -19,11 +19,7 @@
 const {extractCommandFragments} = require('@lib/utils/sh');
 const {spawn} = require('child_process');
 const {project} = require('@lib/utils');
-const {Signale} = require('signale');
-
-const LOG = new Signale({
-  'scope': 'Grow',
-});
+const log = require('@lib/utils/log')('Grow');
 
 // Messages printed by Grow used to determine log levels
 const MESSAGES = {
@@ -48,13 +44,13 @@ function handler(data, resolve, reject) {
   // development as Grow starting should be awaited before the user
   // can access the platform
   if (message == MESSAGES.START_SUCCESSFUL) {
-    LOG.success(message);
+    log.success(message);
     resolve();
     return message;
   }
 
   if (message.includes(MESSAGES.WARNING)) {
-    LOG.warn(message);
+    log.warn(message);
     return message;
   }
 
@@ -63,11 +59,11 @@ function handler(data, resolve, reject) {
     message.includes(MESSAGES.ERROR_2) ||
     message.includes(MESSAGES.ERROR_3)
   ) {
-    LOG.error(message);
+    log.error(message);
     return message;
   }
 
-  LOG.info(message);
+  log.info(message);
   return message;
 }
 

--- a/platform/lib/utils/log.js
+++ b/platform/lib/utils/log.js
@@ -15,14 +15,24 @@
  */
 
 const {Signale} = require('signale');
+const config = require('@lib/config');
 const loggers = {};
 
 function log(scope, options = {}) {
   options.scope = scope;
-  if (!loggers[scope]) {
+  let logger = loggers[scope];
+  if (!logger) {
     loggers[scope] = new Signale(options);
+    logger = loggers[scope];
+
+    // Disable all loggers during test runs as they might be confusing for
+    // tests targeting error cases
+    if (config.isTestMode()) {
+      logger.disable();
+    }
   }
-  return loggers[scope];
+
+  return logger;
 }
 
 module.exports = log;


### PR DESCRIPTION
This has been confusing not just for @DerekNonGeneric in #3346 but for team mates of mine as well: test cases that test error handling print error messages although the test itself succeeded.

**Currently**
![Bildschirmfoto 2020-02-20 um 15 03 08](https://user-images.githubusercontent.com/12857772/74941150-d8a36780-53f2-11ea-9131-59ac90799243.png)

**With this PR**
![Bildschirmfoto 2020-02-20 um 15 03 27](https://user-images.githubusercontent.com/12857772/74941167-e0fba280-53f2-11ea-8cd3-60d2ea8930bc.png)
