### PR TITLE
template, fix pages linking

### DIFF
--- a/templates/websites/travel/templates/travel.amp.html
+++ b/templates/websites/travel/templates/travel.amp.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8">
   <title>Travel Template</title>
-  <link rel="canonical" href="https://www.ampstart.com/templates/travel/travel.amp">
+  <link rel="canonical" href="https://www.ampstart.com/templates/travel/travel.amp.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <meta name="amp-google-client-id-api" content="googleanalytics">
 
@@ -76,7 +76,7 @@
 <section class="relative z2">
   <header class="travel-header absolute top-0 right-0 left-0">
     <div class="px1 md-px2 py1 md-py2 flex justify-between items-center">
-       <a href="travel.amp" class="travel-icon-logo mx-auto inline-block circle">
+       <a href="travel.amp.html" class="travel-icon-logo mx-auto inline-block circle">
 <svg class="travel-icon travel-icon-logo h2" viewBox="0 0 100 100"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="7.5"><circle cx="50" cy="50" r="45"></circle><path d="M20.395 83.158c-2.37-10.263-.79-18.553 4.737-24.87 8.29-9.472 17.763-1.183 26.052-9.472 8.29-8.29 2.37-18.948 10.658-26.053 5.526-4.737 12.237-6.316 20.132-4.737M39.084 95c-2.788-10.2-1.912-17.304 2.627-21.316 6.808-6.017 14.956-.68 24.088-9.623 9.13-8.94 3.062-17.133 10.255-23.534 4.795-4.267 10.282-5.668 16.46-4.203"></path></g></svg>        </a>
     </div>
   </header>
@@ -147,7 +147,7 @@
           </label>
         </div>
 
-        <a href="travel-results.amp" class="ampstart-btn travel-input-big rounded center bold white block col-12" on="
+        <a href="travel-results.amp.html" class="ampstart-btn travel-input-big rounded center bold white block col-12" on="
             tap:AMP.setState({
                 ui_reset: false,
                 ui_filterPane: false,
@@ -228,7 +228,7 @@
   <div class="overflow-scroll">
     <div class="travel-overflow-container">
       <div class="flex justify-center p1 md-px1 mxn1">
-          <a href="travel-results.amp" class="travel-activities-activity travel-type-active mx1" on="
+          <a href="travel-results.amp.html" class="travel-activities-activity travel-type-active mx1" on="
               tap:AMP.setState({
                 ui_viewIndex: 1,
                 fields_type: ['active'],
@@ -244,7 +244,7 @@
               Active
             </p>
           </a>
-          <a href="travel-results.amp" class="travel-activities-activity travel-type-artistic mx1" on="
+          <a href="travel-results.amp.html" class="travel-activities-activity travel-type-artistic mx1" on="
               tap:AMP.setState({
                 ui_viewIndex: 1,
                 fields_type: ['artistic'],
@@ -260,7 +260,7 @@
               Artistic
             </p>
           </a>
-          <a href="travel-results.amp" class="travel-activities-activity travel-type-drinks mx1" on="
+          <a href="travel-results.amp.html" class="travel-activities-activity travel-type-drinks mx1" on="
               tap:AMP.setState({
                 ui_viewIndex: 1,
                 fields_type: ['drinks'],
@@ -276,7 +276,7 @@
               Drinks
             </p>
           </a>
-          <a href="travel-results.amp" class="travel-activities-activity travel-type-fashion mx1" on="
+          <a href="travel-results.amp.html" class="travel-activities-activity travel-type-fashion mx1" on="
               tap:AMP.setState({
                 ui_viewIndex: 1,
                 fields_type: ['fashion'],
@@ -292,7 +292,7 @@
               Fashion
             </p>
           </a>
-          <a href="travel-results.amp" class="travel-activities-activity travel-type-food mx1" on="
+          <a href="travel-results.amp.html" class="travel-activities-activity travel-type-food mx1" on="
               tap:AMP.setState({
                 ui_viewIndex: 1,
                 fields_type: ['food'],
@@ -308,7 +308,7 @@
               Food
             </p>
           </a>
-          <a href="travel-results.amp" class="travel-activities-activity travel-type-music mx1" on="
+          <a href="travel-results.amp.html" class="travel-activities-activity travel-type-music mx1" on="
               tap:AMP.setState({
                 ui_viewIndex: 1,
                 fields_type: ['music'],
@@ -324,7 +324,7 @@
               Music
             </p>
           </a>
-          <a href="travel-results.amp" class="travel-activities-activity travel-type-nature mx1" on="
+          <a href="travel-results.amp.html" class="travel-activities-activity travel-type-nature mx1" on="
               tap:AMP.setState({
                 ui_viewIndex: 1,
                 fields_type: ['nature'],
@@ -340,7 +340,7 @@
               Nature
             </p>
           </a>
-          <a href="travel-results.amp" class="travel-activities-activity travel-type-nightlife mx1" on="
+          <a href="travel-results.amp.html" class="travel-activities-activity travel-type-nightlife mx1" on="
               tap:AMP.setState({
                 ui_viewIndex: 1,
                 fields_type: ['nightlife'],
@@ -356,7 +356,7 @@
               Nightlife
             </p>
           </a>
-          <a href="travel-results.amp" class="travel-activities-activity travel-type-tours mx1" on="
+          <a href="travel-results.amp.html" class="travel-activities-activity travel-type-tours mx1" on="
               tap:AMP.setState({
                 ui_viewIndex: 1,
                 fields_type: ['tours'],
@@ -372,7 +372,7 @@
               Tours
             </p>
           </a>
-          <a href="travel-results.amp" class="travel-activities-activity travel-type-water mx1" on="
+          <a href="travel-results.amp.html" class="travel-activities-activity travel-type-water mx1" on="
               tap:AMP.setState({
                 ui_viewIndex: 1,
                 fields_type: ['water'],
@@ -546,7 +546,7 @@
   <div class="max-width-3 mx-auto relative">
     <div class="travel-featured-grid flex flex-wrap items-stretch">
       <div class="col-12 md-col-6 flex items-stretch flex-auto">
-        <a href="travel-results.amp" class="travel-featured-tile flex flex-auto relative travel-featured-color-blue" on="tap:AMP.setState({fields_query: 'New York', query_query: 'New York'})">
+        <a href="travel-results.amp.html" class="travel-featured-tile flex flex-auto relative travel-featured-color-blue" on="tap:AMP.setState({fields_query: 'New York', query_query: 'New York'})">
           <amp-img class="travel-object-cover flex-auto" layout="responsive" width="336" height="507" src="../../img/travel/city/new-york.jpg"></amp-img>
           <div class="travel-featured-overlay absolute z1 center top-0 right-0 bottom-0 left-0 white p2">
             <div class="travel-featured-tile-heading caps bold line-height-2 h3">New York</div>
@@ -554,14 +554,14 @@
           </div>
         </a>
         <div class="flex flex-column items-stretch flex-auto">
-          <a href="travel-results.amp" class="travel-featured-tile flex flex-auto relative travel-featured-color-cyan" on="tap:AMP.setState({fields_query: 'Barcelona', query_query: 'Barcelona'})">
+          <a href="travel-results.amp.html" class="travel-featured-tile flex flex-auto relative travel-featured-color-cyan" on="tap:AMP.setState({fields_query: 'Barcelona', query_query: 'Barcelona'})">
             <amp-img class="travel-object-cover flex-auto" layout="responsive" width="264" height="246" src="../../img/travel/city/barcelona.jpg"></amp-img>
             <div class="travel-featured-overlay absolute z1 center top-0 right-0 bottom-0 left-0 white p2">
               <div class="travel-featured-tile-heading bold caps line-height-2 h3">Barcelona</div>
               <div class="h5">68 adventures</div>
             </div>
           </a>
-          <a href="travel-results.amp" class="travel-featured-tile flex flex-auto pointer relative travel-featured-color-orange" on="tap:AMP.setState({fields_query: 'Paris', query_query: 'Paris'})">
+          <a href="travel-results.amp.html" class="travel-featured-tile flex flex-auto pointer relative travel-featured-color-orange" on="tap:AMP.setState({fields_query: 'Paris', query_query: 'Paris'})">
             <amp-img class="travel-object-cover flex-auto" layout="responsive" width="264" height="264" src="../../img/travel/city/paris.jpg"></amp-img>
             <div class="travel-featured-overlay absolute z1 center top-0 right-0 bottom-0 left-0 white p2">
               <div class="travel-featured-tile-heading bold caps line-height-2 h3">Paris</div>
@@ -572,14 +572,14 @@
       </div>
       <div class="col-12 md-col-6 flex items-stretch flex-auto">
         <div class="flex flex-column items-stretch flex-auto">
-          <a href="travel-results.amp" class="travel-featured-tile flex flex-auto pointer relative travel-featured-color-purple" on="tap:AMP.setState({fields_query: 'Tokyo', query_query: 'Tokyo'})">
+          <a href="travel-results.amp.html" class="travel-featured-tile flex flex-auto pointer relative travel-featured-color-purple" on="tap:AMP.setState({fields_query: 'Tokyo', query_query: 'Tokyo'})">
             <amp-img class="travel-object-cover flex-auto" layout="responsive" width="276" height="207" src="../../img/travel/city/tokyo.jpg"></amp-img>
             <div class="travel-featured-overlay absolute z1 center top-0 right-0 bottom-0 left-0 white p2">
               <div class="travel-featured-tile-heading caps bold line-height-2 h3">Tokyo</div>
               <div class="h5">500+ adventures</div>
             </div>
           </a>
-          <a href="travel-results.amp" class="travel-featured-tile flex flex-auto relative travel-featured-color-cornflower" on="tap:AMP.setState({fields_query: 'Chicago', query_query: 'Chicago'})">
+          <a href="travel-results.amp.html" class="travel-featured-tile flex flex-auto relative travel-featured-color-cornflower" on="tap:AMP.setState({fields_query: 'Chicago', query_query: 'Chicago'})">
             <amp-img class="travel-object-cover flex-auto" layout="responsive" width="264" height="286" src="../../img/travel/city/chicago.jpg"></amp-img>
             <div class="travel-featured-overlay absolute z1 center top-0 right-0 bottom-0 left-0 white p2">
               <div class="travel-featured-tile-heading caps bold line-height-2 h3">Chicago</div>
@@ -587,7 +587,7 @@
             </div>
           </a>
         </div>
-        <a href="travel-results.amp" class="travel-featured-tile flex flex-auto relative travel-featured-color-teal" on="tap:AMP.setState({fields_query: 'Reykjavik', query_query: 'Reykjavik'})">
+        <a href="travel-results.amp.html" class="travel-featured-tile flex flex-auto relative travel-featured-color-teal" on="tap:AMP.setState({fields_query: 'Reykjavik', query_query: 'Reykjavik'})">
           <amp-img class="travel-object-cover flex-auto" layout="responsive" width="312" height="507" src="../../img/travel/city/reykjavik.jpg"></amp-img>
           <div class="travel-featured-overlay absolute z1 center top-0 right-0 bottom-0 left-0 white p2">
             <div class="travel-featured-tile-heading caps bold h3">Reykjavik</div>
@@ -610,7 +610,7 @@
       <div class="travel-input-group flex items-center col-8">
           <input class="travel-input travel-input-big line-height-2 block col-12 flex-auto rounded-left" type="text" name="query" placeholder="Where would you like to go?" on="change:AMP.setState({fields_query: event.value})" value="" [value]="fields_query">
           <span class="travel-input-group-sep travel-border-gray relative z1 block"></span>
-          <a href="travel-results.amp" class="travel-link travel-input travel-input-big line-height-2 link rounded-right nowrap text-decoration-none" on="
+          <a href="travel-results.amp.html" class="travel-link travel-input travel-input-big line-height-2 link rounded-right nowrap text-decoration-none" on="
               tap:AMP.setState({
                   ui_reset: false,
                   ui_filterPane: false,
@@ -692,7 +692,7 @@
     <div class="max-width-3 mx-auto px1 md-px2">
       <div class="flex pt3 md-pt4 col-12 md-col-6 pr3">
         <div class="col-2">
-          <a href="travel.amp" class="inline-block h2 line-height-1 circle white">
+          <a href="travel.amp.html" class="inline-block h2 line-height-1 circle white">
 <svg class="travel-icon travel-icon-logo h2" viewBox="0 0 100 100"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="7.5"><circle cx="50" cy="50" r="45"></circle><path d="M20.395 83.158c-2.37-10.263-.79-18.553 4.737-24.87 8.29-9.472 17.763-1.183 26.052-9.472 8.29-8.29 2.37-18.948 10.658-26.053 5.526-4.737 12.237-6.316 20.132-4.737M39.084 95c-2.788-10.2-1.912-17.304 2.627-21.316 6.808-6.017 14.956-.68 24.088-9.623 9.13-8.94 3.062-17.133 10.255-23.534 4.795-4.267 10.282-5.668 16.46-4.203"></path></g></svg>          </a>
         </div>
         <div class="col-5">


### PR DESCRIPTION
fix wrong links in travel templates landing page to result page

currently the links are without `.html`, and the result page is a 404: https://amp.dev/documentation/templates/preview/websites/travel/templates/travel-results.amp

This page with `.html` works: https://amp.dev/documentation/templates/preview/websites/travel/templates/travel-results.amp.html (but the APIs for that page are not there)