### PR TITLE
Add Permutive to the analytics-vendors page

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics-vendors.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics-vendors.md
@@ -286,6 +286,17 @@ Type attribute value: `parsely`
 
 Adds support for Parsely. Configuration details can be found at [parsely.com/docs](http://parsely.com/docs/integration/tracking/google-amp.html).
 
+### Permutive
+
+Type attribute value: `permutive`
+
+Adds support for Permutive event collection. Additionally, the following `vars` must be defined:
+
+* `namespace`: your Permutive AMP namespace
+* `key`: your Permutive public API key
+
+Use `extraUrlParams` to add additional event properties. Full configuration details can be found at [support.permutive.com](http://support.permutive.com).
+
 ### Piano
 
 Type attribute value: `piano`


### PR DESCRIPTION
This PR is to add Permutive to the AMP analytics-vendors page. 

The previous PR for this (ampproject/amp.dev/pull/1313) was merged after analytics-vendors was migrated.