### PR TITLE
🐛 Use absolute URL for pixi's amp-script src

### DIFF
--- a/pixi/src/pixi.hbs
+++ b/pixi/src/pixi.hbs
@@ -1,5 +1,5 @@
 {{#htmlWebpackPlugin.files.js }}
-<amp-script layout="container" src="{{ . }}" sandbox="allow-forms">
+<amp-script layout="container" src="\{{ podspec.base_urls.platform }}{{ . }}" sandbox="allow-forms">
   <button class="ap-a-btn">Hello amp-script!</button>
 </amp-script>
 {{/htmlWebpackPlugin.files.js }}


### PR DESCRIPTION
Fixes #4296 