### PR TITLE
🎨 Remove headline tags from teaser texts

### DIFF
--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -224,11 +224,12 @@ class MarkdownDocument {
     // Strip out all possible HTML tags
     excerpt = excerpt[1].replace(/<\/?[^>]+(>|$)/g, '');
     // Unwrap back ticks, ...
-    excerpt = excerpt.replace(/`(.+)`/g, '$1');
+    excerpt = excerpt.replace(/`(.+?)`/g, '$1');
     // unwrap possible markdown links, ...
-    excerpt = excerpt.replace(/\[(.+)\]\(.+\)/g, '$1');
+    excerpt = excerpt.replace(/\[(.+?)\]\(.+?\)/g, '$1');
     // and remove headline markers
     excerpt = excerpt.replace(/#/g, '');
+
     return excerpt;
   }
 

--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -223,10 +223,12 @@ class MarkdownDocument {
 
     // Strip out all possible HTML tags
     excerpt = excerpt[1].replace(/<\/?[^>]+(>|$)/g, '');
-    // Unwrap back ticks
+    // Unwrap back ticks, ...
     excerpt = excerpt.replace(/`(.+)`/g, '$1');
-    // And unwrap possible markdown links
+    // unwrap possible markdown links, ...
     excerpt = excerpt.replace(/\[(.+)\]\(.+\)/g, '$1');
+    // and remove headline markers
+    excerpt = excerpt.replace(/#/g, '');
     return excerpt;
   }
 


### PR DESCRIPTION
Related to #3591. For all automatically extracted teaser texts we have been removing all Markdown syntax except headlines - or at least tried to. This PR fixes that and also adds a RegEx for headline tags.

Manual teaser texts don't contain any markdown tags. At the latest after https://github.com/ampproject/amphtml/pull/26383/.

@sebastianbenz, you decide if we should still enable Markdown rendering in the intro table as requested with #3591: the problem is that we somewhat rely on the teaser text to not contain any markdown as when we show it in a teaser (which naturally is an `<a>` the text shouldn't contain any other links as for example Chrome would move them out of their enclosing `<a>` which could have strange side effects.