### PR TITLE
💄 Adapt mixin for larger scrollbars

### DIFF
--- a/frontend/scss/_mixins.scss
+++ b/frontend/scss/_mixins.scss
@@ -180,16 +180,17 @@ box-shadow: 0 25px 50px 0 rgba(0,0,0,0.21);
 }
 
 @mixin scrollbar {
-  ::-webkit-scrollbar {
-    width: 4px;
-    height: 4px;
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
   }
 
-  ::-webkit-scrollbar-thumb {
+  &::-webkit-scrollbar-thumb {
+    border-radius: 3px;
     background-color: color('oslo-gray');
   }
 
-  ::-webkit-scrollbar-corner {
+  &::-webkit-scrollbar-corner {
     background-color: transparent;
   }
 }

--- a/frontend/scss/components/atoms/copy-script.scss
+++ b/frontend/scss/components/atoms/copy-script.scss
@@ -16,17 +16,10 @@
     background: color('gallery');
     font-size: 12.6px;
 
+    @include scrollbar;
+
     &::-webkit-scrollbar {
-      width: 4px;
       height: 2px;
-    }
-
-    &::-webkit-scrollbar-corner {
-      background-color: transparent;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      background-color: #91979d;
     }
   }
 }

--- a/frontend/scss/components/atoms/copy-script.scss
+++ b/frontend/scss/components/atoms/copy-script.scss
@@ -19,7 +19,11 @@
     @include scrollbar;
 
     &::-webkit-scrollbar {
-      height: 2px;
+      height: 4px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: 0px;
     }
   }
 }

--- a/frontend/scss/components/molecules/code-snippet.scss
+++ b/frontend/scss/components/molecules/code-snippet.scss
@@ -35,18 +35,7 @@ Styles taken and combined from: https://raw.githubusercontent.com/richleland/pyg
     user-select: none;
   }
 
-  &::-webkit-scrollbar {
-    width: 4px;
-    height: 4px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: color('oslo-gray');
-  }
-
-  &::-webkit-scrollbar-corner {
-    background-color: transparent;
-  }
+  @include scrollbar;
 
   @media (min-width: 768px) {
     max-width: 100%;

--- a/frontend/scss/components/molecules/code-snippet.scss
+++ b/frontend/scss/components/molecules/code-snippet.scss
@@ -37,6 +37,10 @@ Styles taken and combined from: https://raw.githubusercontent.com/richleland/pyg
 
   @include scrollbar;
 
+  &::-webkit-scrollbar-thumb {
+    border-radius: 0;
+  }
+
   @media (min-width: 768px) {
     max-width: 100%;
     margin-right: -30px;

--- a/frontend/scss/components/molecules/table-component.scss
+++ b/frontend/scss/components/molecules/table-component.scss
@@ -59,16 +59,6 @@
       flex-direction: row;
       overflow-x: scroll;
 
-      &::-webkit-scrollbar {
-        width: 2px;
-        height: 2px;
-        padding-bottom: 8px;
-      }
-
-      &::-webkit-scrollbar-thumb {
-        background-color: #cecece;
-      }
-
       @media (min-width: 1024px) {
         flex-wrap: wrap;
       }

--- a/frontend/scss/components/organisms/_sidebar.scss
+++ b/frontend/scss/components/organisms/_sidebar.scss
@@ -36,7 +36,7 @@
     @include scrollbar;
 
     &::-webkit-scrollbar-thumb {
-      background-color: rgba(color('black'), 0.10);
+      background-color: transparentize(color('black'), 0.9);
     }
   }
 }

--- a/frontend/scss/components/organisms/_sidebar.scss
+++ b/frontend/scss/components/organisms/_sidebar.scss
@@ -33,9 +33,7 @@
       max-height: 100%;
     }
 
-    &::-webkit-scrollbar {
-      width: 2px;
-    }
+    @include scrollbar;
 
     &::-webkit-scrollbar-thumb {
       background-color: rgba(color('black'), 0.10);

--- a/frontend/scss/components/organisms/search.scss
+++ b/frontend/scss/components/organisms/search.scss
@@ -204,9 +204,7 @@
       max-height: calc(100vh - 108px);
       margin-right: 30px;
 
-      &::-webkit-scrollbar {
-        width: 4px;
-      }
+      @include scrollbar;
 
       &::-webkit-scrollbar-thumb {
         background: color('gallery');

--- a/frontend/scss/components/organisms/toc.scss
+++ b/frontend/scss/components/organisms/toc.scss
@@ -36,7 +36,7 @@
   @include scrollbar;
 
   &::-webkit-scrollbar-thumb {
-    background-color: rgba(color('black'), 0.10);
+    background-color: transparentize(color('black'), 0.9);
   }
 
   @media (min-width: 768px) {

--- a/frontend/scss/components/organisms/toc.scss
+++ b/frontend/scss/components/organisms/toc.scss
@@ -1,9 +1,9 @@
-@import '../../extends';
-@import '../../functions';
-@import '../../mixins';
-@import '../../variables';
-@import '../atoms/_color.scss';
-@import '../atoms/_text.scss';
+@import '_extends.scss';
+@import '_functions.scss';
+@import '_mixins.scss';
+@import '_variables.scss';
+@import 'components/atoms/_color.scss';
+@import 'components/atoms/_text.scss';
 
 @import '../organisms/_sidebar.scss';
 

--- a/frontend/scss/components/organisms/toc.scss
+++ b/frontend/scss/components/organisms/toc.scss
@@ -33,9 +33,7 @@
   padding: 15px;
   margin-bottom: 10px;
 
-  &::-webkit-scrollbar {
-    width: 2px;
-  }
+  @include scrollbar;
 
   &::-webkit-scrollbar-thumb {
     background-color: rgba(color('black'), 0.10);


### PR DESCRIPTION
Replaces #4261.

Hey @morsssss, the `@mixin scrollbar` was only used in the playground so far. I now updated the styling and made use of it throughout the whole project. To create variations (as seen in the screenshots below) the `@mixin` needs to be overwritten. I think for e.g. the `copy-script` it makes sense to leave the scrollbar at `height: 2px`? 

<img width="691" alt="Bildschirmfoto 2020-08-03 um 16 08 19" src="https://user-images.githubusercontent.com/35134232/89191674-91292600-d5a3-11ea-8517-5eba4b602db8.png">

<img width="326" alt="Bildschirmfoto 2020-08-03 um 15 22 44" src="https://user-images.githubusercontent.com/35134232/89187852-1c9fb880-d59e-11ea-95b6-099d4a8b3f7e.png">

<img width="680" alt="Bildschirmfoto 2020-08-03 um 15 15 07" src="https://user-images.githubusercontent.com/35134232/89187858-20333f80-d59e-11ea-8d4d-33ec5ab303f2.png">

