### PR TITLE
🚸 Show specific component samples as first in component intro

### DIFF
--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -425,7 +425,7 @@ class SamplesBuilder {
 
       this._componentSamples[component].sort((sample1, sample2) => {
         return sample1.title.startsWith(component) ? 1 : 0;
-      }).reverse();
+      });
     }
 
     try {


### PR DESCRIPTION
Fixes #3767 - I guess. The order is correct during development for me and it's inverted on prod and honestly, I can't get my head around why. But I assume not reversing the array should fix it for production at least.