### PR TITLE
Update AMP for Email best practices

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/amp_email_best_practices.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/amp_email_best_practices.md
@@ -15,13 +15,13 @@ When using [`amp-list`](../../../documentation/components/reference/amp-list.md?
 #Usability and accessibility
 
 - When using
-  [`amp-carousel`](../../../documentation/components/amp-carousel-v0.1/), ensure the `controls` attribute is set. This lets users on touchscreen devices such as smartphones to navigate the carousel.
-- When using [`amp-form`](../../../documentation/components/amp-form), keep in mind not all input types are supported on iOS. Refer to [Supported Input Values](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/InputTypes.html) in the Safari HTML Reference for more information.
+  [`amp-carousel`](../../components/reference/amp-carousel-v0.1.md?format=email), ensure the `controls` attribute is set. This lets users on touchscreen devices such as smartphones to navigate the carousel.
+- When using [`amp-form`](../../../documentation/components/reference/amp-form.md?format=email), keep in mind not all input types are supported on iOS. Refer to [Supported Input Values](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/InputTypes.html) in the Safari HTML Reference for more information.
 - Not all [`autocomplete` attribute values](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) are supported across different apps and browsers. Assume that autocomplete isn't available to your users and keep the forms short.
 
 #Styling
 
-- Make sure your email is only using [AMP for Email Supported CSS](../../../documentation/guides-and-tutorials/learn/email-spec/amp-email-css/?format=email)
+- Make sure your email is only using [AMP for Email Supported CSS](../learn/email-spec/amp-email-css.md?format=email)
 - Avoid using viewport units (`vw`, `vh`, `vmin` and `vmax`) anywhere in your CSS and HTML. Since AMP emails render inside an iframe, the viewport of the email doesn't match the browser's viewport.
 - Different browsers have different default CSS styling. Use a CSS library that normalizes styles if needed. For more information about default styles, style normalization and a list of available libaries, see [Reboot, Resets, and Reasoning](https://css-tricks.com/reboot-resets-reasoning/).
 - Be careful with overflowing margin in CSS: they may not get rendered due to [an AMP layout limitation](https://github.com/ampproject/amphtml/issues/13343#issuecomment-447380241).

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/amp_email_best_practices.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/amp_email_best_practices.md
@@ -12,16 +12,29 @@ AMP allows for exciting new types of immersive and engaging content in email! Wh
 
 When using [`amp-list`](../../../documentation/components/reference/amp-list.md?format=email) to dynamically fetch content, include a placeholder to keep the integrity of the components structure. The placeholder should be as similar in layout as possible to the document after it's returned the requested data. This ensures the message size isn't changing or mutating the layout significantly.
 
-#Mobile
+#Usability and accessibility
 
-Ensure your message looks good on all screen sizes by using [CSS media queries](style_and_layout/control_layout.md?format=email) to identify the device. Messages should be tested on mobile devices to ensure the layout is correct and components work as expected. Because swiping is a common action on mobile email apps, take proper steps to ensure your users can interact with your content. Components such as [`amp-carousel`](../../../documentation/components/reference/amp-carousel.md?format=email) can include the [`controls`](../../../documentation/components/reference/amp-carousel.md?format=email#controls-(optional)) attribute to make the navigation buttons always visible on mobile.
+- When using
+  [`amp-carousel`](../../../documentation/components/amp-carousel-v0.1/), ensure the `controls` attribute is set. This lets users on touchscreen devices such as smartphones to navigate the carousel.
+- When using [`amp-form`](../../../documentation/components/amp-form), keep in mind not all input types are supported on iOS. Refer to [Supported Input Values](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/InputTypes.html) in the Safari HTML Reference for more information.
+- Not all [`autocomplete` attribute values](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) are supported across different apps and browsers. Assume that autocomplete isn't available to your users and keep the forms short.
+
+#Styling
+
+- Make sure your email is only using [AMP for Email Supported CSS](../../../documentation/guides-and-tutorials/learn/email-spec/amp-email-css/?format=email)
+- Avoid using viewport units (`vw`, `vh`, `vmin` and `vmax`) anywhere in your CSS and HTML. Since AMP emails render inside an iframe, the viewport of the email doesn't match the browser's viewport.
+- Different browsers have different default CSS styling. Use a CSS library that normalizes styles if needed. For more information about default styles, style normalization and a list of available libaries, see [Reboot, Resets, and Reasoning](https://css-tricks.com/reboot-resets-reasoning/).
+- Be careful with overflowing margin in CSS: they may not get rendered due to [an AMP layout limitation](https://github.com/ampproject/amphtml/issues/13343#issuecomment-447380241).
+
+##Mobile
+
+Ensure your message looks good on all screen sizes by using [CSS media queries](style_and_layout/control_layout.md?format=email) to identify the device. Messages should be tested on mobile devices to ensure the layout is correct and components work as expected.
 
 #Other Gotchas
 
 When working AMP for Email, keep in mind the following tips and tricks:
 
-*   The AMP for Email playground doesn't proxy XHRs, but some email providers do.
-*   The AMP MIME part should appear before the HTML MIME part in your email to ensure maximum compatibility across email clients.
-*   The `src` attribute of [`amp-list`](../../../documentation/components/reference/amp-list.md?format=email), [`action-xhr`](../../../documentation/components/reference/amp-form.md?format=email#action-xhr) of [`amp-form`](../../../documentation/components/reference/amp-form.md?format=email), the `src` for [`amp-img`](../../../documentation/examples/documentation/amp-img.html?format=email), or the href attribute of an `<a>` tag cannot be mutated by [`amp-bind`](../../../documentation/examples/documentation/amp-bind.html?format=email).
-*   Your messages should include a static HTML version in the event that a user is taken to the HTML version of the message, or if that user forwards the message.
-*   Be careful with overflowing margin in CSS: they may not get rendered due to [an AMP layout limitation](https://github.com/ampproject/amphtml/issues/13343#issuecomment-447380241).
+- The AMP for Email playground doesn't proxy XHRs, but some email providers do.
+- The AMP MIME part should appear before the HTML MIME part in your email to ensure maximum compatibility across email clients.
+- The `src` attribute of [`amp-list`](../../../documentation/components/reference/amp-list.md?format=email), [`action-xhr`](../../../documentation/components/reference/amp-form.md?format=email#action-xhr) of [`amp-form`](../../../documentation/components/reference/amp-form.md?format=email), the `src` for [`amp-img`](../../../documentation/examples/documentation/amp-img.html?format=email), or the href attribute of an `<a>` tag cannot be mutated by [`amp-bind`](../../../documentation/examples/documentation/amp-bind.html?format=email).
+- Your messages should include a static HTML version in the event that a user is taken to the HTML version of the message, or if that user forwards the message.


### PR DESCRIPTION
This moves tips from [Gmail's documentation](https://developers.google.com/gmail/ampemail/tips) that aren't Gmail-specific and are useful for other email clients.