### PR TITLE
Fix speling mistake in article URL

### DIFF
--- a/examples/source/style-layout/Dark_Mode_Toggle.html
+++ b/examples/source/style-layout/Dark_Mode_Toggle.html
@@ -11,7 +11,7 @@
   This sample demonstrates how to use dark mode. It shows both `prefers-color-scheme`
   as well as a manual toggle for people on non-supporting browsers.
   You can read more about `prefers-color-scheme` in the article
-  https://web.de/prefers-color-scheme.
+  https://web.dev/prefers-color-scheme.
 -->
 
 <!-- -->


### PR DESCRIPTION
The article is not at https://web.de/prefers-color-scheme, but at https://web.dev/prefers-color-scheme. Please also update the article at https://amp.dev/documentation/examples/style-layout/dark_mode_toggle/