### PR TITLE
🔧 Increase disk size for thumbor instances and make logs less verbose

### DIFF
--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -1,6 +1,6 @@
 FROM minimalcompact/thumbor
 
-ENV LOG_LEVEL "DEBUG"
+ENV LOG_LEVEL "error"
 ENV THUMBOR_PORT "8080"
 
 ENV AUTO_WEBP "True"

--- a/thumbor/app.yaml
+++ b/thumbor/app.yaml
@@ -13,4 +13,4 @@ readiness_check:
 resources:
   cpu: 1
   memory_gb: 2
-  disk_size_gb: 10
+  disk_size_gb: 30


### PR DESCRIPTION
It has been the logs that made the thumbor instances unresponsive:

```
2020-07-28 07:40:13.607 MESZ
[ERROR:serialization_utils.cc(304)] error writing output: No space left on device (28)

2020-07-28 07:40:15.005 MESZ
time="2020-07-28T05:40:15.005186180Z" level=error msg="Failed to log msg \"\" for logger json-file: write /var/lib/docker/containers/9a43cf850db23e35a0c3a014d6f52924f89acbc8853becb75a7e8440aa8eb3c7/9a43cf850db23e35a0c3a014d6f52924f89acbc8853becb75a7e8440aa8eb3c7-json.log: no space left on device"
```

thumbor doesn't use rotating logs but recommends to send logs to something like Sentry. I reduced the amount of logs - currently its ~14 lines for every request with log level `debug`:

```
A 2020-07-30T20:11:26.426142500Z 2020-07-30 20:11:26 thumbor:DEBUG METRICS: timing: original_image.fetch.200.amp_dev:22
 
A 2020-07-30T20:11:26.426303624Z 2020-07-30 20:11:26 thumbor:DEBUG METRICS: inc: original_image.status.200:1
 
A 2020-07-30T20:11:26.426476642Z 2020-07-30 20:11:26 thumbor:DEBUG METRICS: inc: original_image.response_bytes:3982
 
A 2020-07-30T20:11:26.456737126Z 2020-07-30 20:11:26 thumbor:DEBUG Image format set by AUTO_WEBP as .webp.
 
A 2020-07-30T20:11:26.457064578Z 2020-07-30 20:11:26 thumbor:DEBUG Content Type of image/webp detected.
 
A 2020-07-30T20:11:26.525366673Z 2020-07-30 20:11:26 thumbor:DEBUG METRICS: timing: response.time:127
 
A 2020-07-30T20:11:26.525534890Z 2020-07-30 20:11:26 thumbor:DEBUG METRICS: timing: response.time.200:127
 
A 2020-07-30T20:11:26.525679472Z 2020-07-30 20:11:26 thumbor:DEBUG METRICS: inc: response.status.200:1
 
A 2020-07-30T20:11:26.525835897Z 2020-07-30 20:11:26 thumbor:DEBUG METRICS: inc: response.format.webp:1
 
A 2020-07-30T20:11:26.525982526Z 2020-07-30 20:11:26 thumbor:DEBUG METRICS: timing: response.time.webp:127
 
A 2020-07-30T20:11:26.526123873Z 2020-07-30 20:11:26 thumbor:DEBUG METRICS: inc: response.bytes.webp:46920
 
A 2020-07-30T20:11:26.527567024Z 2020-07-30 20:11:26 thumbor:DEBUG creating tempfile for https%3A//amp.dev/static/img/amp-stories-base.png%3Fhash%3Da805112175bae5252b5f53b83734db8b7358f4da%26original%3Dtrue in /data/storage/3a/51255382751db8674367f7f469836747f40b39.e43c1f2e7af0424d86ac078ad38c2073...
 
A 2020-07-30T20:11:26.527872327Z 2020-07-30 20:11:26 thumbor:DEBUG moving tempfile /data/storage/3a/51255382751db8674367f7f469836747f40b39.e43c1f2e7af0424d86ac078ad38c2073 to /data/storage/3a/51255382751db8674367f7f469836747f40b39...
 
A 2020-07-30T20:11:26.528395621Z 2020-07-30 20:11:26 thumbor:DEBUG converting image from 8-bit/1-bit palette to 32-bit RGB(A) for resize
 ```

I set the error log level to `error` - it seems we never reached this level so far but I still increased disk size just to be sure. A more robust fix would be of course to implement a rotating log handler for our thumbor instance - yeah, Python. 

I know updating the thumbor instance is tedious - LMK if I can help, @sebastianbenz.