### PR TITLE
Add keyboard-select-mode

### DIFF
--- a/examples/source/style-layout/Tab_Panels_with_amp-selector.html
+++ b/examples/source/style-layout/Tab_Panels_with_amp-selector.html
@@ -104,7 +104,7 @@ author: tcorley
 
       The tab content is positioned below the tab button using a flex layout.
     -->
-    <amp-selector class="tabs-with-flex" role="tablist">
+    <amp-selector class="tabs-with-flex" role="tablist" keyboard-select-mode="focus">
       <div id="tab1" role="tab" aria-controls="tabpanel1" option selected>Tab one</div>
       <div id="tabpanel1" role="tabpanel" aria-labelledby="tab1">Tab one content... </div>
       <div id="tab2" role="tab" aria-controls="tabpanel2" option>Tab two</div>
@@ -123,7 +123,7 @@ author: tcorley
       <button on="tap:myTabs.toggle(index=1, value=true)">Select tab 2</button>
       <button on="tap:myTabs.toggle(index=2, value=true)">Select tab 3</button>
 
-      <amp-selector id="myTabs" class="tabs-with-flex" role="tablist">
+      <amp-selector id="myTabs" class="tabs-with-flex" role="tablist" keyboard-select-mode="focus">
         <div id="sample2-tab1" role="tab" aria-controls="sample2-tabpanel1" option selected>Tab one</div>
         <div id="sample2-tabpanel1" role="tabpanel" aria-labelledby="sample2-tab1">Tab one content... </div>
         <div id="sample2-tab2" role="tab" aria-controls="sample2-tabpanel2" option>Tab two</div>
@@ -141,7 +141,7 @@ author: tcorley
      -->
     <div>
       <amp-selector class="tabs-with-selector" role="tablist"
-        on="select:myTabPanels.toggle(index=event.targetOption, value=true)">
+        on="select:myTabPanels.toggle(index=event.targetOption, value=true)" keyboard-select-mode="focus">
         <div id="sample3-tab1" role="tab" aria-controls="sample3-tabpanel1" option="0" selected>Tab one</div>
         <div id="sample3-tab2" role="tab" aria-controls="sample3-tabpanel2" option="1">Tab two</div>
         <div id="sample3-tab3" role="tab" aria-controls="sample3-tabpanel3" option="2">Tab three</div>


### PR DESCRIPTION
At the request of @sebastianbenz, I've added the `keyboard-select-mode` attribute to each of the three examples on this sample page. 

It's worth noting that I've passed the `focus` option (versus `select` or `none`). There was no stipulation as to which option these examples ought to employ, so I went with what I thought was the most approachable alternative.  Please let me know if you would like me to make any changes.