### PR TITLE
Pixi: Cleanup runtime errors and edge cases

### DIFF
--- a/frontend/scss/components/organisms/pixi-recommendations.scss
+++ b/frontend/scss/components/organisms/pixi-recommendations.scss
@@ -18,7 +18,7 @@
       line-height: 1.4;
       color: color('silver');
       opacity: 0;
-      transition: opacity .3s ease-in;
+      transition: opacity 0.3s ease-in;
     }
   }
 
@@ -40,5 +40,9 @@
         opacity: 1;
       }
     }
+  }
+
+  &.loading > .#{molecule('pixi-recommendations-item')} {
+    display: none;
   }
 }

--- a/pixi/src/checks/AmpLinterCheck.js
+++ b/pixi/src/checks/AmpLinterCheck.js
@@ -39,7 +39,7 @@ export default class AmpLinterCheck {
   }
 
   createError(error) {
-    return {error};
+    return {error, data: {}};
   }
 
   createReportData(apiResult) {

--- a/pixi/src/checks/AmpLinterCheck.test.js
+++ b/pixi/src/checks/AmpLinterCheck.test.js
@@ -39,6 +39,6 @@ describe('Linter check', () => {
 
     const report = await linterCheck.run('http://example.com');
     expect(report.error).toBeDefined();
-    expect(report.data).toBe(undefined);
+    expect(report.data.result).toBe(undefined);
   });
 });

--- a/pixi/src/checks/SafeBrowsingCheck.js
+++ b/pixi/src/checks/SafeBrowsingCheck.js
@@ -28,7 +28,7 @@ export default class SafeBrowsingCheck {
 
   createReportData(error, apiResult) {
     if (error) {
-      return {error};
+      return {error, data: {}};
     }
     return {
       error,

--- a/pixi/src/checks/SafeBrowsingCheck.test.js
+++ b/pixi/src/checks/SafeBrowsingCheck.test.js
@@ -39,6 +39,6 @@ describe('Safe browsing check', () => {
 
     const report = await safeBrowsingCheck.run('http://example.com');
     expect(report.error).toBeDefined();
-    expect(report.data).toBe(undefined);
+    expect(report.data.result).toBe(undefined);
   });
 });

--- a/pixi/src/ui/PageExperience.js
+++ b/pixi/src/ui/PageExperience.js
@@ -145,7 +145,7 @@ export default class PageExperience {
     if (error) {
       console.error('Could not perform AMP Linter check', error);
     }
-    this.reportViews.httpsCheck.render(data.usesHttps);
+    this.reportViews.httpsCheck.render(data.result);
 
     return data.recommendations;
   }

--- a/pixi/src/ui/PageExperience.js
+++ b/pixi/src/ui/PageExperience.js
@@ -145,7 +145,7 @@ export default class PageExperience {
     if (error) {
       console.error('Could not perform AMP Linter check', error);
     }
-    this.reportViews.httpsCheck.render(data.result);
+    this.reportViews.httpsCheck.render(data.usesHttps);
 
     return data.recommendations;
   }

--- a/pixi/src/ui/recommendations/RecommendationsView.js
+++ b/pixi/src/ui/recommendations/RecommendationsView.js
@@ -24,6 +24,9 @@ export default class RecommendationsView {
 
   render(recommendations) {
     for (const item of recommendations) {
+      if (item === undefined) {
+        continue;
+      }
       const recommendation = this.template.cloneNode(true);
       const header = recommendation.querySelector(
         '.ap-m-pixi-recommendations-item-header'


### PR DESCRIPTION
- One common error is cannot read property `result` of `undefined`, due to error cases for the Safe Browsing and HTTPS checks. In this case I return an empty `data` object `{}` to allow the "Analysis Failed" UI to surface.
- Recommendations are hidden during loading. It also looks like some of the flattened recommendations contain a few `undefined` entries so I disregarded those explicitly. We should dig more where they are coming from and consider disregarding any entries that do not have our expected properties (currently `id`, `title`, and `description`).