### PR TITLE
typo. <img> tag not properly terminated.

### DIFF
--- a/examples/source/1.components/amp-img.html
+++ b/examples/source/1.components/amp-img.html
@@ -91,7 +91,7 @@ author: sebastianbenz
   -->
   <amp-img src="/static/samples/img/amp.jpg" alt="AMP" width="475" height="268" layout="responsive">
     <noscript>
-      <img src="/static/samples/img/amp.jpg" width="475" height="268" alt="AMP">
+      <img src="/static/samples/img/amp.jpg" width="475" height="268" alt="AMP" />
     </noscript>
   </amp-img>
 


### PR DESCRIPTION
In the amp-img [example](https://amp.dev/documentation/examples/components/amp-img/), under the <noscript> example, the <img> has a typo.

Currently reads
```jsx
<amp-img src="/static/samples/img/amp.jpg"
  alt="AMP"
  width="475"
  height="268"
  layout="responsive">
  <noscript>
    <img src="/static/samples/img/amp.jpg" width="475" height="268" alt="AMP">
  </noscript>
</amp-img>
```
It should end in a `/>`.