### PR TITLE
🐛 Make filter call blocks unique

### DIFF
--- a/pages/extensions/amp_dev/markdown_extras/block_filter.py
+++ b/pages/extensions/amp_dev/markdown_extras/block_filter.py
@@ -27,7 +27,7 @@ def _transform(content):
         replacement = '{% call filter(formats=\'' + attributes['formats'] + '\' , level=\'' + attributes['level'] + '\') %}\n'
 
         # Then also replace end tags
-        content = content.replace(FILTER_END_TAG_PATTERN, '\n{% endcall %}')
+        content = content.replace(FILTER_END_TAG_PATTERN, '\n<!-- filter -->{% endcall %}')
 
         content = content.replace(match, replacement)
 
@@ -44,7 +44,7 @@ def _get_attributes(match):
         attributes[match[0]] = match[1]
     return attributes
 
-FILTERED_SECTION_PATTERN = re.compile(r'({% call filter\(.*?\) %})(.*?)({% endcall %})', re.MULTILINE | re.DOTALL)
+FILTERED_SECTION_PATTERN = re.compile(r'({% call filter\(.*?\) %})(.*?)(<!-- filter -->{% endcall %})', re.MULTILINE | re.DOTALL)
 HEADLINE_PATTERN = re.compile(r'^#+ (.*)', re.MULTILINE)
 
 def filter_toc(doc, content=''):


### PR DESCRIPTION
That's quick and dirty but will be unnecessary with #3367.

It addresses the problem of nested `{% call %}` blocks that occurs when for example tips are in a filtered section.