### PR TITLE
Allow HTTPS check to report `Analysis failed`

### DIFF
--- a/pixi/src/checks/AmpLinterCheck.js
+++ b/pixi/src/checks/AmpLinterCheck.js
@@ -45,7 +45,8 @@ export default class AmpLinterCheck {
   createReportData(apiResult) {
     return {
       data: {
-        usesHttps: apiResult.url.startsWith('https:'),
+        usesHttps:
+          apiResult.url != undefined && apiResult.url.startsWith('https:'),
         recommendations: [],
       },
     };

--- a/pixi/src/ui/PageExperience.js
+++ b/pixi/src/ui/PageExperience.js
@@ -143,7 +143,7 @@ export default class PageExperience {
 
     const {error, data} = await this.linterCheck.run(pageUrl);
     if (error) {
-      console.error('Could not perform safe browsing check', error);
+      console.error('Could not perform AMP Linter check', error);
     }
     this.reportViews.httpsCheck.render(data.result);
 


### PR DESCRIPTION
It looks like the HTTPS check always hangs because the AMP linter does not return a `url` property (surfacing as `Cannot read property 'startsWith' of undefined`), and the UI does not update when the error surfaces. For now this PR (1) updates the error message and (2) allows it to fail if `apiResult.url` is `undefined` /cc @tharders 