### PR TITLE
♻️ Use thumbor's HTTP loader to keep it stateless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,4 @@ jobs:
     - scripts/unbuffer.sh gulp buildFinalize
     - scripts/unbuffer.sh npm run smoke-test
     script:
-    - scripts/unbuffer.sh gulp thumborCollectImages
-    - gcloud app deploy thumbor/app.yaml --project=amp-dev-staging --quiet --version=1
     - gcloud app deploy --project=amp-dev-staging --quiet --version=1

--- a/gulpfile.js/deploy.js
+++ b/gulpfile.js/deploy.js
@@ -389,6 +389,11 @@ exports.packagerUpdateStart = packagerUpdateStart;
 exports.thumborImageUpload = thumborImageUpload;
 exports.thumborInstanceTemplateCreate = thumborInstanceTemplateCreate;
 exports.thumborUpdateStart = thumborUpdateStart;
+exports.thumborDeploy = series(
+  thumborImageUpload,
+  thumborInstanceTemplateCreate,
+  thumborUpdateStart
+);
 
 exports.updateStop = updateStop;
 exports.updateStatus = updateStatus;

--- a/gulpfile.js/thumbor.js
+++ b/gulpfile.js/thumbor.js
@@ -16,7 +16,6 @@
 
 'use strict';
 
-const gulp = require('gulp');
 const {join} = require('path');
 
 const config = require('@lib/config');
@@ -37,15 +36,4 @@ async function thumborRunLocal() {
   );
 }
 
-async function thumborCollectImages() {
-  const imagePaths = config.shared.thumbor.fileExtensions.map((extension) => {
-    return join(project.paths.STATICS_DEST, '/**/', `*.${extension}`);
-  });
-
-  return gulp
-    .src(imagePaths)
-    .pipe(gulp.dest(`${project.paths.THUMBOR_STATICS_DEST}`));
-}
-
 exports.thumborRunLocal = thumborRunLocal;
-exports.thumborCollectImages = thumborCollectImages;

--- a/platform/lib/routers/thumbor.js
+++ b/platform/lib/routers/thumbor.js
@@ -40,12 +40,11 @@ const imagePaths = config.shared.thumbor.fileExtensions.map((extension) => {
 thumborRouter.get(imagePaths, (request, response, next) => {
   const imageUrl = new URL(request.url, config.hosts.platform.base);
   const imageWidth = imageUrl.searchParams.get('width');
-  // Thumbor expects SECURITY_KEY as URL partial and the desired
-  // size (x * y) as another one
+
   request.url = join(
     SECURITY_KEY,
     imageWidth ? `/${imageWidth}x0/` : '/',
-    imageUrl.pathname
+    imageUrl.href
   );
 
   proxy.web(request, response, proxyOptions, (error) => {

--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -5,15 +5,11 @@ ENV THUMBOR_PORT "8080"
 
 ENV AUTO_WEBP "True"
 
-ENV LOADER "thumbor.loaders.file_loader"
-ENV FILE_LOADER_ROOT_PATH "/app/"
-
-COPY static /app/static
-
-# ENV LOADER = 'thumbor_cloud_storage.loaders.cloud_storage_loader'
-# ENV CLOUD_STORAGE_PROJECT_ID = 'amp-dev-staging'
-# ENV CLOUD_STORAGE_BUCKET_ID = 'amp-dev-staging-thumbor-storage'
-#
-# ENV RESULT_STORAGE = 'thumbor_cloud_storage.result_storages.cloud_storage'
-# ENV RESULT_STORAGE_CLOUD_STORAGE_PROJECT_ID = 'amp-dev-staging'
-# ENV RESULT_STORAGE_CLOUD_STORAGE_BUCKET_ID = 'amp-dev-staging-thumbor-storage'
+ENV LOADER "thumbor.loaders.http_loader"
+ENV ALLOWED_SOURCES "[ \
+  'amp.dev', \
+  '.+.amp.dev', \
+  'amp-dev-staging.appspot.com', \
+  '.+dot-amp-dev-staging.appspot.com', \
+  'localhost:.+' \
+]"


### PR DESCRIPTION
As long as we are not using Google Cloud Storage we can keep Thumbor entirely stateless just like the packager.