### PR TITLE
🚧 Rework custom markdown tag handling

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/test.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/test.md
@@ -1,0 +1,25 @@
+---
+$title: Test
+$order: 1
+description: 'Follow these best practices to create a satisfying snackable story'
+formats:
+  - websites
+  - stories
+author: matthiasrohmer
+---
+
+Stories on the web are an immersive, tappable, and easily shareable storytelling format. Stories is an opportunity for creators and publishers to structure content in a full-screen, visually rich, and engaging mobile first experience for users.  
+
+Stories are snackable, and readers like quick bites in their micro moments! Waiting for the subway or grabbing coffee opens up opportunities for condensed content consumption! Ensure each bite engages and delights by following these best practices for creating a satisfying snackable story.
+
+
+## At a glance
+
+[tip type=note]
+Write an awesome story!
+[/tip]
+
+*   Stories must be valid AMP. You can test yours in the [AMP validator](https://validator.ampproject.org/).
+*   [Metadata attributes](/content/amp-dev/documentation/components/reference/amp-story.md/#metadata-guidelines) ensure your story is defined well. Check that your story has them setup correctly.
+*   Configure you [structured data ](https://developers.google.com/search/docs/guides/sd-policies)so that interested readers can find your story!
+*   Clearly label sponsored content. Any and all paid or affiliated links require the [nofollow](https://support.google.com/webmasters/answer/96569?hl=en) attribute.

--- a/pages/extensions/amp_dev/extension.py
+++ b/pages/extensions/amp_dev/extension.py
@@ -3,11 +3,7 @@ from grow import extensions
 from grow.documents import document, document_format, static_document
 from grow.extensions import hooks
 
-from .markdown_extras import block_filter as BlockFilter
-from .markdown_extras import block_tip as BlockTip
-from .markdown_extras import block_video as BlockVideo
-from .markdown_extras import inline_tip as InlineTip
-
+from .markdown_extras import render as render_markdown_extras
 
 class AmpDevPreRenderHook(hooks.PreRenderHook):
     """Handle the pre-render hook."""
@@ -28,13 +24,15 @@ class AmpDevPreRenderHook(hooks.PreRenderHook):
     def trigger(self, previous_result, doc, original_body, *_args, **_kwargs):
         content = previous_result if previous_result else original_body
 
-        content = self.extension.transform_markdown(doc, original_body, content)
+        # content = self.extension.transform_markdown(doc, original_body, content)
+        content = render_markdown_extras(content)
 
         # The TOC should not contain headlines that are actually enclosed
         # in format filtered sections. filter_toc creates a callable that is
         # later able to filter the TOC based on those sections. It is *not* possible
         # to already evaluate this here as it would overwrite all transformations
-        setattr(doc.format, 'filter_toc', BlockFilter.filter_toc(doc, content))
+        # setattr(doc.format, 'filter_toc', BlockFilter.filter_toc(doc, content))
+        setattr(doc.format, 'filter_toc', lambda toc : toc)
 
         return content
 
@@ -53,12 +51,12 @@ class AmpDevExtension(extensions.BaseExtension):
         # Expose extension direclty on pod for use in templates
         setattr(pod, 'amp_dev', self)
 
-    def transform_markdown(self, doc, original_body, content):
-        content = InlineTip.trigger(original_body, content)
-        content = BlockTip.trigger(original_body, content)
-        content = BlockVideo.trigger(original_body, content)
-        content = BlockFilter.trigger(original_body, content)
-        return content
+    # def transform_markdown(self, doc, original_body, content):
+    #     content = InlineTip.trigger(original_body, content)
+    #     content = BlockTip.trigger(original_body, content)
+    #     content = BlockVideo.trigger(original_body, content)
+    #     content = BlockFilter.trigger(original_body, content)
+    #     return content
 
     def get_represented_locales(self, doc):
         """

--- a/pages/extensions/amp_dev/markdown_extras/__init__.py
+++ b/pages/extensions/amp_dev/markdown_extras/__init__.py
@@ -1,2 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from .skcode import parse_skcode, render_to_html
+from .skcode.tags import build_recognized_tags_dict
+
+from block_tip import TipTreeNode
+
+def render(content):
+    tree = parse_skcode(
+        text=content,
+        recognized_tags=[TipTreeNode, ],
+    )
+    return render_to_html(tree, html_error_template='{source}')

--- a/pages/extensions/amp_dev/markdown_extras/block_tip.py
+++ b/pages/extensions/amp_dev/markdown_extras/block_tip.py
@@ -1,30 +1,97 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import
 
-import re
+from .skcode.etree import TreeNode
 
-TIP_TRIGGER = '[tip'
-TIP_START_TAG_PATTERN = re.compile(r'(\[tip( type=\"(.*?)\")?\])',
-                                   re.MULTILINE)
-TIP_END_TAG_PATTERN = '[/tip]'
-ALLOWED_TYPES = ['default', 'note', 'important', 'read-on']
-
-def trigger(original_body, content):
-    if TIP_TRIGGER in original_body:
-        return _transform(content)
-    return content
+TIP_TYPE_DEFAULT = 'default'
+TIP_TYPE_NOTE = 'note'
+TIP_TYPE_IMPORTANT = 'important'
+TIP_TYPE_READ_ON = 'read-on'
 
 
-def _transform(content):
-    for match in TIP_START_TAG_PATTERN.findall(content):
-        # For tips without a type
-        if not match[1]:
-            content = content.replace(
-                match[0],
-                '{% call tip(\'\', type=\'note\') %}')
-        if match[2]:
-            type = 'default' if not match[2] in ALLOWED_TYPES else match[2]
-            content = content.replace(match[0], '{% call tip(\'\', type=\'' + type + '\') %}')
-    # Then also replace end tags
-    content = content.replace(TIP_END_TAG_PATTERN, '{% endcall %}')
-    return content
+class TipTreeNode(TreeNode):
+    canonical_tag_name = 'tip'
+    alias_tag_names = ()
+
+    accepted_types = (
+        TIP_TYPE_DEFAULT,
+        TIP_TYPE_NOTE,
+        TIP_TYPE_IMPORTANT,
+        TIP_TYPE_READ_ON,
+    )
+
+    default_type = TIP_TYPE_DEFAULT
+
+    # HTML templates for all alert types
+    html_template = {
+
+        TIP_TYPE_DEFAULT: """<div class="ap-m-tip ap-m-tip-default">
+          <div class="ap-m-tip-content">
+            <p>{inner_html}</p>
+          </div>
+        </div>
+        """,
+
+        TIP_TYPE_NOTE: """<div class="ap-m-tip ap-m-tip-note">
+          <div class="ap-m-tip-content">
+            <p>{inner_html}</p>
+          </div>
+        </div>
+        """,
+
+        TIP_TYPE_IMPORTANT: """<div class="ap-m-tip ap-m-tip-important">
+          <div class="ap-m-tip-content">
+            <p>{inner_html}</p>
+          </div>
+        </div>
+        """,
+
+        TIP_TYPE_READ_ON: """<div class="ap-m-tip ap-m-tip-read-on">
+          <div class="ap-m-tip-content">
+            <p>{inner_html}</p>
+          </div>
+        </div>
+        """,
+    }
+
+    alert_type_attr_name = 'type'
+
+    def get_alert_type(self):
+        user_alert_type = self.attrs.get(self.alert_type_attr_name, self.default_type)
+        user_alert_type = user_alert_type.lower()
+        return user_alert_type if user_alert_type in self.accepted_types else self.default_type
+
+    def get_alert_html_template(self, alert_type):
+        return self.html_template[alert_type]
+
+    def render_html(self, inner_html, **kwargs):
+        # Get the alert variables
+        alert_type = self.get_alert_type()
+        alert_html_template = self.get_alert_html_template(alert_type)
+
+        # Render the alert
+        return alert_html_template.format(type=alert_type,
+                                          inner_html=inner_html.strip())
+
+    def render_text(self, inner_text, **kwargs):
+        u"""
+        Callback function for rendering text.
+        :param inner_text: The inner text of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered text of this node.
+        """
+
+        # Get the alert variables
+        alert_type = self.get_alert_type()
+        alert_title = self.get_alert_title()
+        alert_text_title_line_template = self.get_alert_text_title_line_template(alert_type)
+
+        # Render the alert title line
+        lines = [u'*** ' + alert_text_title_line_template.format(title=alert_title)]
+
+        # Render all inner lines
+        for line in inner_text.strip().splitlines():
+            lines.append(u'* ' + line)
+        lines.append(u'***')
+        lines.append(u'')
+        return u'\n'.join(lines)

--- a/pages/extensions/amp_dev/markdown_extras/skcode/__init__.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/__init__.py
@@ -1,0 +1,19 @@
+u"""
+PySkCode, a Python implementation of a full-featured BBCode syntax parser library.
+"""
+
+# Package information
+from __future__ import absolute_import
+__author__ = u"Fabien Batteix (@skywodd)"
+__copyright__ = u"Copyright 2016, TamiaLab"
+__credits__ = [u"Fabien Batteix", u"TamiaLab"]
+__license__ = u"GPLv3"
+__version__ = u"3.2.1"
+__maintainer__ = u"Fabien Batteix"
+__email__ = u"fabien.batteix@tamialab.fr"
+__status__ = u"Production"
+
+
+# User friendly imports
+from .treebuilder import parse_skcode
+from .render import render_to_html, render_to_text

--- a/pages/extensions/amp_dev/markdown_extras/skcode/etree.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/etree.py
@@ -1,0 +1,345 @@
+u"""
+SkCode elements tree code.
+"""
+
+from __future__ import absolute_import
+from html import escape as escape_html
+
+
+class TreeNode(object):
+    u"""
+    Tree node container class.
+
+    A tree node is made of:
+    - a root node instance (used to store document-level information),
+    - a parent node instance (or ``None`` for root node),
+    - a name (``None`` for internal-use only nodes),
+    - an attributes dictionary,
+    - a raw content string (for raw text nodes),
+    - a list child nodes,
+    - the opening and closing tag source strings (for error displaying),
+    - an error message (in case of error).
+
+    The tree node class also contain all tag behavior options as static variables.
+    """
+
+    # ----- Node naming options
+
+    # Canonical tag name (string, mandatory)
+    canonical_tag_name = None
+
+    # Alias tag names (tuple of strings, can be empty)
+    alias_tag_names = ()
+
+    # ----- Node parsing options
+
+    # Set to ``True`` if a newline should automatically close this tag.
+    # When enabling this option, be sure to enable ``same_tag_closes`` to
+    # avoid problem with nested tags not closed by newline.
+    newline_closes = False
+
+    # Set to ``True`` if another opening tag of the same type should
+    # automatically close this tag.
+    # When enabling this option, be sure to enable ``weak_parent_close`` to
+    # avoid problem with unclosed tag taking down the closing tag of his parent.
+    same_tag_closes = False
+
+    # Set to ``True`` if the parent closing tag should
+    # automatically close this tag (if not already closed).
+    weak_parent_close = False
+
+    # Set to ``True`` if this tag does not have a closing tag.
+    # When this option is enabled, the self closing tag format is
+    # allowed for the given tag along with the open tag format.
+    standalone = False
+
+    # Set to ``True`` if children tags should be parsed inside this tag
+    # Setting this to ``False`` will make the tag act like a DATA/CODE tag.
+    parse_embedded = True
+
+    # Set to ``True`` if this tag is an inline tag, or to ``False`` for a block tag.
+    # If set, this tag will be merging into paragraphs by the ``make_paragraphs`` utility.
+    inline = False
+
+    # Set to ``True`` if this tag should close any unclosed inline tag.
+    close_inlines = True
+
+    # ----- Utilities options
+
+    # Set to ``True`` if any inline children nodes of this tag should be merged into paragraphs.
+    make_paragraphs_here = False
+
+    # ----- Internal use variables
+
+    is_root = False
+
+    def __init__(self,
+                 root_tree_node, parent, name,
+                 attrs=None, content=u'', children=None,
+                 source_open_tag=u'', source_close_tag=u'',
+                 error_message=u'', **kwargs):
+        u"""
+        Create a new tree node instance.
+        :param root_tree_node: The root tree node instance (mandatory). Use to store document-level data.
+        N.B. Child nodes root tree node instance will be reset recursively to this root tree node instance to
+        allow merging of two different tree.
+        :param parent: The node parent instance (mandatory). Set to ``None`` for the root node.
+        N.B. Use the ``RootTreeNode`` class for the root tree node.
+        :param name: The node name (mandatory for non-internal use nodes).
+        :param attrs: the node attributes dictionary (default to an empty dictionary).
+        :param content: The node raw content (default to an empty string).
+        :param children: The node children list (default to an empty list).
+        N.B. Child nodes parent instance will be reset to this node instance.
+        :param source_open_tag: The source text for the opening tag of this node (default to an empty string).
+        :param source_close_tag: The source text for the closing tag of this node (default to an empty string).
+        :param error_message: The error message, if any error need to be reported (default to an empty string).
+        """
+        assert root_tree_node, u"The root tree node instance is mandatory."
+        if not self.is_root:
+            assert parent, u"The parent node instance is mandatory for non-root nodes."
+
+        # Store value as attributes
+        self.root_tree_node = root_tree_node
+        self.parent = parent
+        self.name = name
+        self.attrs = attrs or {}
+        self.content = content
+        self.children = children or []
+        self.source_open_tag = source_open_tag
+        self.source_close_tag = source_close_tag
+        self.error_message = error_message
+
+        # Allow class constants overload at object creation
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+        # Rebase children parent and root tree node
+        for child in self.children:
+            child.parent = self
+        self.reset_root_tree_node(root_tree_node)
+
+    def reset_root_tree_node(self, new_root_tree_node):
+        u"""
+        Reset the root tree node instance of this node and all child nodes recursively.
+        :param new_root_tree_node: The new root tree node instance
+        """
+        self.root_tree_node = new_root_tree_node
+        for child in self.children:
+            child.reset_root_tree_node(new_root_tree_node)
+
+    def new_child(self, name, node_cls, append=True, **kwargs):
+        u"""
+        Create a new child node from the given arguments.
+        Auto set the parent attribute of the newly created child node to this node instance and append the child
+        node to the children list of this node if ``append=True``.
+        :param name: The tag name of the new tre node.
+        :param node_cls: The class to be used to create the new tree node.
+        :param append: If set to ``True``, the newly created child will be added to the node children list.
+        :param kwargs: Keyword arguments for the tree node class constructor.
+        :return: The newly created node instance.
+        """
+        new_child_node = node_cls(self.root_tree_node, self, name, **kwargs)
+        if append:
+            self.children.append(new_child_node)
+        return new_child_node
+
+    def get_raw_content(self, recursive=True):
+        u"""
+        Return the raw content of this node and of children nodes if ``recursive=True``.
+        :param recursive: Set to ``True`` to include any child nodes content (default ``True``).
+        :return The raw content of this node and of children nodes, if requested.
+        """
+        content = self.content
+        if recursive:
+            for child_node in self.children:
+                content += child_node.get_raw_content()
+        return content
+
+    def get_attribute_value(self, *fields, **_3to2kwargs):
+        if 'default' in _3to2kwargs: default = _3to2kwargs['default']; del _3to2kwargs['default']
+        else: default = u''
+        u"""
+        Get the attribute value by looking at each given field names.
+        Return the first non empty field value or the default value.
+        Use an empty string as field name to indicate the node name.
+        :param fields: The list of fields to look for value in lookup order.
+        :param default: The default value to be returned.
+        :return: The attribute value.
+        """
+        for field in fields:
+            value = self.attrs.get(field if field else self.name)
+            if value:
+                return value
+        return default
+
+    def has_attribute_switch_set(self, attr_name, name_attr_value=None):
+        u"""
+        Check if the given attribute switch is set or not.
+        The attribute switch is set of the attribute name is found in the attributes dictionary or
+        if the node named attribute has the given value.
+        :param attr_name: The attribute switch field name.
+        :param name_attr_value: The attribute switch node named attribute value.
+        :return: A bool ``True`` if the switch is set, ``False`` otherwise.
+        """
+        return attr_name in self.attrs or self.attrs.get(self.name, u'').lower() == name_attr_value
+
+    def search_in_tree(self, node_cls):
+        u"""
+        Walk down the tree and yield any node matching the given class.
+        :param node_cls: The class type to search for (or a tuple of class types).
+        """
+
+        # Check the current tree node first
+        if isinstance(self, node_cls):
+            yield self
+
+        # Check all children nodes
+        for child in self.children:
+            for subchild in child.search_in_tree(node_cls):
+                yield subchild
+
+    def has_errors(self):
+        u"""
+        Walk down the tree and return ``True`` only if at least one node is erroneous.
+        """
+        if self.error_message:
+            return True
+        for child in self.children:
+            if child.has_errors():
+                return True
+        return False
+
+    def pre_process_node(self):
+        u"""
+        Callback function for pre-processing the given node. Allow registration of IDs, references, etc.
+        This function is called in a top-to-down visit order, starting from the root node and going down to each
+        leaf node.
+        """
+
+    def sanitize_node(self, breadcrumb):
+        u"""
+        Callback function for sanitizing and cleaning-up the given node.
+        This function must validate it's own state and direct children type / ordering.
+        This function is called in a down-to-top visit order (depth-first algorithm), starting from the last
+        node of each branch and going up to the root node. This allow unwrapping of the current node
+        in the parent node children list because the parent children list is checked AFTER all his children.
+        In worst case scenario, an erroneous node can be unwrap up to the root node level.
+        :param breadcrumb: The breadcrumb of node instances from the root node to the current node (excluded).
+        """
+        # TODO implement default behavior
+        # Default policy:
+        # - inline accept only other inline
+        # - allowed_parent_type option
+        # - allow_same_type_nested option
+        # - add tag_categories
+        # - white list category
+        # - blacklist category
+        pass
+
+    def post_process_node(self):
+        u"""
+        Callback function for post-processing the given node. Allow generation of summary, etc.
+        This function is called in a top-to-down visit order, starting from the root node and going down to each
+        leaf node.
+        """
+
+    def render_html(self, inner_html, **kwargs):
+        u"""
+        Callback function for rendering HTML.
+        :param inner_html: The inner HTML of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered HTML of this node.
+        """
+        raise NotImplementedError(u'render_html() need to be implemented in subclass')
+
+    def render_error_html(self, inner_html, html_error_template, **kwargs):
+        u"""
+        Callback function for rendering HTML when the node is erroneous.
+        :param inner_html: The inner HTML of this tree node.
+        :param html_error_template: The HTML template for rendering the erroneous parts of the output.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered HTML of this node.
+        """
+        output_html = []
+        if self.source_open_tag:
+            output_html.append(html_error_template.format(error_message=self.error_message,
+                                                          source=escape_html(self.source_open_tag)))
+
+        inner_content = inner_html or escape_html(self.get_raw_content())
+        if inner_content:
+            output_html.append(inner_content)
+
+        if self.source_close_tag:
+            output_html.append(html_error_template.format(error_message=self.error_message,
+                                                          source=escape_html(self.source_close_tag)))
+
+        return u'\n'.join(output_html)
+
+    def render_text(self, inner_text, **kwargs):
+        u"""
+        Callback function for rendering text.
+        :param inner_text: The inner text of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered text of this node.
+        """
+        raise NotImplementedError(u'render_text() need to be implemented in subclass')
+
+    def render_error_text(self, inner_text, **kwargs):
+        u"""
+        Callback function for rendering text when the node is erroneous.
+        :param inner_text: The inner text of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered HTML of this node.
+        """
+        output_html = []
+        if self.source_open_tag:
+            output_html.append(self.source_open_tag)
+
+        inner_content = inner_text or self.get_raw_content()
+        if inner_content:
+            output_html.append(inner_content)
+
+        if self.source_close_tag:
+            output_html.append(self.source_close_tag)
+
+        return u''.join(output_html)
+
+
+class RootTreeNode(TreeNode):
+    u"""
+    Root tree node container class.
+    Subclass of the ``TreeNode`` class which set ``parent=None``.
+    This class is special, unwrap and delete operations are not supported.
+    Attributes dictionary is not used for rendering, but instead, as a document-level data container.
+    """
+
+    make_paragraphs_here = True
+
+    is_root = True
+
+    def __init__(self, attrs=None, children=None, **kwargs):
+        u"""
+        Create a new root tree node.
+        :param attrs: The root node attributes dictionary (default to an empty dictionary).
+        :param children: The root node children list (default to an empty list).
+        """
+        self.known_ids = set()
+        super(RootTreeNode, self).__init__(self, None, None, attrs=attrs, children=children, **kwargs)
+
+    def render_html(self, inner_html, **kwargs):
+        u"""
+        Callback function for rendering HTML.
+        :param inner_html: The inner HTML of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered HTML of this node.
+        """
+        return inner_html
+
+    def render_text(self, inner_text, **kwargs):
+        u"""
+        Callback function for rendering text.
+        :param inner_text: The inner text of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered text of this node.
+        """
+        return inner_text

--- a/pages/extensions/amp_dev/markdown_extras/skcode/parser.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/parser.py
@@ -1,0 +1,232 @@
+u"""
+SkCode tag parsing code.
+"""
+
+from __future__ import absolute_import
+import string
+
+
+# Character charsets
+WHITESPACE_CHARSET = frozenset(string.whitespace)
+IDENTIFIER_CHARSET = frozenset(string.ascii_letters + string.digits + u'_*')
+
+
+def skip_whitespaces(text, offset):
+    u"""
+    Skip any whitespaces.
+    :param text: The input text.
+    :param offset: The current offset in the input text.
+    :return The new offset in the input text.
+    """
+    while text[offset] in WHITESPACE_CHARSET:
+        offset += 1
+    return offset
+
+
+def get_identifier(text, offset):
+    u"""
+    Get the identifier string starting in the text at the given offset.
+    :param text: The input text.
+    :param offset: The current offset in the input text.
+    :return The identifier normalized as lowercase and the new offset in the input text.
+    """
+    identifier = u''
+
+    # Get any identifier char
+    while text[offset] in IDENTIFIER_CHARSET:
+        identifier += text[offset]
+        
+        # Process the next char
+        offset += 1
+
+    # Normalize the identifier and return new values
+    return identifier.lower(), offset
+
+
+def get_attribute_value(text, offset, opening_tag_ch, closing_tag_ch):
+    u"""
+    Get the attribute value starting in the text at the given offset.
+    :param text: The input text.
+    :param offset: The current offset in the input text.
+    :param opening_tag_ch: The opening tag char (must be one char long).
+    :param closing_tag_ch: The closing tag char (must be one char long).
+    :return The attribute value with trailing whitespaces removed and the new offset in the input text.
+    """
+    attribute_value = u''
+    
+    # Handle quoted and unquoted value
+    if text[offset] == u"'" or text[offset] == u'"':
+        quoting_ch = text[offset]
+
+        # Process the next char
+        offset += 1
+
+        # Get attribute value
+        while text[offset] != quoting_ch:
+
+            # Handle escape sequences
+            if text[offset] == u'\\':
+
+                # Process the next char
+                offset += 1
+
+                # Only the quoting char and the backslash char can be escaped
+                if text[offset] != quoting_ch and text[offset] != u'\\':
+                    attribute_value += u'\\'
+                
+            # Store the char
+            attribute_value += text[offset]
+
+            # Process the next char
+            offset += 1
+
+        # Skip last quoting sign
+        offset += 1
+
+    else:
+
+        # Get raw attribute value
+        ch = text[offset]
+        while ch != closing_tag_ch and ch != opening_tag_ch and ch not in WHITESPACE_CHARSET:
+            attribute_value += ch
+
+            # Process the next char
+            offset += 1
+            ch = text[offset]
+
+    # Check format
+    if text[offset] != closing_tag_ch and text[offset] not in WHITESPACE_CHARSET:
+        raise ValueError(u'A whitespace is mandatory after the attribute '
+                         u'value if not followed by the closing tag char')
+
+    # Strip the attribute value and return new values
+    return attribute_value.strip(), offset
+
+
+def parse_tag(text, start_offset,
+              opening_tag_ch=u'[', closing_tag_ch=u']',
+              allow_tagvalue_attr=True, allow_self_closing_tags=True):
+    u"""
+    Parse the text starting at ``start_offset`` to extract a valid tag, if any.
+    Return the tag name, the ``is_closing_tag`` and ``is_self_closing_tag`` flags,
+    the tag attributes (as a dictionary) and the offset just after the end of the tag.
+    If something goes wrong (malformed tag, unexpected end-of-file, etc.) an exception
+    of type``IndexError`` (unexpected end-of-file) or ``ValueError`` (malformed tag) is raised.
+    :param text: The input text.
+    :param start_offset: The offset in the input text to start with.
+    :param opening_tag_ch: The opening tag char (must be one char long, default '[').
+    :param closing_tag_ch: The closing tag char (must be one char long, default ']').
+    :param allow_tagvalue_attr: Set to ``True`` to allow the BBcode ``tagname=tagvalue`` syntax shortcut
+    (default is ``True``).
+    :param allow_self_closing_tags: Set to ``True`` to allow the self closing tags syntax (default is ``True``).
+    :return A tuple ``(tag_name, is_closing_tag, is_self_closing_tag, tag_attrs, offset + 1)`` on success, or an
+    exception on error (see possible exception in the docstring above).
+    """
+    assert text, u"No text input given (mandatory)."
+    assert start_offset >= 0, u"Starting offset must be greater or equal to zero."
+    assert start_offset < len(text), u"Starting offset must be lower than the size of the text."
+    assert len(opening_tag_ch) == 1, u"Opening tag character must be one char long exactly."
+    assert len(closing_tag_ch) == 1, u"Closing tag character must be one char long exactly."
+    assert text[start_offset] == opening_tag_ch, u"Unexpected call to parse_tag, no opening tag char at starting offset."
+
+    # Init tag variables
+    tag_attrs = {}
+    is_closing_tag = is_self_closing_tag = False
+
+    # Skip the opening char and whitespaces
+    offset = skip_whitespaces(text, start_offset + 1)
+
+    # Check for closing tag
+    if text[offset] == u'/':
+
+        # Look like a closing tag for me
+        is_closing_tag = True
+
+        # Skip slash and whitespaces
+        offset = skip_whitespaces(text, offset + 1)
+
+    # Get the tag name
+    tag_name, offset = get_identifier(text, offset)
+
+    # Detect invalid tag early
+    if not tag_name:
+        raise ValueError(u'Invalid tag format: no tag name found')
+
+    # Skip whitespaces
+    offset = skip_whitespaces(text, offset)
+
+    # Check for closing char if is_closing_tag is set (closing tags have no attribute)
+    if is_closing_tag and text[offset] != closing_tag_ch:
+        raise ValueError(u'Invalid tag format: closing tags cannot have attribute')
+
+    # Check for tag value
+    if text[offset] == u'=':
+
+        # Check for support
+        if not allow_tagvalue_attr:
+            raise ValueError(u'Invalid tag format: tagname=tagvalue shortcut support disabled by caller.')
+
+        # Skip equal sign and whitespaces
+        offset = skip_whitespaces(text, offset + 1)
+
+        # Get the tag value
+        tag_value, offset = get_attribute_value(text, offset, opening_tag_ch, closing_tag_ch)
+
+        # Store the tag value
+        tag_attrs[tag_name] = tag_value
+
+        # Skip whitespaces
+        offset = skip_whitespaces(text, offset)
+
+    # Named attributes handling
+    while text[offset] != closing_tag_ch and text[offset] != u'/':
+
+        # Get the attribute name
+        attr_name, offset = get_identifier(text, offset)
+
+        # Detect erroneous attribute name
+        if not attr_name:
+            raise ValueError(u'Invalid tag format: no attribute name found or invalid character found')
+
+        # Skip whitespaces
+        offset = skip_whitespaces(text, offset)
+
+        # Check for attr value
+        if text[offset] == u'=':
+
+            # Skip equal sign and whitespaces
+            offset = skip_whitespaces(text, offset + 1)
+            
+            # Get the attribute value
+            attr_value, offset = get_attribute_value(text, offset, opening_tag_ch, closing_tag_ch)
+            
+            # Store the tag value
+            tag_attrs[attr_name] = attr_value
+
+            # Skip whitespaces
+            offset = skip_whitespaces(text, offset)
+
+        else:
+
+            # Attribute without value
+            tag_attrs[attr_name] = u''
+
+    # Handle self closing tag
+    if text[offset] == u'/':
+
+        # Check for support
+        if not allow_self_closing_tags:
+            raise ValueError(u'Invalid tag format: self closing tags support disabled by caller.')
+
+        # Look like a self closing tag for me
+        is_self_closing_tag = True
+
+        # Skip slash and whitespaces
+        offset = skip_whitespaces(text, offset + 1)
+
+    # Assert end of tag
+    if text[offset] != closing_tag_ch:
+        raise ValueError(u'Invalid tag format: malformed end of tag')
+    
+    # Emit the tag
+    return tag_name, is_closing_tag, is_self_closing_tag, tag_attrs, offset + 1

--- a/pages/extensions/amp_dev/markdown_extras/skcode/render.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/render.py
@@ -1,0 +1,97 @@
+u"""
+SkCode rendering code.
+"""
+
+
+# Default HTML for error messages
+DEFAULT_ERROR_HTML_TEMPLATE = u'<span style="font-weight: bold; color: red;" ' \
+                              u'title="{error_message}">{source}</span>'
+SUPPRESS_ERROR_HTML_TEMPLATE = u'<!-- {error_message} --> {source}'
+
+
+def render_inner_html(tree_node,
+                      force_rel_nofollow=True,
+                      html_error_template=DEFAULT_ERROR_HTML_TEMPLATE, **kwargs):
+    u"""
+    Render all children of the given tree node as HTML.
+    :param tree_node: The parent tree node with children to be rendered.
+    :param force_rel_nofollow: If set to ``True``, all links in the rendered HTML will have the attribute
+        "rel=nofollow" to avoid search engines to scrawl them (default ``True``).
+    :param html_error_template: HTML template for displaying error messages.
+    :param kwargs: Extra keywords arguments for the ``render_html`` callback method.
+    :return The rendered children tree as HTML.
+    """
+
+    # Get the inner HTML
+    inner_html = []
+    for child_node in tree_node.children:
+        inner_html.append(render_to_html(child_node,
+                                         force_rel_nofollow=force_rel_nofollow,
+                                         html_error_template=html_error_template, **kwargs))
+
+    # Return the inner HTML as string
+    return u''.join(inner_html)
+
+
+def render_to_html(tree_node,
+                   force_rel_nofollow=True,
+                   html_error_template=DEFAULT_ERROR_HTML_TEMPLATE, **kwargs):
+    u"""
+    Render the given tree node and children recursively as HTML.
+    :param tree_node: The tree node to be rendered.
+    :param force_rel_nofollow: If set to ``True``, all links in the rendered HTML will have the attribute
+        "rel=nofollow" to avoid search engines to scrawl them (default ``True``).
+    :param html_error_template: HTML template for displaying error messages.
+    :param kwargs: Extra keywords arguments for the ``render_html`` callback method.
+    :return The rendered document tree as HTML.
+    """
+
+    # Get the inner HTML
+    inner_html = render_inner_html(tree_node,
+                                   force_rel_nofollow=force_rel_nofollow,
+                                   html_error_template=html_error_template, **kwargs)
+
+    # Render the node
+    if tree_node.error_message:
+        return tree_node.render_error_html(inner_html,
+                                           force_rel_nofollow=force_rel_nofollow,
+                                           html_error_template=html_error_template, **kwargs)
+    else:
+        return tree_node.render_html(inner_html,
+                                     force_rel_nofollow=force_rel_nofollow,
+                                     html_error_template=html_error_template, **kwargs)
+
+
+def render_inner_text(tree_node, **kwargs):
+    u"""
+    Render all children of the given tree node as text.
+    :param tree_node: The parent tree node with children to be rendered.
+    :param kwargs: Extra keywords arguments for the ``render_text`` callback method.
+    :return The rendered children tree as text.
+    """
+
+    # Get the inner text
+    inner_text = []
+    for child_node in tree_node.children:
+        inner_text.append(render_to_text(child_node, **kwargs))
+
+    # Return the inner text as string
+    return u''.join(inner_text)
+
+
+def render_to_text(tree_node, **kwargs):
+    u"""
+    Render the given tree node and children recursively as text.
+    :param tree_node: The tree node to be rendered.
+    :param kwargs: Extra keywords arguments for the ``render_text`` callback method.
+    :return The rendered document tree as text.
+    """
+
+    # Get the inner text
+    inner_text = render_inner_text(tree_node, **kwargs)
+
+    # Render the node
+    if tree_node.error_message:
+        return tree_node.render_error_text(inner_text, **kwargs)
+    else:
+        return tree_node.render_text(inner_text, **kwargs)

--- a/pages/extensions/amp_dev/markdown_extras/skcode/tags/__init__.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/tags/__init__.py
@@ -1,0 +1,43 @@
+u"""
+SkCode tag definitions code.
+"""
+
+# Import all tag definitions here
+from __future__ import absolute_import
+from .internal import (
+    TextTreeNode,
+    NewlineTreeNode,
+    HardNewlineTreeNode
+)
+
+
+def build_recognized_tags_dict(tag_class_list):
+    u"""
+    Turn a list of tag node classes into a dictionary of tag names and corresponding node class.
+    :param tag_class_list: The list of tag node classes for all supported tags.
+    :return: A dictionary ``{tag_name: class}`` with all tag name and alias registered as key.
+    """
+    recognized_tags_dict = {}
+
+    # For each tag declaration
+    for tag_class in tag_class_list:
+
+        # Sanity checks
+        if type(tag_class) is not type:
+            raise ValueError(u'{} is an instance, not a class type'.format(tag_class.__class__.__name__))
+        if not tag_class.canonical_tag_name:
+            raise ValueError(u'{} does not have a canonical name'.format(tag_class.__name__))
+
+        # Register the canonical tag name
+        if tag_class.canonical_tag_name in recognized_tags_dict:
+            raise KeyError(u'Tag name "{}" is already registered'.format(tag_class.canonical_tag_name))
+        recognized_tags_dict[tag_class.canonical_tag_name] = tag_class
+
+        # Register all aliases
+        for alias_name in tag_class.alias_tag_names:
+            if alias_name in recognized_tags_dict:
+                raise KeyError(u'Alias name "{}" is already registered'.format(alias_name))
+            recognized_tags_dict[alias_name] = tag_class
+
+    # Return the dict
+    return recognized_tags_dict

--- a/pages/extensions/amp_dev/markdown_extras/skcode/tags/internal.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/tags/internal.py
@@ -1,0 +1,82 @@
+u"""
+SkCode internal tag definitions code.
+"""
+
+from __future__ import absolute_import
+from ..etree import TreeNode
+
+
+class TextTreeNode(TreeNode):
+    u""" Text tree node class. """
+
+    inline = True
+    close_inlines = False
+
+    def render_html(self, inner_html, **kwargs):
+        u"""
+        Callback function for rendering HTML.
+        :param inner_html: The inner HTML of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered HTML of this node.
+        """
+        content = self.content
+        return content
+
+    def render_text(self, inner_text, **kwargs):
+        u"""
+        Callback function for rendering text.
+        :param inner_text: The inner text of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered text of this node.
+        """
+        content = self.content
+        content = unescape_html_entities(content)
+        content = do_cosmetics_replacement(self.root_tree_node, content)
+        return content
+
+
+class NewlineTreeNode(TreeNode):
+    u""" Newline tree node class. """
+
+    inline = True
+    close_inlines = False
+
+    def render_html(self, inner_html, **kwargs):
+        u"""
+        Callback function for rendering HTML.
+        :param inner_html: The inner HTML of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered HTML of this node.
+        """
+        return u'\n'
+
+    def render_text(self, inner_text, **kwargs):
+        u"""
+        Callback function for rendering text.
+        :param inner_text: The inner text of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered text of this node.
+        """
+        return u' '
+
+
+class HardNewlineTreeNode(NewlineTreeNode):
+    u""" Newline (hard line break variant) tree node class. """
+
+    def render_html(self, inner_html, **kwargs):
+        u"""
+        Callback function for rendering HTML.
+        :param inner_html: The inner HTML of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered HTML of this node.
+        """
+        return u'<br>\n'
+
+    def render_text(self, inner_text, **kwargs):
+        u"""
+        Callback function for rendering text.
+        :param inner_text: The inner text of this tree node.
+        :param kwargs: Extra keyword arguments for rendering.
+        :return The rendered text of this node.
+        """
+        return u'\n'

--- a/pages/extensions/amp_dev/markdown_extras/skcode/tokenizer.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/tokenizer.py
@@ -1,0 +1,103 @@
+u"""
+SkCode tag tokenizer code.
+"""
+
+from __future__ import absolute_import
+from .parser import parse_tag
+
+
+# Token types
+TOKEN_DATA = 0
+TOKEN_NEWLINE = 1
+TOKEN_OPEN_TAG = 2
+TOKEN_CLOSE_TAG = 3
+TOKEN_SELF_CLOSE_TAG = 4
+
+
+def tokenize_newline(data):
+    u"""
+    Given a string that does not contain any tags, this function will
+    yield a list of ``TOKEN_NEWLINE`` and ``TOKEN_DATA`` tokens in such way
+    that if you concatenate their data, you will have the original string.
+    N.B. Newline must have been normalized to ``\n`` before calling this function.
+    :param data: Input data string to be tokenize.
+    """
+    lines = data.split(u'\n')
+    last_line = lines.pop()
+    for line in lines:
+        if line:
+            yield TOKEN_DATA, None, None, line
+        yield TOKEN_NEWLINE, None, None, u'\n'
+
+    if last_line:
+        yield TOKEN_DATA, None, None, last_line
+
+
+def tokenize_tag(text,
+                 opening_tag_ch=u'[', closing_tag_ch=u']',
+                 allow_tagvalue_attr=True, allow_self_closing_tags=True):
+    u"""
+    Split the given text into tokens (generator function).
+    :param text: The input text to be tokenize.
+    :param opening_tag_ch: The opening tag char (must be one char long, default '[').
+    :param closing_tag_ch: The closing tag char (must be one char long, default ']').
+    :param allow_tagvalue_attr: Set to ``True`` to allow the BBcode ``tagname=tagvalue`` syntax shortcut
+    (default is ``True``).
+    :param allow_self_closing_tags: Set to ``True`` to allow the self closing tags syntax (default is ``True``).
+    """
+    assert text, u"No text input given (mandatory)."
+    assert len(opening_tag_ch) == 1, u"Opening tag character must be one char long exactly."
+    assert len(closing_tag_ch) == 1, u"Closing tag character must be one char long exactly."
+
+    # Normalize newlines (fastest method)
+    text = text.replace(u'\r\n', u'\n').replace(u'\r', u'\n')
+
+    # Search an opening tag
+    start = text.find(opening_tag_ch)
+    pos = 0
+
+    # Process the whole text until no more tag can be found
+    # N.B. string.find(s, beg) return -1 if beg >= len(string)
+    while start >= 0:
+
+        # Run the parser to get the tag
+        try:
+            tag = parse_tag(text, start,
+                            opening_tag_ch, closing_tag_ch,
+                            allow_tagvalue_attr, allow_self_closing_tags)
+
+        except (IndexError, ValueError):
+
+            # Continue searching if not a valid tag
+            start = text.find(opening_tag_ch, start + 1)
+            continue
+
+        # Get the text before the tag, if any
+        if start > pos:
+            text_before_tag = text[pos:start]
+            for token in tokenize_newline(text_before_tag):
+                yield token
+
+        # Unpack the tag structure
+        tag_name, is_closing_tag, is_self_closing_tag, tag_attrs, offset = tag
+        tag_source = text[start:offset]
+
+        # Yield the tag token
+        if is_self_closing_tag:
+            yield TOKEN_SELF_CLOSE_TAG, tag_name, tag_attrs, tag_source
+        elif is_closing_tag:
+            yield TOKEN_CLOSE_TAG, tag_name, tag_attrs, tag_source
+        else:
+            yield TOKEN_OPEN_TAG, tag_name, tag_attrs, tag_source
+
+        # Store the current position in text for next loop
+        pos = offset
+
+        # Search the next tag if any
+        start = text.find(opening_tag_ch, offset)
+
+    # Yield the remaining piece of text if any
+    remaining_text = text[pos:]
+    if remaining_text:
+        for token in tokenize_newline(remaining_text):
+            yield token

--- a/pages/extensions/amp_dev/markdown_extras/skcode/tools.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/tools.py
@@ -1,0 +1,125 @@
+u"""
+SkCode tools code.
+"""
+
+from __future__ import absolute_import
+import re
+import unicodedata
+
+from html import escape as escape_html
+from urlparse import urlsplit, urlunsplit, urljoin
+
+
+# URL charset regex for cleaning URL
+URL_CHARSET_SUB = re.compile(ur'[^a-zA-Z0-9-~+_.?#=!&;,/:%@$\|*\'()\[\]\x80-\xff]')
+
+
+def escape_attribute_value(value):
+    u"""
+    Escape the given value and return it escaped and wrapped in simple or double quotes.
+    Try to avoid escape sequence as much as possible to make the value more user-friendly.
+    :param value: The input attribute value (unescaped).
+    :return The attribute value escaped, with surrounding quotes if required.
+    """
+    if u"'" in value and u'"' in value:
+        return u'"{}"'.format(value.replace(u'\\', u'\\\\').replace(u'"', u'\\"'))
+    elif u'"' in value:
+        return u"'{}'".format(value)
+    else:
+        return u'"{}"'.format(value)
+
+
+def sanitize_url(url, default_scheme=u'http',
+                 allowed_schemes=(u'http', u'https', u'ftp', u'ftps', u'mailto'),
+                 encode_html_entities=True, force_default_scheme=False,
+                 force_remove_scheme=False, fix_non_local_urls=True,
+                 absolute_base_url=u''):
+    u"""
+    Sanitize the given URL. Avoid XSS by filtering-out forbidden protocol and characters.
+    Allowed protocols by default are: ``http``, ``https``, ``ftp``, ``ftps`` and ``mailto``.
+    If no protocol scheme is specified, all non-local URL will be tied to the default scheme.
+    :param url: The user-supplied URL to be sanitized.
+    :param default_scheme: The default scheme to use (default to ``http``).
+    :param allowed_schemes: The list of allowed schemes (see defaults above).
+    :param encode_html_entities: If set to ``True``, the output URL will be encoded to avoid raw HTML entities
+    (default is ``True``).
+    :param force_default_scheme: Set to ``True`` to force the default scheme to be used in all case
+    (default is``False``).
+    :param force_remove_scheme: Set to ``True`` to remove the scheme if set (default is ``False``).
+    N.B. The ``force_default_scheme`` and ``force_remove_scheme`` are mutually exclusive for obvious reasons.
+    :param fix_non_local_urls: Set to ``True`` to fix non local URL with netloc in path (default is ``True``).
+    Example: with ``fix_non_local_urls`` set to ``True``, ``google.com`` will become ``http://google.com/``.
+    :param absolute_base_url: The base URL for the relative-to-absolute conversion.
+    If set, relative URLs will be expanded as absolute URLs using the given base URL. Example: with
+    ``absolute_base_url`` set to ``http://example.com/``, ``/forum/`` will become ``http://example.com/forum/``.
+    :return: The sanitized URL as string, or an empty string if erroneous.
+    """
+    assert default_scheme, u"A default scheme is mandatory to avoid XSS."
+    assert len(allowed_schemes) > 0, u"You need to allow at least one scheme to get a result."
+    assert not (force_default_scheme and
+                force_remove_scheme), u"You cannot force the default scheme and also force-remove the scheme."
+
+    # Shortcut for empty string
+    if not url:
+        return u''
+
+    # Remove dangerous stuff
+    url = URL_CHARSET_SUB.sub(u'', url)
+
+    # Split the URL
+    try:
+        scheme, netloc, path, query, fragment = urlsplit(url)
+    except ValueError:
+
+        # Handle malformed URL
+        return u''
+
+    # Check the scheme against the white list
+    if scheme and scheme not in allowed_schemes:
+        return u''
+
+    # Detect and fix non local URL without // at beginning (not supported by  ``urlsplit``)
+    if not netloc and path and not path.startswith(u'/') and fix_non_local_urls:
+        parts = path.split(u'/', 1)
+        if len(parts) == 2:
+            netloc, path = parts
+        else:
+            netloc = parts[0]
+            path = u''
+
+    # Add scheme to any non-local URL if required
+    if (not scheme and netloc) or force_default_scheme:
+        scheme = default_scheme
+
+    # Remove the scheme if requested
+    if force_remove_scheme:
+        scheme = u''
+
+    # Build the final URL
+    if netloc or not absolute_base_url:
+        result = urlunsplit((scheme, netloc, path, query, fragment))
+    else:
+        result = urlunsplit((u'', u'', path, query, fragment))
+        result = urljoin(absolute_base_url, result)
+
+    # Escape HTML if requested
+    if encode_html_entities:
+        result = escape_html(result)
+
+    # Return the sanitized URL
+    return result
+
+
+def slugify(value):
+    u"""
+    Convert the given value to a plain-text ASCII slug. Spaces are converted to hyphens.
+    Characters that aren't alphanumerics, underscores, or hyphens are removed.
+    The resulting string is then converted to lowercase. Leading and trailing whitespace are also stripped.
+    :param value: The string to be turned into a slug.
+    """
+    value = value.strip()
+    if not value:
+        return u''
+    value = unicodedata.normalize(u'NFKD', value).encode(u'ascii', u'ignore').decode(u'ascii')
+    value = re.sub(ur'[^\w\s-]', u'', value).strip().lower()
+    return re.sub(ur'[-\s]+', u'-', value).strip(u'-')

--- a/pages/extensions/amp_dev/markdown_extras/skcode/treebuilder.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/treebuilder.py
@@ -1,0 +1,298 @@
+u"""
+SkCode AST tree builder code.
+"""
+
+from __future__ import absolute_import
+from collections import defaultdict
+from gettext import gettext as _
+
+from .etree import (
+    RootTreeNode,
+    TreeNode
+)
+from .tags import (
+    # DEFAULT_RECOGNIZED_TAGS_LIST,
+    build_recognized_tags_dict,
+    NewlineTreeNode,
+    TextTreeNode
+)
+from .tokenizer import (
+    tokenize_tag,
+    TOKEN_DATA,
+    TOKEN_NEWLINE,
+    TOKEN_OPEN_TAG,
+    TOKEN_CLOSE_TAG,
+    TOKEN_SELF_CLOSE_TAG
+)
+
+
+def parse_skcode(text,
+                 recognized_tags=[],
+                 opening_tag_ch=u'[', closing_tag_ch=u']',
+                 allow_tagvalue_attr=True, allow_self_closing_tags=True,
+                 root_node_cls=RootTreeNode,
+                 text_node_cls=TextTreeNode,
+                 newline_node_cls=NewlineTreeNode,
+                 mark_unclosed_tags_as_erroneous=False,
+                 max_nesting_depth=16,
+                 cls_options_overload=None):
+    u"""
+    Parse the given text as a BBCode formatted document.
+    Return the resulting document tree (DOM-like parser).
+    :param text: The input text to be parsed.
+    :param recognized_tags: A list containing all valid tag classes.
+    :type recognized_tags: iterable[TreeNode]
+    :param opening_tag_ch: The opening tag char (must be one char long exactly, default '[').
+    :param closing_tag_ch: The closing tag char (must be one char long exactly, default ']').
+    :param allow_tagvalue_attr: Set to ``True`` to allow the BBCode ``tagname=tagvalue`` syntax shortcut
+    (default is ``True``).
+    :param allow_self_closing_tags: Set to ``True`` to allow the self closing tags syntax (default is ``True``).
+    :param root_node_cls: The tree node class for the root node.
+    :param text_node_cls: The tree node class for all normal text nodes.
+    :param newline_node_cls: The tree node class for all newlines.
+    :param mark_unclosed_tags_as_erroneous: If set to ``True``, unclosed tags will be mark as erroneous
+    (default is ``False``).
+    :param max_nesting_depth: The maximum nesting depth (default to 16). Set to zero to disable (not recommended
+    because a Denial-Of-Service is possible if nesting depth is not limited).
+    :param cls_options_overload: Dictionary of dictionaries mapped by node class type ``{class: {key : value}}``
+    to be used to overload node options settings on a per node class basis.
+    This allow simple tweak of a default class behaviour at runtime.
+    :type cls_options_overload: dict[TreeNode, dict[str, Any]]
+    :return The resulting document tree at the end of the parsing stage.
+    """
+    assert opening_tag_ch, u"The opening tag character is mandatory."
+    assert len(opening_tag_ch) == 1, u"Opening tag character must be one char long exactly."
+    assert closing_tag_ch, u"The closing tag character is mandatory."
+    assert len(closing_tag_ch) == 1, u"Closing tag character must be one char long exactly."
+    assert root_node_cls, u"Root tree node class is mandatory."
+    assert text_node_cls, u"Text tree node class is mandatory."
+    assert newline_node_cls, u"Newline tree node class is mandatory."
+    assert max_nesting_depth >= 0, u"Maximum nesting depth must be greater or equal than zero."
+
+    # Build the known tag names dictionary
+    recognized_tags = build_recognized_tags_dict(recognized_tags)
+
+    # Build the overload options dictionary
+    extra_cls_kwargs = defaultdict(dict)
+    if cls_options_overload:
+        extra_cls_kwargs.update(cls_options_overload)
+
+    # Initialize the parser
+    root_tree_node = cur_tree_node = root_node_cls()
+    cur_nesting_depth = 0
+
+    # Cleanup text to avoid parsing useless whitespaces
+    text = text.strip()
+    if not text:
+        return root_tree_node
+
+    # Tokenize the input text
+    for token in tokenize_tag(text,
+                              opening_tag_ch, closing_tag_ch,
+                              allow_tagvalue_attr, allow_self_closing_tags):
+
+        # Unpack the token
+        token_type, tag_name, tag_attrs, token_source = token
+
+        # Handle DATA block
+        if not cur_tree_node.parse_embedded and (token_type != TOKEN_CLOSE_TAG or tag_name != cur_tree_node.name):
+
+            # Append the raw source to the node until closing tag found
+            cur_tree_node.content += token_source
+            continue
+
+        # The ``if`` below must be an ``if`` and not an ``elif`` because we need to parse
+        # the closing tag of the DATA block when received.
+
+        # Handle unrecognized tags
+        if tag_name is not None and tag_name not in recognized_tags:
+
+            # Turn the token into raw data
+            cur_tree_node.new_child(None, text_node_cls,
+                                    source_open_tag=token_source,
+                                    error_message=_(u'Unknown tag name'))
+
+        # SAX-like tree building algorithm
+        elif token_type == TOKEN_DATA:
+
+            # Append to the current node
+            cur_tree_node.new_child(None, text_node_cls,
+                                    content=token_source)
+
+        elif token_type == TOKEN_NEWLINE:
+
+            # Handle newline_closes option
+            # Loop to handle the case when nested tag need to be closed at once
+            while cur_tree_node.newline_closes and cur_tree_node.parent is not None:
+                cur_tree_node = cur_tree_node.parent
+
+            # Append to the current node
+            cur_tree_node.new_child(None, newline_node_cls)
+
+        elif token_type == TOKEN_OPEN_TAG:
+
+            # Handle nesting depth limit
+            if max_nesting_depth and cur_nesting_depth >= max_nesting_depth:
+
+                # Tag cannot be open, fallback as erroneous text
+                cur_tree_node.new_child(None, text_node_cls,
+                                        source_open_tag=token_source,
+                                        error_message=_(u'Nesting depth limit reached'))
+
+                # End of processing for this tag
+                continue
+
+            # Load tag options
+            tag_cls = recognized_tags[tag_name]
+
+            # Handle same_tag_closes option
+            if cur_tree_node.same_tag_closes \
+                    and isinstance(cur_tree_node, tag_cls) \
+                    and cur_tree_node.parent is not None:
+                cur_tree_node = cur_tree_node.parent
+
+            # Handle close_inlines
+            if tag_cls.close_inlines:
+                while cur_tree_node.inline and cur_tree_node.parent is not None:
+                    cur_tree_node = cur_tree_node.parent
+
+            # Create a new child node
+            new_node = cur_tree_node.new_child(tag_name, tag_cls,
+                                               attrs=tag_attrs,
+                                               source_open_tag=token_source,
+                                               **extra_cls_kwargs[tag_cls])
+
+            # Jump to the new child node if not standalone
+            if not tag_cls.standalone:
+                cur_tree_node = new_node
+
+                # Update nesting depth limit
+                cur_nesting_depth += 1
+
+        elif token_type == TOKEN_CLOSE_TAG:
+
+            # Check if current node can be closed
+            if cur_tree_node.parent is None or cur_tree_node.name != tag_name:
+
+                # Look for the parent to close
+                depth = 0
+                cursor = cur_tree_node
+                while cursor.parent is not None and (
+                            (cursor.weak_parent_close and cursor.parent.name != tag_name) or cursor.parent.name == tag_name):
+                    depth += 1
+                    cursor = cursor.parent
+
+                # Handle weak parent close option
+                if cursor.name == tag_name:
+
+                    # Close all traversal tree nodes
+                    cur_tree_node = cursor
+
+                    # Also close the parent node
+                    cur_tree_node.source_close_tag = token_source
+                    cur_tree_node = cur_tree_node.parent
+
+                    # Update nesting depth limit
+                    cur_nesting_depth -= depth
+
+                else:
+
+                    # Tag cannot be closed, fallback as erroneous text
+                    cur_tree_node.new_child(None, text_node_cls,
+                                            source_close_tag=token_source,
+                                            error_message=_(u'Unexpected closing tag'))
+
+            else:
+
+                # Close the current tree node
+                cur_tree_node.source_close_tag = token_source
+                cur_tree_node = cur_tree_node.parent
+
+                # Update nesting depth limit
+                if cur_nesting_depth:
+                    cur_nesting_depth -= 1
+
+        elif token_type == TOKEN_SELF_CLOSE_TAG:
+
+            # Load tag options
+            tag_cls = recognized_tags[tag_name]
+
+            # Detect erroneous self closing tag
+            if not tag_cls.standalone:
+
+                # Erroneous tag, fallback as erroneous text
+                cur_tree_node.new_child(None, text_node_cls,
+                                        source_open_tag=token_source,
+                                        error_message=_(u'Unexpected self closing tag'))
+
+            else:
+
+                # Create a new child node
+                cur_tree_node.new_child(tag_name, tag_cls,
+                                        attrs=tag_attrs,
+                                        source_open_tag=token_source,
+                                        **extra_cls_kwargs[tag_cls])
+
+    # Close all remaining weak nodes
+    while cur_tree_node != root_tree_node and cur_tree_node.parent is not None and cur_tree_node.weak_parent_close:
+        cur_tree_node = cur_tree_node.parent
+
+    # Mark unclosed tags as erroneous
+    if mark_unclosed_tags_as_erroneous:
+        while cur_tree_node != root_tree_node and cur_tree_node.parent is not None:
+            cur_tree_node.error_message = _(u'Unclosed tag')
+            cur_tree_node = cur_tree_node.parent
+
+    # Perform sanity check
+    pre_process_tree(root_tree_node)
+    sanitize_tree(root_tree_node)
+    post_process_tree(root_tree_node)
+
+    # Return the resulting AST
+    return root_tree_node
+
+
+def pre_process_tree(tree_node):
+    u"""
+    Recursive method for pre-processing the given tree node and children recursively.
+    :param tree_node: The tree node to be pre-processed.
+    """
+
+    # Pre-process the node
+    tree_node.pre_process_node()
+
+    # Go down the tree
+    for child_node in tree_node.children:
+        pre_process_tree(child_node)
+
+
+def sanitize_tree(tree_node, breadcrumb=None):
+    u"""
+    Recursive method for sanitizing the given tree node and children recursively.
+    :param tree_node: The tree node to be sanitized.
+    :param breadcrumb: The current breadcrumb of parent nodes (default to an empty list).
+    :type breadcrumb: list or None
+    """
+    breadcrumb = breadcrumb or []
+
+    # Down to top visit order (depth-first algorithm) with breadcrumb
+    sub_breadcrumb = [] if tree_node.is_root else [tree_node]
+    for child_node in tree_node.children:
+        sanitize_tree(child_node, breadcrumb + sub_breadcrumb)
+
+    # Sanitize the node
+    tree_node.sanitize_node(breadcrumb)
+
+
+def post_process_tree(tree_node):
+    u"""
+    Recursive method for post-processing the given tree node and children recursively.
+    :param tree_node: The tree node to be post-processed.
+    """
+
+    # Post-process the node
+    tree_node.post_process_node()
+
+    # Go down the tree
+    for child_node in tree_node.children:
+        post_process_tree(child_node)

--- a/pages/extensions/amp_dev/markdown_extras/skcode/utility/__init__.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/utility/__init__.py
@@ -1,0 +1,3 @@
+u"""
+SkCode utilities library.
+"""

--- a/pages/extensions/amp_dev/markdown_extras/skcode/utility/relative_urls.py
+++ b/pages/extensions/amp_dev/markdown_extras/skcode/utility/relative_urls.py
@@ -1,0 +1,30 @@
+u"""
+Relative to absolute URLs conversion utility.
+"""
+
+# Document attribute name for storing the base URL
+RELATIVE_URL_BASE_ATTR_NAME = u'RELATIVE_URL_BASE'
+
+
+def setup_relative_urls_conversion(document_tree, relative_url_base):
+    u"""
+    Setup the document for automatic relative URLs to absolute URLs conversion.
+    :param document_tree: The document tree to be setup.
+    :param relative_url_base: The base URL to be used for converting all relative URLs to absolute ones. Need to
+    be in form ``scheme://netloc/(path/)``.
+    """
+    assert document_tree, u"Document tree is mandatory."
+    assert document_tree.is_root, u"Document tree must be a root tree node instance."
+    assert relative_url_base, u"The base URL for relative URLs conversion if mandatory."
+
+    # Store the base URL for relative URLs
+    document_tree.attrs[RELATIVE_URL_BASE_ATTR_NAME] = relative_url_base
+
+
+def get_relative_url_base(document_tree):
+    u"""
+    Get the base URL for all relative URLs.
+    :param document_tree: The document tree.
+    :return: The base URL or an empty string.
+    """
+    return document_tree.attrs.get(RELATIVE_URL_BASE_ATTR_NAME, u'')


### PR DESCRIPTION
Works towards #3657 and #3658.

The basic problem of our custom markdown extensions (besides them consisting of multiple rendering layers) are that they are RegEx based at their core. This introduces pitfalls like the following:

```
[filter format="'websites"]
This is for websites.

[filter level="advanced"]
And this only for website experts.
[/filter]

[/filter]
```

The example above currently only works fine because it is translated to `{% call %}` tags which are evaluated by jinja2 which uses a parse-tree and gracefully handles nested tags. If we skip jinja2 and only rely on regular expressions this would fail as the inner closing tag would match the first opening tag. The only way I see to approach this is to use a parser for our custom tags while staying away from building our own - but I'm coming to that.

We initially switched to the RegEx based solution coming from [bbcode](https://github.com/dcwatson/bbcode). The problem was it is kinda slow, malformatted some of our documents and didn't have a great API. Therefore I reevaluated some others and came to [PySkCode](https://github.com/TamiaLab/PySkCode). It would serve all our needs and is simply extensible. Our `[tip]` tag, for example, would look like this:

https://github.com/ampproject/amp.dev/blob/925c266487380c97fa610b2fc28015b7d4c24309/pages/extensions/amp_dev/markdown_extras/block_tip.py#L12-L14

Although it's simple to extend it still comes with downsides: we mix HTML templating and logic. Before our tip template was simple jinja2:

https://github.com/ampproject/amp.dev/blob/80e0f4644fc2dc24fa2e73b82c166ec30a4b7bb1/frontend/templates/views/partials/tip.j2#L6-L15

But there are more downsides: PySkCode was actually built for Python 3. I could easily backport it for 2.7. (since Grow is still working on Python 3 support: https://github.com/grow/grow/issues/164) by using [3to2](https://pypi.org/project/3to2/) and doing some minor manual adjustments though now it's not really upgradeable anymore. Also, we are manually adding code to our repository which should actually be installed by a package manager because we are trying to get rid of the need for `pip` at the same time.

I'm somehow stuck deciding how to proceed that's why I'm opening this draft PR for discussion: I think writing a parser on our own isn't worth the effort which would, in my opinion, better be invested in switching to something that would us get rid of all the Python stuff all along. Using a third-party, existing parser comes with the downsides described above...

