### PR TITLE
Updating page to reflect updated CSS limit

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors.md
@@ -716,13 +716,13 @@ and it will check validation rules for the pre-defined layout.
   </tr>
    <tr>
   	<td class="col-thirty"><strong>Fix</strong></td>
-  	<td>Reduce the size of the stylesheet to be under 50,000 bytes.</td>
+  	<td>Reduce the size of the stylesheet to be under 75,000 bytes.</td>
   </tr>
 </table>
 
 The AMP validator throws this error
 when it measures the size of the styles content
-within `<style amp-custom>` to exceed the 50,000 bytes limit.
+within `<style amp-custom>` to exceed the 75,000 bytes limit.
 
 ### CSS syntax error
 


### PR DESCRIPTION
Page updated: https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/

The CSS limit has been upped to 75,000 per https://github.com/ampproject/amphtml/pull/26475