### PR TITLE
Larger scrollbars for samples

### DIFF
--- a/frontend/scss/_mixins.scss
+++ b/frontend/scss/_mixins.scss
@@ -181,8 +181,8 @@ box-shadow: 0 25px 50px 0 rgba(0,0,0,0.21);
 
 @mixin scrollbar {
   ::-webkit-scrollbar {
-    width: 4px;
-    height: 4px;
+    width: 7px;
+    height: 7px;
   }
 
   ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
I had trouble with scrolling the 4px scrollbars. How about 7px?

I never succeeded in seeing this change happen in my dev environment, but this CSS change did work on the production site. Please let me know if I'm doing this incorrectly....