### PR TITLE
Deutsch zu unterstützten Sprachen hinzufügen

### DIFF
--- a/platform/lib/config.js
+++ b/platform/lib/config.js
@@ -36,6 +36,7 @@ const DEFAULT_LOCALE = 'en';
 
 const AVAILABLE_LOCALES = [
   'en',
+  'de',
   'fr',
   'ar',
   'es',


### PR DESCRIPTION
after digging into some analytics with the devsite folks, the numbers seem to say having a Deutsch version of the site makes a lot of sense. @ilyaspiridonov and co were kind enough to provide it, we just need to add this to the config (I think? - @matthiasrohmer/@sebastianbenz please correct me if I am wrong)