### PR TITLE
📈 Add various analytics triggers

### DIFF
--- a/frontend/templates/views/partials/analytics.j2
+++ b/frontend/templates/views/partials/analytics.j2
@@ -1,3 +1,13 @@
+{% if '/documentation/examples/' in doc.pod_path %}
+{% set category = 'examples' %}
+{% elif '/documentation/components/' in doc.pod_path %}
+{% set category = 'components' %}
+{% elif '/documentation/courses/' in doc.pod_path %}
+{% set category = 'courses' %}
+{% elif '/documentation/guides-and-tutorials/' in doc.pod_path %}
+{% set category = 'guides-and-tutorials' %}
+{% endif %}
+
 {% set config = {
   'vars': {
     'gtag_id': podspec.gaTrackingId,
@@ -16,19 +26,31 @@
         'event_category': 'search',
         'event_action': 'open'
       }
+    },
+    'scrolledHalf': {
+      'on': 'scroll',
+      'scrollSpec': {
+        'verticalBoundaries': [50]
+      },
+      'vars': {
+        'event_name': 'scroll',
+        'event_category': category or 'other',
+        'event_action': 'half'
+      }
+    },
+    'scrolledEnd': {
+      'on': 'scroll',
+      'scrollSpec': {
+        'verticalBoundaries': [90]
+      },
+      'vars': {
+        'event_name': 'scroll',
+        'event_category': category or 'other',
+        'event_action': 'end'
+      }
     }
   }
 } %}
-
-{% if '/documentation/examples/' in doc.pod_path %}
-{% set category = 'examples' %}
-{% elif '/documentation/components/' in doc.pod_path %}
-{% set category = 'components' %}
-{% elif '/documentation/courses/' in doc.pod_path %}
-{% set category = 'courses' %}
-{% elif '/documentation/guides-and-tutorials/' in doc.pod_path %}
-{% set category = 'guides-and-tutorials' %}
-{% endif %}
 
 {# On the courses page track how often the courses are downloaded #}
 {% if doc.pod_path == '/content/amp-dev/documentation/courses/teachers.md' %}
@@ -113,31 +135,6 @@
     'event_name': 'format-toggle',
     'event_category': category,
     'event_action': 'link'
-  }
-}}) %}
-
-{# Scroll #}
-{# Track when certain depths of the site have been reached #}
-{% do config['triggers'].update({'scrolledHalf': {
-  'on': 'scroll',
-  'scrollSpec': {
-    'verticalBoundaries': [50]
-  },
-  'vars': {
-    'event_name': 'scroll',
-    'event_category': category,
-    'event_action': 'half'
-  }
-}}) %}
-{% do config['triggers'].update({'scrolledEnd': {
-  'on': 'scroll',
-  'scrollSpec': {
-    'verticalBoundaries': [90]
-  },
-  'vars': {
-    'event_name': 'scroll',
-    'event_category': category,
-    'event_action': 'end'
   }
 }}) %}
 {% endif %}

--- a/frontend/templates/views/partials/analytics.j2
+++ b/frontend/templates/views/partials/analytics.j2
@@ -1,38 +1,150 @@
+{% set config = {
+  'vars': {
+    'gtag_id': podspec.gaTrackingId,
+    'config': {
+      podspec.gaTrackingId: {
+        'groups': 'default'
+      }
+    }
+  },
+  'triggers': {
+    'searchButton': {
+      'selector': '#searchTriggerOpen',
+      'on': 'click',
+      'vars': {
+        'event_name': 'search',
+        'event_category': 'search',
+        'event_action': 'open'
+      }
+    }
+  }
+} %}
+
+{% if '/documentation/examples/' in doc.pod_path %}
+{% set category = 'examples' %}
+{% elif '/documentation/components/' in doc.pod_path %}
+{% set category = 'components' %}
+{% elif '/documentation/courses/' in doc.pod_path %}
+{% set category = 'courses' %}
+{% elif '/documentation/guides-and-tutorials/' in doc.pod_path %}
+{% set category = 'guides-and-tutorials' %}
+{% endif %}
+
+{# On the courses page track how often the courses are downloaded #}
+{% if doc.pod_path == '/content/amp-dev/documentation/courses/teachers.md' %}
+{% do config['triggers'].update({'getCoursesButton': {
+  'selector': '#get-courses',
+  'on': 'click',
+  'vars': {
+    'event_name': 'courses',
+    'event_category': category,
+    'event_action': 'download'
+    }
+}}) %}
+{% endif %}
+
+{% if category %}
+{# Table of contents #}
+{% if not (doc.format.toc == '<div class="toc">\n<ul></ul>\n</div>\n' or not doc.format.toc) and not (doc.toc == False or doc.collection.toc == False) %}
+{# Track click on links inside the TOC #}
+{% do config['triggers'].update({'tocLink': {
+  'selector': '.ap-o-toc a',
+  'on': 'click',
+  'vars': {
+    'event_name': 'toc',
+    'event_category': category,
+    'event_action': 'link'
+    }
+}}) %}
+
+{# Track when the TOC is toggled #}
+{% do config['triggers'].update({'tocToggle': {
+  'selector': '.ap-o-toc label',
+  'on': 'click',
+  'vars': {
+    'event_name': 'toc',
+    'event_category': category,
+    'event_action': 'toggle'
+    }
+}}) %}
+{% endif %}
+
+{# Sidebar #}
+{# Track clicks on links inside the sidebar #}
+{% do config['triggers'].update({'sidebarLink': {
+  'selector': '.ap-o-sidebar a',
+  'on': 'click',
+  'vars': {
+    'event_name': 'sidebar',
+    'event_category': category,
+    'event_action': 'link'
+    }
+}}) %}
+{# Track when the sidebar is toggled #}
+{% do config['triggers'].update({'sidebarToggle': {
+  'selector': 'label[for="sidebar-desktop"], label[for="sidebar"]',
+  'on': 'click',
+  'vars': {
+    'event_name': 'sidebar',
+    'event_category': category,
+    'event_action': 'toggle'
+    }
+}}) %}
+
+{# Breadcrubms #}
+{# Track when a breadcrumb is used #}
+{% do config['triggers'].update({'breadcrumbLink': {
+  'selector': '.ap-m-breadcrumbs-crumb',
+  'on': 'click',
+  'vars': {
+    'event_name': 'breadcrumbs',
+    'event_category': category,
+    'event_action': 'link'
+    }
+}}) %}
+
+
+{# Format toggle #}
+{# Track when format is changed #}
+{% do config['triggers'].update({'formatToggle': {
+  'selector': '.ap-m-format-toggle-link',
+  'on': 'click',
+  'vars': {
+    'event_name': 'format-toggle',
+    'event_category': category,
+    'event_action': 'link'
+  }
+}}) %}
+
+{# Scroll #}
+{# Track when certain depths of the site have been reached #}
+{% do config['triggers'].update({'scrolledHalf': {
+  'on': 'scroll',
+  'scrollSpec': {
+    'verticalBoundaries': [50]
+  },
+  'vars': {
+    'event_name': 'scroll',
+    'event_category': category,
+    'event_action': 'half'
+  }
+}}) %}
+{% do config['triggers'].update({'scrolledEnd': {
+  'on': 'scroll',
+  'scrollSpec': {
+    'verticalBoundaries': [90]
+  },
+  'vars': {
+    'event_name': 'scroll',
+    'event_category': category,
+    'event_action': 'end'
+  }
+}}) %}
+{% endif %}
+
 {% do doc.amp_dependencies.add('amp-analytics', '0.1') %}
 <amp-analytics type="gtag" data-credentials="include">
   <script type="application/json">
-  {
-    "vars" : {
-      "gtag_id": "{{ podspec.gaTrackingId }}",
-      "config" : {
-        "{{ podspec.gaTrackingId }}": {
-          "groups": "default"
-        }
-      }
-    },
-    "triggers": {
-      "searchButton": {
-        "selector": "#searchTriggerOpen",
-        "on": "click",
-        "vars": {
-          "event_name": "search",
-          "event_category": "search",
-          "event_action": "open"
-        }
-      }
-      {% if doc.pod_path == '/content/amp-dev/documentation/courses/teachers.md' %}
-      ,
-      "getCoursesButton": {
-        "selector": "#get-courses",
-        "on": "click",
-        "vars": {
-          "event_name": "courses",
-          "event_category": "courses",
-          "event_action": "download"
-          }
-      }
-      {% endif %}
-    }
-  }
+    {{ config|tojson }}
   </script>
 </amp-analytics>


### PR DESCRIPTION
Resolves #3723. This adds analytics triggers for the following events:

- Clicks on links inside the table of contents 
- Clicks on links inside the sidebar
- Toggling of the sidebar
- Toggling of the TOC
- Clicks on breadcrumb links
- Clicks on a new format inside the format toggle or the format notification
- Scroll depths (50% and 90% depth)

I've been wondering why `event_name` isn't sent to GTM with each request. I assume that's handled under the hood when the configuration is initially transformed by the GTM?
