### PR TITLE
Add a `go.amp.dev` link for working group updates

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -44,6 +44,7 @@
 /vision-mission: /about/mission-and-vision/
 /websites: /about/websites/
 /wg: https://github.com/ampproject/meta/tree/master/working-groups
+/wg-updates: https://github.com/search?o=desc&q=org%3Aampproject+label%3A%22Type%3A+Status+Update%22&s=created&
 
 # Regex-based entries
 ^/c/amp-([a-z-]+)$:


### PR DESCRIPTION
This PR adds a short link go.amp.dev/wg-updates to redirect to AMP's [working group updates](https://github.com/search?o=desc&q=org%3Aampproject+label%3A%22Type%3A+Status+Update%22&s=created&type=Issues).