### PR TITLE
✨ Create i18n util for Pixi runtime translations

### DIFF
--- a/pages/content/amp-dev/page-experience.html
+++ b/pages/content/amp-dev/page-experience.html
@@ -48,7 +48,23 @@ description: Coming soon - analyze and learn how to optimize your AMP pages for 
       to delivering a great user experience on the web.
     </p>
   </section>
+
   {% do doc.styles.addCssFile('css/components/molecules/input-bar.css') %}
+  <amp-state id="pixi">
+    <script type="application/json">
+      {
+        "i18n": {
+          "language": "{{ doc.locale }}",
+          "translations": {
+            "Analyzing ...": "{{ _('Analyzing ...') }}",
+            "Failed": "{{ _('Failed') }}",
+            "Passed": "{{ _('Passed') }}"
+          }
+        }
+      }
+    </script>
+  </amp-state>
   {% include '/views/partials/pixi.j2' %}
+
   {% endif %}
 </main>

--- a/pages/translations/de/LC_MESSAGES/messages.po
+++ b/pages/translations/de/LC_MESSAGES/messages.po
@@ -3121,3 +3121,15 @@ msgstr "Unterstützte Plattformen, Anbieter und Partner"
 
 msgid "AMP Conf 2020: Save the date!"
 msgstr "AMP Conf 2020: Termin vormerken!"
+
+#: /content/amp-dev/page-experience.html:52
+msgid "Analyzing ..."
+msgstr "Analyse läuft ..."
+
+#: /content/amp-dev/page-experience.html:53
+msgid "Failed"
+msgstr "Fehlgeschlagen"
+
+#: /content/amp-dev/page-experience.html:54
+msgid "Passed"
+msgstr "Bestanden"

--- a/pixi/src/pixi.hbs
+++ b/pixi/src/pixi.hbs
@@ -1,5 +1,0 @@
-{{#htmlWebpackPlugin.files.js }}
-<amp-script layout="container" src="\{{ podspec.base_urls.platform }}{{ . }}" sandbox="allow-forms">
-  <button class="ap-a-btn">Hello amp-script!</button>
-</amp-script>
-{{/htmlWebpackPlugin.files.js }}

--- a/pixi/src/ui/I18n.js
+++ b/pixi/src/ui/I18n.js
@@ -1,0 +1,31 @@
+const DEFAULT_LANGUAGE = 'en';
+
+class I18n {
+
+  constructor() {
+    this.language = DEFAULT_LANGUAGE;
+    this.translations = {};
+  }
+
+  async init() {
+    try {
+      const i18nConfig = JSON.parse(await AMP.getState('pixi.i18n'));
+      this.language = i18nConfig.language;
+      this.translations = i18nConfig.translations;
+    } catch (e) {
+      console.warn('Could not get translations from amp-state. Falling back to original strings', e);
+    }
+  }
+
+  translate(originalString) {
+    const translation = this.translations[originalString];
+    if (!translation && IS_DEVELOPMENT) {
+      // Mark untranslated strings during development
+      return `[${this.language}] ${originalString}`;
+    }
+
+    return translation || originalString;
+  }
+}
+
+export default new I18n();

--- a/pixi/src/ui/I18n.js
+++ b/pixi/src/ui/I18n.js
@@ -1,7 +1,6 @@
 const DEFAULT_LANGUAGE = 'en';
 
 class I18n {
-
   constructor() {
     this.language = DEFAULT_LANGUAGE;
     this.translations = {};
@@ -13,7 +12,10 @@ class I18n {
       this.language = i18nConfig.language;
       this.translations = i18nConfig.translations;
     } catch (e) {
-      console.warn('Could not get translations from amp-state. Falling back to original strings', e);
+      console.warn(
+        'Could not get translations from amp-state. Falling back to original strings',
+        e
+      );
     }
   }
 

--- a/pixi/src/ui/PageExperience.js
+++ b/pixi/src/ui/PageExperience.js
@@ -14,6 +14,7 @@
 
 import PageExperienceCheck from '../checks/PageExperienceCheck.js';
 import CoreWebVitalsReport from './report/CoreWebVitalsReport.js';
+import i18n from './I18n.js';
 
 export default class PageExperience {
   constructor() {
@@ -35,12 +36,16 @@ export default class PageExperience {
 
   async onSubmitUrl() {
     const inputUrl = this.input.value;
-
     if (!this.isValidURL(inputUrl)) {
       // TODO: Initialize lab data reports
       throw new Error('Please enter a valid URL');
     } else {
       this.toggleLoading(true);
+
+      // Everything until here is statically translated by Grow. From now
+      // on Pixi might dynamically render translated strings, so wait
+      // for them to be ready
+      await i18n.init();
 
       const check = new PageExperienceCheck();
       const report = await check.run(inputUrl);

--- a/pixi/src/ui/page-experience.hbs
+++ b/pixi/src/ui/page-experience.hbs
@@ -1,5 +1,5 @@
 {{#htmlWebpackPlugin.files.js }}
-  <amp-script class="ap-t-pixi-checks" src="{{ . }}" layout="container" sandbox="allow-forms">
+  <amp-script class="ap-t-pixi-checks" src="\{{ podspec.base_urls.platform }}{{ . }}" layout="container" sandbox="allow-forms">
 
     <div class="ap-m-input-bar">
       <input id="input-field" class="ap-m-input-bar-field" type="url" name="url" placeholder="Your URL">

--- a/pixi/webpack.config.js
+++ b/pixi/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = (env, argv) => {
         AMP_DEV_API_KEY_PAGE_SPEED_INSIGHTS: '',
       }),
       new webpack.DefinePlugin({
+        IS_DEVELOPMENT: mode == 'development' ? true : false,
         API_ENDPOINT_SAFE_BROWSING: JSON.stringify(
           'https://safebrowsing.googleapis.com/v4/threatMatches:find'
         ),

--- a/pixi/webpack.config.js
+++ b/pixi/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = (env, argv) => {
         AMP_DEV_API_KEY_PAGE_SPEED_INSIGHTS: '',
       }),
       new webpack.DefinePlugin({
-        IS_DEVELOPMENT: mode == 'development' ? true : false,
+        IS_DEVELOPMENT: mode == 'development',
         API_ENDPOINT_SAFE_BROWSING: JSON.stringify(
           'https://safebrowsing.googleapis.com/v4/threatMatches:find'
         ),


### PR DESCRIPTION
My idea was to use a prefilled AMP State to provide two things to Pixi: an object containing i18n strings which could be used in the JavaScript codebase like for example:

```js
    this.label.textContent = i18n.passed;
```

and on the other hand the URL to check if it has been shared. But sadly the following returns `null`:

```js
    AMP.getState().then((state) => {
      console.log('AMP State', state);
    });
```

Getting it on user-interaction as in this [AMP Playground demo](https://playground.amp.dev/#share=PCFkb2N0eXBlIGh0bWw+CjxodG1sIOKaoT4KPGhlYWQ+CiAgPG1ldGEgY2hhcnNldD0idXRmLTgiPgogIDx0aXRsZT5NeSBBTVAgUGFnZTwvdGl0bGU+CiAgPGxpbmsgcmVsPSJjYW5vbmljYWwiIGhyZWY9InNlbGYuaHRtbCIgLz4KICA8bWV0YSBuYW1lPSJ2aWV3cG9ydCIgY29udGVudD0id2lkdGg9ZGV2aWNlLXdpZHRoLG1pbmltdW0tc2NhbGU9MSxpbml0aWFsLXNjYWxlPTEiPgogIDxzdHlsZSBhbXAtYm9pbGVycGxhdGU+Ym9keXstd2Via2l0LWFuaW1hdGlvbjotYW1wLXN0YXJ0IDhzIHN0ZXBzKDEsZW5kKSAwcyAxIG5vcm1hbCBib3RoOy1tb3otYW5pbWF0aW9uOi1hbXAtc3RhcnQgOHMgc3RlcHMoMSxlbmQpIDBzIDEgbm9ybWFsIGJvdGg7LW1zLWFuaW1hdGlvbjotYW1wLXN0YXJ0IDhzIHN0ZXBzKDEsZW5kKSAwcyAxIG5vcm1hbCBib3RoO2FuaW1hdGlvbjotYW1wLXN0YXJ0IDhzIHN0ZXBzKDEsZW5kKSAwcyAxIG5vcm1hbCBib3RofUAtd2Via2l0LWtleWZyYW1lcyAtYW1wLXN0YXJ0e2Zyb217dmlzaWJpbGl0eTpoaWRkZW59dG97dmlzaWJpbGl0eTp2aXNpYmxlfX1ALW1vei1rZXlmcmFtZXMgLWFtcC1zdGFydHtmcm9te3Zpc2liaWxpdHk6aGlkZGVufXRve3Zpc2liaWxpdHk6dmlzaWJsZX19QC1tcy1rZXlmcmFtZXMgLWFtcC1zdGFydHtmcm9te3Zpc2liaWxpdHk6aGlkZGVufXRve3Zpc2liaWxpdHk6dmlzaWJsZX19QC1vLWtleWZyYW1lcyAtYW1wLXN0YXJ0e2Zyb217dmlzaWJpbGl0eTpoaWRkZW59dG97dmlzaWJpbGl0eTp2aXNpYmxlfX1Aa2V5ZnJhbWVzIC1hbXAtc3RhcnR7ZnJvbXt2aXNpYmlsaXR5OmhpZGRlbn10b3t2aXNpYmlsaXR5OnZpc2libGV9fTwvc3R5bGU+PG5vc2NyaXB0PjxzdHlsZSBhbXAtYm9pbGVycGxhdGU+Ym9keXstd2Via2l0LWFuaW1hdGlvbjpub25lOy1tb3otYW5pbWF0aW9uOm5vbmU7LW1zLWFuaW1hdGlvbjpub25lO2FuaW1hdGlvbjpub25lfTwvc3R5bGU+PC9ub3NjcmlwdD4KICA8c2NyaXB0IGFzeW5jIHNyYz0iaHR0cHM6Ly9jZG4uYW1wcHJvamVjdC5vcmcvdjAuanMiPjwvc2NyaXB0PgogIDxzY3JpcHQgYXN5bmMgY3VzdG9tLWVsZW1lbnQ9ImFtcC1iaW5kIiBzcmM9Imh0dHBzOi8vY2RuLmFtcHByb2plY3Qub3JnL3YwL2FtcC1iaW5kLTAuMS5qcyI+PC9zY3JpcHQ+CiAgPHNjcmlwdCBhc3luYyBjdXN0b20tZWxlbWVudD0iYW1wLXNjcmlwdCIgc3JjPSJodHRwczovL2Nkbi5hbXBwcm9qZWN0Lm9yZy92MC9hbXAtc2NyaXB0LTAuMS5qcyI+PC9zY3JpcHQ+CiAgPHN0eWxlIGFtcC1jdXN0b20+CiAgICBoMSB7CiAgICAgIG1hcmdpbjogMXJlbTsKICAgIH0KICA8L3N0eWxlPgogIDxtZXRhIG5hbWU9ImFtcC1zY3JpcHQtc3JjIiBjb250ZW50PSJzaGEzODQtUkF4ejhXRDNiOEpkQlhabGJEYm9tam1DVkpscVpNYmticTg2c2Q2SXdxQTdNTi1aZzdOVE01QVlxQmlJMmt3bSBzaGEzODQtUVpjaHBQYXFtZGVSbTd4N1NGVXkyM2hoTjRvc1dxUXJfSDRrR1lQTmt4RV9ROTVZREEyTFAxY2wzVlVyVEJFNSBzaGEzODQtTTduUG0xSnNITWpmcGJfWEFOREZDN29NSi1TSGRNZWYyWS1HUlROa1FaR1dBZHJCeDBVOHVnZ3VNNWNpR0tRRCAiPgo8L2hlYWQ+Cjxib2R5PgoKICA8YW1wLXNjcmlwdCBsYXlvdXQ9ImNvbnRhaW5lciIgc2NyaXB0PSJkZW1vIj4KICAgIDxidXR0b24gaWQ9ImdldC1zdGF0ZSI+CiAgICAgIEFNUC5nZXRTdGF0ZSgpCiAgICA8L2J1dHRvbj4KICAgIDxpbnB1dCBwbGFjZWhvbGRlcj0ic3RhdGUtanNvbiIgaWQ9InN0YXRlLWpzb24iIGRpc2FibGVkPgogIDwvYW1wLXNjcmlwdD4KICA8YW1wLXN0YXRlIGlkPSJwaXhpIj4KICAgIDxzY3JpcHQgdHlwZT0iYXBwbGljYXRpb24vanNvbiI+CiAgICAgIHsKICAgICAgICAia2V5IjogInZhbCIKICAgICAgfQogICAgPC9zY3JpcHQ+CiAgPC9hbXAtc3RhdGU+CiAgPHNjcmlwdCBpZD0iZGVtbyIgdHlwZT0idGV4dC9wbGFpbiIgdGFyZ2V0PSJhbXAtc2NyaXB0Ij4KICAgIEFNUC5nZXRTdGF0ZSgpLnRoZW4oKHN0YXRlKSA9PiB7CiAgICAJY29uc29sZS5sb2coJ1JlY2VpdmVkIHN0YXRlJywgc3RhdGUpOwogICAgfSk7CiAgICAKICAgIGRvY3VtZW50LmdldEVsZW1lbnRCeUlkKCdnZXQtc3RhdGUnKS5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIChlKSA9PiB7CiAgICAgICAgQU1QLmdldFN0YXRlKCkudGhlbigoc3RhdGUpID0+IHsKICAgICAgICAJZG9jdW1lbnQuZ2V0RWxlbWVudEJ5SWQoJ3N0YXRlLWpzb24nKS52YWx1ZSA9IEpTT04uc3RyaW5naWZ5KHN0YXRlKQogICAgICAgIH0pCiAgICB9KQogIDwvc2NyaXB0Pgo8L2JvZHk+CjwvaHRtbD4K) also fails...

Does anyone know if this should work? Only getting the state on user-interaction would be fine for i18n as all strings in the `amp-script` DOM would already be translated ("Submit" for example...) - but getting it on initialization would allow us to get the URL as `window.location` is not supported by worker-dom.