### PR TITLE
✨ Highlight amp-state changes in playground state tree view

### DIFF
--- a/playground/src/state-view/state-view.js
+++ b/playground/src/state-view/state-view.js
@@ -89,7 +89,13 @@ class StateView extends FlyIn {
     }
 
     const treeRoot = this.content.querySelector('.children');
-    const highlight = document.evaluate(expression, treeRoot, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+    const highlight = document.evaluate(
+      expression,
+      treeRoot,
+      null,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
+      null
+    );
 
     if (highlight.singleNodeValue) {
       highlight.singleNodeValue.classList.add('highlight');

--- a/playground/src/state-view/state-view.js
+++ b/playground/src/state-view/state-view.js
@@ -38,6 +38,10 @@ class StateView extends FlyIn {
     this.treeView.showCountOfObjectOrArray = false;
     this.content.appendChild(this.treeView.dom.querySelector('.children'));
 
+    /**
+     * Disabled on IE11
+     * Listen for state changes in tree view and hand hand them over to highlightChanges()
+     */
     if (document.evaluate) {
       this.treeView.on('change', (self, key) => {
         this.highlightChanges(key);
@@ -66,6 +70,10 @@ class StateView extends FlyIn {
     this.toggle();
   }
 
+  /**
+   * Run highlight animation on updated tree view dom elements
+   * @param  {Array} key     Array of keys in tree view that have changed
+   */
   highlightChanges(key) {
     key.shift();
     if (!key.length) {

--- a/playground/src/state-view/state-view.scss
+++ b/playground/src/state-view/state-view.scss
@@ -1,4 +1,20 @@
+@import 'base.scss';
+
+@keyframes HIGHTLIGHT {
+  from {
+    background: color('lavender');
+  }
+  to {
+    background: transparent;
+  }
+}
+
 #state-view {
   width: 50%;
   max-width: 780px;
+
+  .highlight {
+    border-radius: 2px;
+    animation: HIGHTLIGHT 1s ease-out;
+  }
 }

--- a/playground/src/state-view/state-view.scss
+++ b/playground/src/state-view/state-view.scss
@@ -1,6 +1,6 @@
 @import 'base.scss';
 
-@keyframes HIGHTLIGHT {
+@keyframes HIGHLIGHT {
   from {
     background: color('lavender');
   }
@@ -15,6 +15,6 @@
 
   .highlight {
     border-radius: 2px;
-    animation: HIGHTLIGHT 1s ease-out;
+    animation: HIGHLIGHT 1s ease-out;
   }
 }


### PR DESCRIPTION
Similar to the Chrome Dev tools, state changes are now highlighted

![amp-state-view](https://user-images.githubusercontent.com/35134232/86348655-3af15c00-bc60-11ea-846c-e62af826ffaf.gif)
