### PR TITLE
fix rendering issue on RU version of amp-lightbox docs

### DIFF
--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@ru.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@ru.md
@@ -91,7 +91,7 @@ teaser:
         <td width="40%"><strong>scrollable (необязательно)</strong></td>
         <td>Наличие атрибута <code>scrollable</code> означает, что содержимое окна просмотра можно прокручивать, если оно выходит за рамки окна.
           <br><br>
-            <strong>Примечание.</strong> Атрибут <code>scrollable</code> нельзя использовать с компонентом <code><amp-lightbox></code> в объявлениях HTML с технологией AMP. Подробную информацию можно найти в <a href="#a4a">этом разделе</a>.</td>
+            <strong>Примечание.</strong> Атрибут `scrollable` нельзя использовать с компонентом `&lt;amp-lightbox&gt;` в объявлениях HTML с технологией AMP. Подробную информацию можно найти в <a href="#a4a">этом разделе</a>.</td>
           </tr>
           <tr>
             <td width="40%"><strong>scrollable (необязательно)</strong></td>

--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@ru.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@ru.md
@@ -91,7 +91,7 @@ teaser:
         <td width="40%"><strong>scrollable (необязательно)</strong></td>
         <td>Наличие атрибута <code>scrollable</code> означает, что содержимое окна просмотра можно прокручивать, если оно выходит за рамки окна.
           <br><br>
-            <strong>Примечание.</strong> Атрибут `scrollable` нельзя использовать с компонентом `&lt;amp-lightbox&gt;` в объявлениях HTML с технологией AMP. Подробную информацию можно найти в <a href="#a4a">этом разделе</a>.</td>
+            <strong>Примечание.</strong> Атрибут <code>scrollable</code> нельзя использовать с компонентом <code>&lt;amp-lightbox&gt;</code> в объявлениях HTML с технологией AMP. Подробную информацию можно найти в <a href="#a4a">этом разделе</a>.</td>
           </tr>
           <tr>
             <td width="40%"><strong>scrollable (необязательно)</strong></td>


### PR DESCRIPTION
fixes #3659

The page was not [valid AMP](https://validator.ampproject.org/#url=https%3A%2F%2Famp.dev%2Fru%2Fdocumentation%2Fcomponents%2Famp-lightbox%2F%3Fformat%3Dwebsites), the snippet intended to be a code sample was being rendered by the docs page.