### PR TITLE
🚸 Filter TOC based on format and level

### DIFF
--- a/frontend/templates/views/partials/toc.j2
+++ b/frontend/templates/views/partials/toc.j2
@@ -20,7 +20,7 @@
     <input class="ap-a-sidebar-toggle-input ap-a-sidebar-toggle-input-toc" type="checkbox" name="toc" id="toc" autocomplete="off">
     {# Unwrap TOC from useless markup and strip first level #}
     {% set toc = doc.format.toc.replace('<div class="toc">\n<ul>\n', '<ul>').replace('\n</ul>\n</div>', '</ul>') %}
-    {{ toc|safe }}
+    {{ doc.format.filter_toc(toc)|safe }}
   </div>
 </section>
 {% endif %}

--- a/pages/extensions/amp_dev/extension.py
+++ b/pages/extensions/amp_dev/extension.py
@@ -8,8 +8,9 @@ from .markdown_extras import block_tip as BlockTip
 from .markdown_extras import block_video as BlockVideo
 from .markdown_extras import inline_tip as InlineTip
 
+
 class AmpDevPreRenderHook(hooks.PreRenderHook):
-    """Handle the post-render hook."""
+    """Handle the pre-render hook."""
 
     def should_trigger(self, previous_result, doc, original_body, *_args,
                        **_kwargs):
@@ -26,8 +27,17 @@ class AmpDevPreRenderHook(hooks.PreRenderHook):
 
     def trigger(self, previous_result, doc, original_body, *_args, **_kwargs):
         content = previous_result if previous_result else original_body
+
         content = self.extension.transform_markdown(doc, original_body, content)
+
+        # The TOC should not contain headlines that are actually enclosed
+        # in format filtered sections. filter_toc creates a callable that is
+        # later able to filter the TOC based on those sections. It is *not* possible
+        # to already evaluate this here as it would overwrite all transformations
+        setattr(doc.format, 'filter_toc', BlockFilter.filter_toc(doc, content))
+
         return content
+
 
 class AmpDevExtension(extensions.BaseExtension):
     """Extends Grow with specifics for amp.dev."""

--- a/pages/extensions/amp_dev/markdown_extras/block_filter.py
+++ b/pages/extensions/amp_dev/markdown_extras/block_filter.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import json
 import re
 
 FILTER_TRIGGER = '[filter'
@@ -15,6 +16,7 @@ def trigger(original_body, content):
   if FILTER_TRIGGER in original_body:
     return _transform(content)
   return content
+
 
 def _transform(content):
     for match in FILTER_TAG_PATTERN.findall(content):
@@ -41,3 +43,35 @@ def _get_attributes(match):
     for match in matches:
         attributes[match[0]] = match[1]
     return attributes
+
+FILTERED_SECTION_PATTERN = re.compile(r'({% call filter\(.*?\) %})(.*?)({% endcall %})', re.MULTILINE | re.DOTALL)
+HEADLINE_PATTERN = re.compile(r'^#+ (.*)', re.MULTILINE)
+
+def filter_toc(doc, content=''):
+  filtered_sections = FILTERED_SECTION_PATTERN.findall(content)
+
+  def filter(toc):
+    # Check if any of the headlines is in a filtered section and if so
+    # then also filter it in the TOC
+    for section in filtered_sections:
+      section_content = section[1]
+
+      headlines = HEADLINE_PATTERN.findall(section_content)
+      for headline in headlines:
+        # As jinja2 has already run when the TOC is printed SSR statements
+        # have to be handcrafted here
+        filter_tags = _get_ssr_filter_tags(_get_attributes(section[0]))
+        filtered_headline = filter_tags[0] + r'\1' + headline + r'\2' + filter_tags[1]
+        toc = re.sub(r'(<a .*?>)' + headline + '(</a>)', filtered_headline, toc)
+    return toc
+
+  return filter
+
+def _get_ssr_filter_tags(attributes):
+  levels = attributes.get('levels', DEFAULT_LEVEL).replace(' ', '').split(',')
+  formats = attributes.get('formats', DEFAULT_FORMATS).replace(' ', '').split(',')
+
+  return (
+    '[% if format in ' + json.dumps(formats) + ' and level in ' + json.dumps(levels) + ' %]',
+    '[% endif %]'
+    )


### PR DESCRIPTION
That's ugly and did cost me more time than I had hoped. It's not possible to access `doc.format.toc` in any of the render hooks to get the generated TOC as this would reevaluate the document's content and make all transformations obsolete.

Therefore this passes a callable to the template in which you are free to call `doc.format.toc` as `doc.format.content` has already been rendered.

Resolves #3545, adds to #2774. @morsssss, this would allow the courses to have level-specific TOCs again. Do you want them back?