### PR TITLE
Add banner for OpenJS Collaborator Summit

### DIFF
--- a/frontend/templates/views/partials/banner.j2
+++ b/frontend/templates/views/partials/banner.j2
@@ -1,9 +1,12 @@
 {% do doc.styles.addCssFile('/css/components/molecules/banner.css') %}
 
 <div class="ap-m-banner">
-  <a id="top-banner" href="http://go.amp.dev/devx-survey" class="ap-m-banner-link">
+  <a id="top-banner"
+     class="ap-m-banner-link"
+     target="_blank"
+     href="https://events.linuxfoundation.org/openjs-world/features/openjs-collaborator-summit/">
     <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
-    {{ _('Do you build things with AMP? Fill out the AMP Developer Survey!') }}
+    {{ _('Help contribute to AMP! Join us at the OpenJS Collaborator Summit on June 25 and 26.') }}
   </a>
 {% if banner_closeable %}
   <button class="ap-m-banner-dismiss" on="tap:{{ banner_notification_id }}.dismiss">

--- a/frontend/templates/views/partials/header.j2
+++ b/frontend/templates/views/partials/header.j2
@@ -9,8 +9,8 @@
 {%- endmacro %}
 
 {# Simply set to False to disable banner #}
-{% set show_banner = False %}
-{% set banner_notification_id = 'amp-devx-survey' %}
+{% set show_banner = True %}
+{% set banner_notification_id = 'top-banner' %}
 {% set banner_closeable = True %}
 
 {% if show_banner and banner_closeable %}


### PR DESCRIPTION
/cc @mrjoro 

The banner is somewhat long. It takes up two lines on mobile. I tried to compress this rather complex message... then again, I think the previous banner probably wrapped on mobile too :)