### PR TITLE
remove request for help on banner shown when missing translations

### DIFF
--- a/frontend/templates/layouts/default.j2
+++ b/frontend/templates/layouts/default.j2
@@ -130,7 +130,7 @@
     {% if not '@' in doc.pod_path and not doc.locale == podspec.default_locale and doc.pod_path.startswith('/content/amp-dev/documentation') %}
     {% do doc.styles.addCssFile('/css/components/organisms/translation-hint.css') %}
     <aside class="ap-o-translation-hint">
-      <p class="ap-o-translation-hint-wrapper">{{ _('Sadly this page isn\'t translated yet, but we could use some help doing so. See the <a href="/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute.') }}</p>
+      <p class="ap-o-translation-hint-wrapper">{{ _('Sadly this page isn\'t translated yet, but will be shortly - check back soon!.') }}</p>
     </aside>
     {% endif %}
 

--- a/frontend/templates/layouts/default.j2
+++ b/frontend/templates/layouts/default.j2
@@ -130,7 +130,7 @@
     {% if not '@' in doc.pod_path and not doc.locale == podspec.default_locale and doc.pod_path.startswith('/content/amp-dev/documentation') %}
     {% do doc.styles.addCssFile('/css/components/organisms/translation-hint.css') %}
     <aside class="ap-o-translation-hint">
-      <p class="ap-o-translation-hint-wrapper">{{ _('Sadly this page isn\'t translated yet, but will be shortly - check back soon!.') }}</p>
+      <p class="ap-o-translation-hint-wrapper">{{ _('Sadly this page isn\'t translated yet, but will be shortly - check back soon!') }}</p>
     </aside>
     {% endif %}
 

--- a/pages/translations/ar/LC_MESSAGES/messages.po
+++ b/pages/translations/ar/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr "…أثناء محاولة تحميل نتائج البحث."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "للأسف لم تُترجَم هذه الصفحة بعد، لكن يمكننا الاستعانة ببعض المساعدة في ترجمتها. راجع <a href=\"/documentation/guides-and-tutorials/contribute/translations\">دليل الترجمة</a> لمعرفة كيف يمكنك المساهمة."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "لم تتم ترجمة هذه الصفحة حتى الآن، ولكن سيتم ذلك بعد قليل. يُرجى إعادة التحقّق قريبًا."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/de/LC_MESSAGES/messages.po
+++ b/pages/translations/de/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr "...beim Versuch, die Suchergebnisse zu laden."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "Diese Seite ist leider noch nicht übersetzt. Wir könnten dabei Hilfe gebrauchen. Lies bitte den <a href=\"/documentation/guides-and-tutorials/contribute/translations\">Übersetzungsleitfaden</a>, wenn du beitragen möchtest."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "Diese Seite ist leider noch nicht übersetzt, wir arbeiten allerdings daran – schau einfach später noch einmal vorbei!"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/es/LC_MESSAGES/messages.po
+++ b/pages/translations/es/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr "…mientras intentaba cargar los resultados de la búsqueda."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "Lamentablemente esta página aún no está traducida y necesitamos un poco de ayuda para hacerlo. Consulte la <a href=\"/documentation/guides-and-tutorials/contribute/translations\">Guía de traducción</a> donde encontrará información sobre cómo puede contribuir."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "Lamentablemente, esta página todavía no está traducida, pero lo estará en breve. Vuelve a visitarla más adelante."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/fr/LC_MESSAGES/messages.po
+++ b/pages/translations/fr/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr "... en essayant de charger les résultats de la recherche."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "Malheureusement, cette page n'est pas encore traduite, mais nous pourrions avoir besoin d'aide pour le faire. Consultez le <a href=\"/documentation/guides-and-tutorials/contribute/translations\">guide de traduction</a> pour découvrir comment participer."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "Cette page n'est malheureusement pas traduite pour le moment, mais elle le sera bientôt. Revenez plus tard."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/id/LC_MESSAGES/messages.po
+++ b/pages/translations/id/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr "…saat mencoba memuat hasil pencarian."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "Sayangnya, halaman ini belum diterjemahkan, tetapi kami bersedia menerima bantuan untuk menerjemahkannya. Baca <a href=\"/documentation/guides-and-tutorials/contribute/translations\">panduan penerjemahan</a> untuk mengetahui kontribusi yang dapat Anda lakukan."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "Sayangnya, halaman ini belum diterjemahkan, tetapi tak lama lagi akan diterjemahkan. Periksa kembali nanti!"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/it/LC_MESSAGES/messages.po
+++ b/pages/translations/it/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr "…durante il tentativo di caricare i risultati di ricerca."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "Purtroppo questa pagina non è stata ancora tradotta, per cui potrebbe esserci utile dell'aiuto allo scopo. Consulta la <a href=\"/documentation/guides-and-tutorials/contribute/translations\">guida alle traduzioni</a> per scoprire come puoi contribuire."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "Purtroppo questa pagina non è ancora stata tradotta, ma lo sarà a breve. Ricontrolla presto!"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/ja/LC_MESSAGES/messages.po
+++ b/pages/translations/ja/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr "不具合が発生しました。"
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "残念ながら、このページはまだ翻訳されていません。翻訳へのご協力をお願いします。翻訳を提供する方法については、<a href=\"/documentation/guides-and-tutorials/contribute/translations\">翻訳ガイド</a>をご覧ください。"
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "このページはまだ翻訳されていません。近日翻訳を予定しているため、後日もう一度ご確認ください。"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/ko/LC_MESSAGES/messages.po
+++ b/pages/translations/ko/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr "... 검색 결과를 로딩하는 중 발생."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "죄송하지만 이 페이지는 아직 번역되지 않았습니다. 페이지 번역을 지원하고 싶다면 참여해 주세요. <a href=\"/documentation/guides-and-tutorials/contribute/translations\">번역 가이드</a>를 통해 참여 방법을 확인하실 수 있습니다."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "죄송하지만 이 페이지는 아직 번역되지 않았습니다. 곧 번역이 지원될 예정이니 다음에 다시 확인해 주세요."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/messages.po
+++ b/pages/translations/messages.po
@@ -1069,7 +1069,7 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
 msgstr ""
 
 #: frontend/templates/views/examples/documentation.j2:206

--- a/pages/translations/pl/LC_MESSAGES/messages.po
+++ b/pages/translations/pl/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr ""
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "Rất tiếc, nội dung trên trang này chưa được dịch. Chúng tôi sẽ nhanh chóng cung cấp bản dịch. Hãy sớm quay lại nhé!"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/pages/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1066,8 +1066,8 @@ msgid "…while trying to load the search results."
 msgstr "…ao tentar carregar os resultados da pesquisa."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "Infelizmente esta página ainda não foi traduzida, mas sua ajuda seria bem-vinda. Veja o <a href=\"/documentation/guides-and-tutorials/contribute/translations\">guia de tradução</a> sobre como você pode contribuir."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "Infelizmente, esta página ainda não foi traduzida, mas logo será. Volte em breve."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/ru/LC_MESSAGES/messages.po
+++ b/pages/translations/ru/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr "…при попытке загрузить результаты поиска."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "Эта страница пока не переведена, но вы можете помочь нам в этом. Чтобы узнать больше, ознакомьтесь с <a href=\"/documentation/guides-and-tutorials/contribute/translations\">руководством по переводу</a>."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "Эта страница пока недоступна на вашем языке, но скоро она будет переведена."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/tr/LC_MESSAGES/messages.po
+++ b/pages/translations/tr/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr "...bir şeyler ters gitti."
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "Ne yazık ki bu sayfa henüz çevrilmedi, ancak bu konuda bize yardımcı olabilirsiniz. Nasıl katkıda bulunabileceğinizle ilgili <a href=\"/documentation/guides-and-tutorials/contribute/translations\">çeviri kılavuzuna</a> göz atın."
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "Maalesef bu sayfa henüz çevrilmedi ancak yakında çevrilecek. Daha sonra tekrar kontrol edin."
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/vi/LC_MESSAGES/messages.po
+++ b/pages/translations/vi/LC_MESSAGES/messages.po
@@ -1065,8 +1065,8 @@ msgid "…while trying to load the search results."
 msgstr ""
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr ""
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "Rất tiếc, nội dung trên trang này chưa được dịch. Chúng tôi sẽ nhanh chóng cung cấp bản dịch. Hãy sớm quay lại nhé!"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."

--- a/pages/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/pages/translations/zh_CN/LC_MESSAGES/messages.po
@@ -1021,8 +1021,8 @@ msgid "…while trying to load the search results."
 msgstr "...同时尝试加载搜索结果"
 
 #: frontend/templates/layouts/default.j2:129
-msgid "Sadly this page isn't translated yet, but we could use some help doing so. See the <a href=\"/documentation/guides-and-tutorials/contribute/translations\">translation guide</a> on how you can contribute."
-msgstr "很遗憾，此页面尚未翻译，我们可能需要一些帮助。敬请参阅 <a href="/documentation/guides-and-tutorials/contribute/translations">翻译指南</a> ，了解您能如何做出贡献。"
+msgid "Sadly this page isn\'t translated yet, but will be shortly - check back soon!"
+msgstr "很遗憾，此页面尚未翻译，不过我们很快将对其进行翻译 - 请稍后再回来查看！"
 
 #: frontend/templates/views/examples/documentation.j2:206
 msgid "If the explanations on this page don't cover all of your questions feel free to reach out to other AMP users to discuss your exact use case."


### PR DESCRIPTION
__Pleaceholder issue to detemine correct path__

Since we are not crowdsourcing the upcoming translations, I want to do something about the banner.
In theory, the automated nature of gitlocalize means that there won't be pages that are untranslated, and therefore this message should never be shown. I am not sure if we want to keep this banner as a backup. 
If we _do_ keep it, I am not sure what the message would be - just an apology? a link to open an issue?