### PR TITLE
Pixi: Display linter results as rudimentary recommendations

### DIFF
--- a/pixi/mocks/ampLinterCheck/apiResponse.js
+++ b/pixi/mocks/ampLinterCheck/apiResponse.js
@@ -2,8 +2,33 @@ const apiResponsePass = {
   status: 'ok',
   redirected: true,
   url: 'https://amp.dev/',
-  components: {},
-  data: {},
+  components: {'amp-analytics': '0.1', 'amp-list': '0.1', 'amp-geo': '0.1'},
+  data: {
+    blockingextensionspreloaded: [
+      {
+        info: '',
+        message: '',
+        status: 'PASS',
+        title: 'Render-blocking extensions are preloaded',
+        url:
+          'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/#optimize-the-amp-runtime-loading',
+      },
+    ],
+    isvalid: {
+      info: '',
+      status: 'PASS',
+      title: 'Document is valid AMP',
+      url: 'https://validator.amp.dev/',
+    },
+    moduleruntimeused: {
+      info: '',
+      message: 'The JavaScript module version of the AMP Runtime is not used',
+      status: 'WARN',
+      title: 'Page is using JavaScript Module version of the AMP Runtime',
+      url:
+        '"https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/"',
+    },
+  },
 };
 const apiResponseFail = {
   status: 'ok',

--- a/pixi/src/checks/AmpLinterCheck.test.js
+++ b/pixi/src/checks/AmpLinterCheck.test.js
@@ -41,4 +41,13 @@ describe('Linter check', () => {
     expect(report.error).toBeDefined();
     expect(report.data).toBe(undefined);
   });
+
+  it('should parse recommendation from result', async () => {
+    fetchMock.mock(`begin:${apiEndpoint}`, apiResponsePass);
+
+    const report = await linterCheck.run('http://example.com');
+    expect(report.data.components).toBeDefined();
+    expect(report.data.recommendations).toBeDefined();
+    expect(report.data.usesHttps).toBe(true);
+  });
 });


### PR DESCRIPTION
Note: This PR parses the data into the shape we want for recommendations, but does not pass finalized copy in any way. It is meant to be a jumping off point for future progress surfacing linter results. 😄 

This also generically flattens the results of the [`BlockingExtensionsPreloaded` findings](https://github.com/ampproject/amp-toolbox/blob/main/packages/linter/src/rules/BlockingExtensionsPreloaded.ts) which we can likely handle more elegantly.