### PR TITLE
take a whack at fixing the new header filters

### DIFF
--- a/frontend/scss/components/molecules/format-filter-hint.scss
+++ b/frontend/scss/components/molecules/format-filter-hint.scss
@@ -13,10 +13,14 @@ $height: 60px;
   height: $height;
   color: color('white');
   background-color: color('ebony-clay');
+  position: sticky!important;
+  top: 50px;
+
   @include txt-2;
 
   @media (min-width: 768px) {
     display: block;
+    top: 85px;
   }
 
   &.amp-active + &-spacer {


### PR DESCRIPTION
every part of this feels super gross, but it seems like a somewhat robust way to approach #3592.

I set `!important` on `position: sticky` , because [they did it first] :/(https://github.com/ampproject/amphtml/blob/5f75efe35b734a4fcf0884d373315de60cd42df9/extensions/amp-user-notification/0.1/amp-user-notification.css#L19).
I used a magic numbers for the height because the header doesn't have a sass variable available (that I can determine)