### PR TITLE
fixed broken link in example

### DIFF
--- a/examples/source/style-layout/How_to_support_Images_with_unknown_Dimensions.html
+++ b/examples/source/style-layout/How_to_support_Images_with_unknown_Dimensions.html
@@ -55,7 +55,7 @@ teaserImage: '/static/samples/img/teaser/how_to_support_images_with_unknown_dime
   -->
   <amp-img width="300" height="200" src="https://unsplash.it/300/200?image=1074"></amp-img>
   <!--
-  The `amp-img` extension supports different [layouts](documentation/guides-and-tutorials/develop/style_and_layout/control_layout). The `responsive` layout requires width and height to be able to determine an image's aspect ratio.
+  The `amp-img` extension supports different [layouts](/documentation/guides-and-tutorials/develop/style_and_layout/control_layout). The `responsive` layout requires width and height to be able to determine an image's aspect ratio.
   -->
   <amp-img layout="responsive" width="300" height="200" src="https://unsplash.it/300/200?image=1074"></amp-img>
 


### PR DESCRIPTION
doc should point visitors to https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout/