### PR TITLE
Fix go.amp.dev/amp-script-apis URL

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -4,7 +4,7 @@
 /ampdevmode: https://github.com/ampproject/amphtml/issues/20974
 /amp-optimizer: https://github.com/ampproject/amp-toolbox/tree/master/packages/optimizer
 /amp-pwa-amp: https://blog.amp.dev/2018/06/19/the-shadow-reader-improved/
-/amp-script-apis: https://github.com/ampproject/worker-dom/blob/master/web_compat_table.md
+/amp-script-apis: https://github.com/ampproject/worker-dom/blob/main/web_compat_table.md
 /ampcs: /events/amp-cs-2019/#Schedule
 /auto-sw: https://github.com/ampproject/amp-sw/
 /axios-case-study: https://blog.amp.dev/2020/04/07/people-behind-the-code-the-axios-ascent/


### PR DESCRIPTION
Update to 'main' branch.

Discovered in a comment on https://www.youtube.com/watch?v=nOEXIcMdr_g. /cc @kristoferbaxter you also need to update http://bit.ly/amp-script-compat