### PR TITLE
📖 Update amp-sidebar example to include always visible desktop sidebar

### DIFF
--- a/examples/source/1.components/amp-sidebar.html
+++ b/examples/source/1.components/amp-sidebar.html
@@ -31,7 +31,9 @@ author: juliantoledo
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <style amp-custom>
     :root {
+      --space-1: 0.5rem;
       --space-2: 1rem;   /* 16px */
+      --space-4: 2rem;
     }
     .sample-sidebar {
       width: 250px;
@@ -42,10 +44,13 @@ author: juliantoledo
     }
     .sample-sidebar li,
     nav[toolbar] li {
-      margin-bottom: var(--space-2);
-      margin-left: 0;
-      margin-right: var(--space-2);
+      margin: var(--space-2);
+      margin-left: var(--space-4);
       list-style: none;
+    }
+    amp-sidebar ul, nav[toolbar] ul {
+      display: block;
+      padding-left: 0;
     }
     .previewOnly {
       margin: var(--space-2);
@@ -53,91 +58,164 @@ author: juliantoledo
     #sidebar-right nav.amp-sidebar-toolbar-target-shown {
         display: none;
     }
+    button {
+      margin-left: var(--space-2);
+    }
+    header {
+      background-color: lightgray;
+      padding-bottom: var(--space-2);
+    }
+    .hamburger {
+      top: 0;
+      right: 0;
+      position: absolute;
+    }
+    h1 {
+      padding: var(--space-1);
+      margin: 0;
+      font-size: 2em;
+    }
+    .desktop-sidebar {
+      background-color: lightblue;
+    }
+    @media (min-width: 783px) {
+      .hamburger {
+        display: none;
+      }
+      main {
+        display: flex;
+        flex-direction: row;
+      }
+      aside {
+        width: 300px;
+      }
+    }
   </style>
 </head>
 <body>
+  <!-- Header -->
+  <header>
+    <h1>Header</h1>
+    <button
+      class="hamburger"
+      on='tap:sidebar-desktop.toggle'
+      aria-label="Click to open sidebar">
+      =
+    </button>
+  </header>
+  
+  <!-- Main Content -->
+  <main>
+    <!-- Target for Desktop sidebar -->
+    <aside id="target-element-desktop" class="desktop-sidebar">
+      <h1>Desktop Sidebar</h1>
+    </aside>
 
-  <p class="previewOnly">
-  Please resize the browser window to view the responsiveness for `amp-sidebar`'s toolbar.
-  </p>
-  <h2 class="previewOnly">Basic usage</h2>
-  <!-- ## Basic usage -->
-  <!--
-    The `amp-sidebar` should be a direct child of the `<body>`. It must have a layout of `nodisplay`.  `amp-sidebar` supports the following actions: `toggle`, `open` and `close`.
-  -->
-  <div>
-    <amp-sidebar id="sidebar" class="sample-sidebar" layout="nodisplay" side="right">
-      <h3>Sidebar</h3>
-      <button on="tap:sidebar.close">Close sidebar</button>
-      <button on="tap:sidebar.toggle">Toggle sidebar</button>
-    </amp-sidebar>
-    <button on="tap:sidebar.toggle">Toggle sidebar</button>
-    <button on="tap:sidebar.open">Open sidebar</button>
-  </div>
-
-  <h2 class="previewOnly">Toolbar</h2>
-  <!-- ## Toolbar -->
-  <!--
-    `toolbar` enables elements within the `amp-sidebar` to be displayed on other parts of the `<body>`. This is useful for responsive design, including navigation bars, social footers, etc.
-
-    `toolbar` elements have their own requirements:
-
-    - The sidebar may implement toolbars by adding `nav` elements with the `toolbar` attribute and `toolbar-target` attribute.
-    - The `nav` element must be a child of `<amp-sidebar>` and follow this format: `<nav toolbar="(media-query)" toolbar-target="elementID">`.
-    - The `nav` containing the toolbar attribute must only contain a single `<ul>` element, that contains `<li>` elements.
-    - The `<li>` elements may contain any valid HTML elements (supported by AMP), or any of the AMP elements that `<amp-sidebar>` supports.
-    - Toolbar behavior is only applied while the `toolbar` attribute media-query is valid. Also, an element with the `toolbar-target` attribute id must exist on the page for the toolbar to be applied.
-  -->
-  <div>
-    <amp-sidebar id="sidebar-left" class="sample-sidebar" layout="nodisplay" side="left">
-      <h3>Sidebar</h3>
-      <button on="tap:sidebar-left.close">Close sidebar</button>
-      <nav toolbar="(min-width: 784px)" toolbar-target="target-element-left">
-        <ul>
-          <li>Nav item 1</li>
-          <li>Nav item 2</li>
-        </ul>
-      </nav>
-      <ul>
-        <li>Nav item 3</li>
-        <li>Nav item 4</li>
-      </ul>
-    </amp-sidebar>
-    <button on="tap:sidebar-left.toggle">Toggle sidebar</button>
-    <div id="target-element-left">
-    </div>
-  </div>
-
-  <h2 class="previewOnly">Styled toolbar</h2>
-  <!-- ## Styled toolbar -->
-  <!--
-    The `toolbar` element within the `<amp-sidebar>` element, will have classes applied to the element depending if the `toolbar-target` element is shown or hidden. This is useful for applying different styles on the `toolbar` element and the `toolbar-target` element. The classes are `amp-sidebar-toolbar-target-shown`, and `amp-sidebar-toolbar-target-hidden`. The class `amp-sidebar-toolbar-target-shown` is applied to the `toolbar` element when the `toolbar-target` element is shown. The class `amp-sidebar-toolbar-target-hidden` is applied to the `toolbar` element when the `toolbar-target` element is hidden.
-
-    ```css
-    .amp-sidebar-toolbar-target-shown {
-      display: none;
-    }
-    ```
-    -->
-    <div>
-      <amp-sidebar id="sidebar-right" class="sample-sidebar" layout="nodisplay" side="right">
-        <h3>Sidebar</h3>
-        <button on="tap:sidebar-right.close">Close sidebar</button>
-        <nav toolbar="(min-width: 784px)" toolbar-target="target-element-right">
-          <ul>
-            <li>Nav item 1</li>
-            <li>Nav item 2</li>
-          </ul>
-        </nav>
-        <ul>
-          <li>Nav item 3</li>
-          <li>Nav item 4</li>
-        </ul>
-      </amp-sidebar>
-      <button on="tap:sidebar-right.toggle">Toggle sidebar</button>
-      <div id="target-element-right">
+    <article>
+      <h1>Main Content</h1>
+      <p class="previewOnly">
+      Please resize the browser window to view the responsiveness for `amp-sidebar`'s toolbar.
+      </p>
+      <h2 class="previewOnly">Basic usage</h2>
+      <!-- ## Basic usage -->
+      <!--
+        The `amp-sidebar` should be a direct child of the `<body>`. It must have a layout of `nodisplay`.  `amp-sidebar` supports the following actions: `toggle`, `open` and `close`.
+      -->
+      <div>
+        <amp-sidebar id="sidebar" class="sample-sidebar" layout="nodisplay" side="right">
+          <h3>Sidebar</h3>
+          <button on="tap:sidebar.close">Close sidebar</button>
+          <button on="tap:sidebar.toggle">Toggle sidebar</button>
+        </amp-sidebar>
+        <button on="tap:sidebar.toggle">Toggle sidebar</button>
+        <button on="tap:sidebar.open">Open sidebar</button>
       </div>
-    </div>
 
-    </body>
+      <h2 class="previewOnly">Toolbar</h2>
+      <!-- ## Toolbar -->
+      <!--
+        `toolbar` enables elements within the `amp-sidebar` to be displayed on other parts of the `<body>`. This is useful for responsive design, including navigation bars, social footers, etc.
+
+        `toolbar` elements have their own requirements:
+
+        - The sidebar may implement toolbars by adding `nav` elements with the `toolbar` attribute and `toolbar-target` attribute.
+        - The `nav` element must be a child of `<amp-sidebar>` and follow this format: `<nav toolbar="(media-query)" toolbar-target="elementID">`.
+        - The `nav` containing the toolbar attribute must only contain a single `<ul>` element, that contains `<li>` elements.
+        - The `<li>` elements may contain any valid HTML elements (supported by AMP), or any of the AMP elements that `<amp-sidebar>` supports.
+        - Toolbar behavior is only applied while the `toolbar` attribute media-query is valid. Also, an element with the `toolbar-target` attribute id must exist on the page for the toolbar to be applied.
+      -->
+      <div>
+        <amp-sidebar id="sidebar-left" class="sample-sidebar" layout="nodisplay" side="left">
+          <h3>Sidebar</h3>
+          <button on="tap:sidebar-left.close">Close sidebar</button>
+          <nav toolbar="(min-width: 784px)" toolbar-target="target-element-left">
+            <ul>
+              <li>Nav item 1</li>
+              <li>Nav item 2</li>
+            </ul>
+          </nav>
+          <ul>
+            <li>Nav item 3</li>
+            <li>Nav item 4</li>
+          </ul>
+        </amp-sidebar>
+        <button on="tap:sidebar-left.toggle">Toggle sidebar</button>
+        <div id="target-element-left">
+        </div>
+      </div>
+
+      <h2 class="previewOnly">Styled toolbar</h2>
+      <!-- ## Styled toolbar -->
+      <!--
+        The `toolbar` element within the `<amp-sidebar>` element, will have classes applied to the element depending if the `toolbar-target` element is shown or hidden. This is useful for applying different styles on the `toolbar` element and the `toolbar-target` element. The classes are `amp-sidebar-toolbar-target-shown`, and `amp-sidebar-toolbar-target-hidden`. The class `amp-sidebar-toolbar-target-shown` is applied to the `toolbar` element when the `toolbar-target` element is shown. The class `amp-sidebar-toolbar-target-hidden` is applied to the `toolbar` element when the `toolbar-target` element is hidden.
+
+        ```css
+        .amp-sidebar-toolbar-target-shown {
+          display: none;
+        }
+        ```
+        -->
+        <div>
+          <amp-sidebar id="sidebar-right" class="sample-sidebar" layout="nodisplay" side="right">
+            <h3>Sidebar</h3>
+            <button on="tap:sidebar-right.close">Close sidebar</button>
+            <nav toolbar="(min-width: 784px)" toolbar-target="target-element-right">
+              <ul>
+                <li>Nav item 1</li>
+                <li>Nav item 2</li>
+              </ul>
+            </nav>
+            <ul>
+              <li>Nav item 3</li>
+              <li>Nav item 4</li>
+            </ul>
+          </amp-sidebar>
+          <button on="tap:sidebar-right.toggle">Toggle sidebar</button>
+          <div id="target-element-right">
+          </div>
+        </div>
+    </article>
+  </main>
+  <!-- ## Desktop Sidebar -->
+  <!--
+    The amp-sidebar can be used as a permanent navigation bar on the main page.
+    The toolbar target is defined as a left hand navigation element using css: flex.
+    (See the `aside` element under `main`.)
+    
+    The amp-sidebar uses the nav toolbar target to populate it's content into this 
+    navigation element.
+  -->
+  <amp-sidebar id="sidebar-desktop" class="desktop-sidebar" layout="nodisplay" side="left">
+    <h1>Desktop Sidebar</h1>
+    <button on="tap:sidebar-desktop.close">Close sidebar</button>
+    <nav toolbar="(min-width: 784px)" toolbar-target="target-element-desktop">
+      <ul>
+        <li>Nav item A</li>
+        <li>Nav item B</li>
+        <li>Nav item C</li>
+        <li>Nav item D</li>
+      </ul>
+    </nav>
+  </amp-sidebar>
+</body>
 </html>

--- a/examples/source/1.components/amp-sidebar.html
+++ b/examples/source/1.components/amp-sidebar.html
@@ -78,7 +78,7 @@ author: juliantoledo
     .desktop-sidebar {
       background-color: lightblue;
     }
-    @media (min-width: 783px) {
+    @media (min-width: 784px) {
       .hamburger {
         display: none;
       }
@@ -93,7 +93,6 @@ author: juliantoledo
   </style>
 </head>
 <body>
-  <!-- Header -->
   <header>
     <h1>Header</h1>
     <button
@@ -103,14 +102,10 @@ author: juliantoledo
       =
     </button>
   </header>
-  
-  <!-- Main Content -->
   <main>
-    <!-- Target for Desktop sidebar -->
     <aside id="target-element-desktop" class="desktop-sidebar">
       <h1>Desktop Sidebar</h1>
     </aside>
-
     <article>
       <h1>Main Content</h1>
       <p class="previewOnly">
@@ -198,24 +193,39 @@ author: juliantoledo
   </main>
   <!-- ## Desktop Sidebar -->
   <!--
-    The amp-sidebar can be used as a permanent navigation bar on the main page.
-    The toolbar target is defined as a left hand navigation element using css: flex.
-    (See the `aside` element under `main`.)
+    The amp-sidebar can be used as a permanent navigation bar on the main page.  The toolbar target (aside element) is defined as a left hand navigation element on the page.
+    ```html
+    <main>
+      <aside id="target-element-desktop" class="desktop-sidebar">...
+      </aside>
+    </main>
+    ```
+
+    Using a media query, the toolbar target can be made visible only when the browser window is greater than a certain width.  Using CSS flex on the parent element of the target allows us to position the target on the left side of the page.
+    ```css
+    @media (min-width: 784px) {
+      main {
+        display: flex;
+        flex-direction: row;
+      }
+    }
+    ```
     
-    The amp-sidebar uses the nav toolbar target to populate it's content into this 
-    navigation element.
+    The amp-sidebar uses the nav toolbar target to populate it's content into this navigation element.  It identifies the nav toolbar target by matching the `id` attribute (defined in the aside element above) with the `toolbar-target` attribute within the `nav` element.
   -->
-  <amp-sidebar id="sidebar-desktop" class="desktop-sidebar" layout="nodisplay" side="left">
-    <h1>Desktop Sidebar</h1>
-    <button on="tap:sidebar-desktop.close">Close sidebar</button>
-    <nav toolbar="(min-width: 784px)" toolbar-target="target-element-desktop">
-      <ul>
-        <li>Nav item A</li>
-        <li>Nav item B</li>
-        <li>Nav item C</li>
-        <li>Nav item D</li>
-      </ul>
-    </nav>
-  </amp-sidebar>
+  <div>
+    <amp-sidebar id="sidebar-desktop" class="desktop-sidebar" layout="nodisplay" side="left">
+      <h1>Desktop Sidebar</h1>
+      <button on="tap:sidebar-desktop.close">Close sidebar</button>
+      <nav toolbar="(min-width: 784px)" toolbar-target="target-element-desktop">
+        <ul>
+          <li>Nav item A</li>
+          <li>Nav item B</li>
+          <li>Nav item C</li>
+          <li>Nav item D</li>
+        </ul>
+      </nav>
+    </amp-sidebar>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
Fixes ampproject/amphtml#26196

Added a navigation sidebar to the amp-sidebar example that is always visible.

@sebastianbenz