### PR TITLE
🐛 Only add required scripts for scripts not for tags

### DIFF
--- a/platform/lib/pipeline/componentReferenceDocument.js
+++ b/platform/lib/pipeline/componentReferenceDocument.js
@@ -65,6 +65,7 @@ class ComponentReferenceDocument extends MarkdownDocument {
 
     const scripts = [];
     const requiredExtensions = [];
+
     if (extension.script) {
       requiredExtensions.push(extension.script.extensionSpec.name);
       scripts.push(
@@ -74,21 +75,21 @@ class ComponentReferenceDocument extends MarkdownDocument {
           extension.type
         )
       );
-    }
 
-    if (extension.tag && extension.tag.requiresExtension) {
-      for (const requiredExtension of extension.tag.requiresExtension) {
-        if (requiredExtensions.includes(requiredExtension)) {
-          continue;
+      if (extension.script.requiresExtension) {
+        for (const requiredExtension of extension.script.requiresExtension) {
+          if (requiredExtensions.includes(requiredExtension)) {
+            continue;
+          }
+
+          scripts.push(
+            this._generateScript(
+              requiredExtension,
+              DEFAULT_VERSION,
+              extension.type
+            )
+          );
         }
-
-        scripts.push(
-          this._generateScript(
-            requiredExtension,
-            DEFAULT_VERSION,
-            extension.type
-          )
-        );
       }
     }
 


### PR DESCRIPTION
Fixes #3699. The look-up for other required extensions has been happening on the tag instead of the script element.

This made `amp-sidebar` listed as a required extension for `amp-nested-menu` but ignored for what the look-up has actually been implemented: `amp-access-poool` (and related) should list `amp-access` and `amp-access-poool`. This is now the case.

I've quickly gone through all imported component docs and required scripts now look fine from what I can tell.