### PR TITLE
🐛 Fix sidebar-toggle prevents clicking content

### DIFF
--- a/frontend/scss/components/atoms/sidebar-toggle.scss
+++ b/frontend/scss/components/atoms/sidebar-toggle.scss
@@ -90,16 +90,17 @@ $originalEasing: cubic-bezier(0,0,.21,1);
     .label-title {
       position: absolute;
       left: 32px;
-      white-space: nowrap;
-      padding: 5px 10px 5px 5px;
-      opacity: 0;
-      margin-left: -5px;
-      border-radius: 0 4px 4px 0;
-      background: color('blue-ribbon');
-      height: 35px;
       display: flex;
       align-items: center;
+      height: 35px;
+      margin-left: -5px;
+      padding: 5px 10px 5px 5px;
+      white-space: nowrap;
+      border-radius: 0 4px 4px 0;
+      background: color('blue-ribbon');
       box-shadow: 0 10px 20px -5px rgba(0,0,0,0.25);
+      transform: scale3d(0, 1, 1);
+      transform-origin: left;
       transition: transform $originalSpeed $originalEasing;
     }
   }

--- a/frontend/templates/views/partials/sidebar-toggle-observer.j2
+++ b/frontend/templates/views/partials/sidebar-toggle-observer.j2
@@ -8,17 +8,17 @@
   <amp-animation id="slideTransition" layout="nodisplay">
     <script type="application/json">
       {
-        "duration": "200ms",
+        "duration": "150ms",
         "fill": "both",
         "easing": "ease-out",
         "iterations": "1",
         "animations": [{
           "selector": ".label-title",
           "keyframes": [{
-              "opacity": "0"
+              "transform": "scale3d(0, 1, 1)"
             },
             {
-              "opacity": "1"
+              "transform": "scale3d(1, 1, 1)"
             }
           ]
         }]


### PR DESCRIPTION
Use `scale3d` for hiding sidebar label-title since `display: none` is not supported by `amp-animation`

Fixes: #3885