### PR TITLE
🎨  Restructure package.json test scripts and don't run Pixi tests twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "start": "cd platform && NODE_ENV=production node serve.js",
     "test": "npm-run-all test:* --aggregate-output --parallel",
     "test:prepare": "gulp updateTestResources",
-    "test:platform": "APP_ENV=test jest --testPathPattern platform",
+    "test:platform": "APP_ENV=test jest --testPathPattern platform --testPathIgnorePatterns smoke-tests",
     "test:playground": "APP_ENV=test jest --testPathPattern playground",
     "test:pixi": "APP_ENV=test jest --testPathPattern pixi",
     "test:grow-extensions": "cd pages/extensions && if which grow; then python -m unittest discover -p \"*_test.py\"; else echo grow not installed with pip. skip tests; fi"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "start": "cd platform && NODE_ENV=production node serve.js",
     "test": "npm-run-all test:* --aggregate-output --parallel",
     "test:prepare": "gulp updateTestResources",
-    "test:platform": "APP_ENV=test jest --testPathIgnorePatterns smoke-tests tests",
+    "test:platform": "APP_ENV=test jest --testPathPattern platform",
+    "test:playground": "APP_ENV=test jest --testPathPattern playground",
     "test:pixi": "APP_ENV=test jest --testPathPattern pixi",
     "test:grow-extensions": "cd pages/extensions && if which grow; then python -m unittest discover -p \"*_test.py\"; else echo grow not installed with pip. skip tests; fi"
   },


### PR DESCRIPTION
Pixi tests are currently ran twice as `test:platform` was testing packages outside its described target.