### PR TITLE
Shorter banner to avoid layout issues

### DIFF
--- a/frontend/templates/views/partials/banner.j2
+++ b/frontend/templates/views/partials/banner.j2
@@ -6,7 +6,7 @@
      target="_blank"
      href="https://events.linuxfoundation.org/openjs-world/features/openjs-collaborator-summit/">
     <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
-    {{ _('Help contribute to AMP! Join us at the OpenJS Collaborator Summit on June 25 and 26.') }}
+    {{ _('Help contribute to AMP! Join us at the OpenJS Collaborator Summit.') }}
   </a>
 {% if banner_closeable %}
   <button class="ap-m-banner-dismiss" on="tap:{{ banner_notification_id }}.dismiss">


### PR DESCRIPTION
Turns out that, on smaller devices, the previous banner wrapped to 3 lines, causing the text to overflow the banner area, which is fixed to 31px.

I tried making the banner height not fixed, but of course that doesn't play well with the fact that the hamburger menu icon is `position:fixed`.

To allow more text on smaller devices, we could do any of the following:
* fix all the header CSS so that the banner could change height with impunity
* make the font smaller on smaller devices. (0.75rem looked great.)
* just warn people not to make the banner too large 🙃

For now, I'm just shortening the message, even though we lose the date. But others may have a better idea!