### PR TITLE
🐛 Fix template dialog in playground

### DIFF
--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -209,13 +209,13 @@ if (preview) {
   showPreview.show();
 }
 
-// load template dialog
-const loadTemplateButton = Button.from(
-  document.getElementById('document-title'),
-  () => templateDialog.open(runtimes.activeRuntime)
-);
+if (document.getElementById('document-title')) {
+  // load template dialog
+  const loadTemplateButton = Button.from(
+    document.getElementById('document-title'),
+    () => templateDialog.open(runtimes.activeRuntime)
+  );
 
-if (loadTemplateButton) {
   // eslint-disable-next-line no-unused-vars
   const templateDialog = createTemplateDialog(loadTemplateButton, {
     onStart: () => editor.showLoadingIndicator(),

--- a/playground/src/template-dialog/base.js
+++ b/playground/src/template-dialog/base.js
@@ -148,14 +148,17 @@ class TemplateDialog {
 
   selectTemplatesForRuntime(sitemap) {
     let templates = null;
-    if (this.runtime.id === 'amphtml') {
-      templates = sitemap['websites'];
-    } else if (this.runtime.id === 'amp4ads') {
-      templates = sitemap['ads'];
-    } else if (this.runtime.id === 'amp4stories') {
-      templates = sitemap['stories'];
-    } else if (this.runtime.id === 'amp4email') {
-      templates = sitemap['email'];
+
+    if (sitemap) {
+      if (this.runtime.id === 'amphtml') {
+        templates = sitemap['websites'];
+      } else if (this.runtime.id === 'amp4ads') {
+        templates = sitemap['ads'];
+      } else if (this.runtime.id === 'amp4stories') {
+        templates = sitemap['stories'];
+      } else if (this.runtime.id === 'amp4email') {
+        templates = sitemap['email'];
+      }
     }
 
     if (templates && templates.categories && templates.categories.length) {


### PR DESCRIPTION
Fixes defect template dialog for playground. The button creation fails due to a wrong check in app.js 

```
main.c0dd5a62e3e993142f13.js:1598 Uncaught ReferenceError: templateDialog is not defined
    at HTMLDivElement.<anonymous> (main.c0dd5a62e3e993142f13.js:1598)
```

The other fix should really only affect a problem for development: if the sitemap is malformed or could not be fetched at all the template dialog did not open.