### PR TITLE
Document validation of delievered AMP emails

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validate_emails.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validate_emails.md
@@ -56,7 +56,7 @@ You can also validate AMP Emails using the [AMP playground](https://playground.a
 
 ### Validate delivered emails
 
-Sometimes your delivered AMP Emails may be invalid even though the email markup you authored has already been validated by tools documented in this page. The most common reason for this to happen is that your ESP modified your email markup and made it invalid after you have sent your email to your ESP for delivery. For example, if you haven't configured HTTPS tracking pixels with your ESP, then your ESP will add a insecure HTTP tracking pixel to your email. Since AMP Emails only allow HTTPS images, this will make your AMP Email invalid.
+Sometimes your delivered AMP Emails may be invalid even though the email markup you authored has already been validated by tools documented in this page. The most common reason for this to happen is that your [ESP](https://amp.dev/support/faq/email-support/) modified your email markup and made it invalid after you have sent your email to your ESP for delivery. For example, if your ESP is SparkPost and you haven't configured HTTPS tracking pixels with SparkPost, then SparkPost will add an insecure HTTP tracking pixel to your email. Since AMP Emails only allow HTTPS images, this will make your AMP Email invalid.
 
 To check whether an email delivered to your inbox is valid AMP:
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validate_emails.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validate_emails.md
@@ -17,7 +17,7 @@ There are several ways available to validate an email as a valid AMP Email. They
 
 ## Web-based validator 
 
-The AMP [web-based validator](https://validator.ampproject.org/#htmlFormat=AMP4EMAIL) support the AMP for Email platform. Use the web-based validator is by pasting your AMP Email into the tool. It will flag any validator errors directly inline. 
+The AMP [web-based validator](https://validator.ampproject.org/#htmlFormat=AMP4EMAIL) supports the AMP for Email platform. Use the web-based validator by pasting your AMP Email into the tool. It will flag any validator errors directly inline. 
 
 
 {{ image('/static/img/docs/guides/emailvalidate.jpg', 500, 382, alt='Image of web-based email validator' ) }}
@@ -29,7 +29,7 @@ The AMP [web-based validator](https://validator.ampproject.org/#htmlFormat=AMP4E
 You can validate AMP Emails files by using the [AMP HTML validator command line tool](https://www.npmjs.com/package/amphtml-validator). 
 
 
-## Installation
+### Installation
 
 
 
@@ -37,7 +37,7 @@ You can validate AMP Emails files by using the [AMP HTML validator command line 
 1.  Install the AMP HTML validator command line tool by running the following command: `npm install -g amphtml-validator`.
 
 
-## Usage
+### Usage
 
 After installing the command-line tool, run the following command after replacing `<amphtml file>` with your file containing the AMP Email content.
 
@@ -49,6 +49,22 @@ amphtml-validator --html_format AMP4EMAIL <amphtml file>
 
 If the email is valid the command-line tool will result in a `PASS`. If invalid, it will return with the errors it found. 
 
+
+## AMP playground
+
+You can also validate AMP Emails using the [AMP playground](https://playground.amp.dev/?runtime=amp4email). Similar to the web-based validator, paste your AMP Email into the tool, and the playground will flag any validator errors directly inline.
+
+### Validate delivered emails
+
+Sometimes your delivered AMP Emails may be invalid even though the email markup you authored has already been validated by tools documented in this page. The most common reason for this to happen is that your ESP modified your email markup and made it invalid after you have sent your email to your ESP for delivery. For example, if you haven't configured HTTPS tracking pixels with your ESP, then your ESP will add a insecure HTTP tracking pixel to your email. Since AMP Emails only allow HTTPS images, this will make your AMP Email invalid.
+
+To check whether an email delivered to your inbox is valid AMP:
+
+1. [download the AMP Email as an `.eml` file](https://www.codetwo.com/kb/export-email-to-file) from your email client.
+2. Open the [AMP playground](https://playground.amp.dev/?runtime=amp4email).
+3. Click on "IMPORT EMAIL", and select the `.eml` file you just downloaded.
+
+The playground will import the AMP email you downloaded into the inline editor and flag any validation errors.
 
 # What happens if my email isn't valid?
 


### PR DESCRIPTION
Many email senders are struggling with AMP validation failures caused by
ESP's modification to the email markup after the sender sends the markup
to the ESP, and they often find it hard to diagnose exactly what the
validation failures are.

/to @CrystalOnScript 
/cc @fstanis 
/cc @choumx 