### PR TITLE
Add isAmp check to linter api

### DIFF
--- a/pages/content/pixi/status-banners/no-amp.md
+++ b/pages/content/pixi/status-banners/no-amp.md
@@ -1,0 +1,6 @@
+---
+$title: This URL is not an AMP page.
+type: error
+---
+Sorry, this tool is designed for AMP pages only.
+Please use tools like Page Speed Insights for non AMP pages.

--- a/pixi/backend/api.js
+++ b/pixi/backend/api.js
@@ -38,6 +38,11 @@ const findAmpComponents = ($) => {
   return versionMap;
 };
 
+const isAmp = ($) => {
+  const ampHtml = $('html[amp],html[⚡]');
+  return ampHtml.length > 0;
+};
+
 const execChecks = async (url) => {
   const res = await rateLimitedFetch.fetchHtmlResponse(url);
   const body = await res.text();
@@ -52,12 +57,21 @@ const execChecks = async (url) => {
     url,
     mode: LintMode.PageExperience,
   };
-  const lintResults = await lint(context);
-  return {
+  const result = {
     redirected: res.redirected,
     url: res.url,
+    isAmp: isAmp($),
+  };
+
+  if (!result.isAmp) {
+    return result;
+  }
+
+  const lintResults = await lint(context);
+  return {
     components: findAmpComponents($),
     data: lintResults,
+    ...result,
   };
 };
 

--- a/pixi/backend/api.test.js
+++ b/pixi/backend/api.test.js
@@ -18,11 +18,35 @@ const app = express();
 const router = require('./api.js');
 app.use(router);
 
-test('returns linter result and page info with no components', (done) => {
+test('returns only the isAmp result with no linter data', (done) => {
   mockResponse = {
     url: 'https://www.test',
     redirected: false,
     text: () => '<html><head></head><body></body></html>',
+  };
+  // linter should not be called
+  linter.lint.mockRejectedValue(new Error('error'));
+
+  request(app)
+    .get('/lint?url=https://www.test')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((res) => {
+      expect(res.body.status).toBe('ok');
+      expect(res.body.redirected).toBe(false);
+      expect(res.body.url).toBe('https://www.test');
+      expect(res.body.isAmp).toBe(false);
+      expect(res.body.components).toBeUndefined();
+      expect(res.body.data).toBeUndefined();
+      done();
+    });
+});
+
+test('returns linter result and page info with no components', (done) => {
+  mockResponse = {
+    url: 'https://www.test',
+    redirected: false,
+    text: () => '<html amp><head></head><body></body></html>',
   };
   linter.lint.mockResolvedValue({
     'isvalid': {
@@ -38,6 +62,7 @@ test('returns linter result and page info with no components', (done) => {
       expect(res.body.status).toBe('ok');
       expect(res.body.redirected).toBe(false);
       expect(res.body.url).toBe('https://www.test');
+      expect(res.body.isAmp).toBe(true);
       expect(res.body.components).toEqual({});
       expect(res.body.data.isvalid.status).toBe('FAIL');
       done();
@@ -49,7 +74,7 @@ test('returns linter result and redirected page with 1 component info', (done) =
     url: 'http://www.test',
     redirected: true,
     text: () =>
-      '<html><head><script src="https://server/v0/amp-script-0.1.js"></script></head><body></body></html>',
+      '<html ⚡><head><script src="https://server/v0/amp-script-0.1.js"></script></head><body></body></html>',
   };
   linter.lint.mockResolvedValue({
     'isvalid': {
@@ -65,6 +90,7 @@ test('returns linter result and redirected page with 1 component info', (done) =
       expect(res.body.status).toBe('ok');
       expect(res.body.redirected).toBe(true);
       expect(res.body.url).toBe('http://www.test');
+      expect(res.body.isAmp).toBe(true);
       expect(res.body.components).toEqual({'amp-script': '0.1'});
       expect(res.body.data.isvalid.status).toBe('PASS');
       done();

--- a/pixi/mocks/ampLinterCheck/apiResponse.js
+++ b/pixi/mocks/ampLinterCheck/apiResponse.js
@@ -2,6 +2,7 @@ const apiResponsePassAll = {
   status: 'ok',
   redirected: true,
   url: 'https://amp.dev/',
+  isAmp: true,
   components: {
     'amp-install-serviceworker': '0.1',
     'amp-consent': '0.1',
@@ -47,6 +48,7 @@ const apiResponseFailAll = {
   status: 'ok',
   redirected: true,
   url: 'http://example.com',
+  isAmp: true,
   components: {
     'amp-experiment': '0.1',
     'amp-access': '0.1',
@@ -94,6 +96,7 @@ const apiResponseInfoBoilerplate = {
   status: 'ok',
   redirected: true,
   url: 'http://example.com',
+  isAmp: true,
   components: {},
   data: {
     boilerplateisremoved: {
@@ -102,8 +105,16 @@ const apiResponseInfoBoilerplate = {
   },
 };
 
+const apiResponseNoAmp = {
+  status: 'ok',
+  redirected: true,
+  url: 'http://example.com',
+  isAmp: false,
+};
+
 module.exports = {
   apiResponsePassAll,
   apiResponseFailAll,
   apiResponseInfoBoilerplate,
+  apiResponseNoAmp,
 };

--- a/pixi/src/checks/AmpLinterCheck.js
+++ b/pixi/src/checks/AmpLinterCheck.js
@@ -56,22 +56,21 @@ export default class AmpLinterCheck {
   }
 
   createReportData(apiResult) {
-    const linterStatus = Object.entries(apiResult.data).reduce(
-      (mappedData, [key, checks]) => {
-        // most checks are mapped 1:1 ro the result
-        const resultKey = directMapping[key];
-        if (resultKey) {
-          if (Array.isArray(checks)) {
-            mappedData[resultKey] =
-              checks.length === 1 && checks[0].status === 'PASS';
-          } else {
-            mappedData[resultKey] = checks.status === 'PASS';
+    const linterStatus = !apiResult.data
+      ? {}
+      : Object.entries(apiResult.data).reduce((mappedData, [key, checks]) => {
+          // most checks are mapped 1:1 ro the result
+          const resultKey = directMapping[key];
+          if (resultKey) {
+            if (Array.isArray(checks)) {
+              mappedData[resultKey] =
+                checks.length === 1 && checks[0].status === 'PASS';
+            } else {
+              mappedData[resultKey] = checks.status === 'PASS';
+            }
           }
-        }
-        return mappedData;
-      },
-      {}
-    );
+          return mappedData;
+        }, {});
 
     if (linterStatus.boilerplateIsRemoved === false) {
       if (apiResult.data.boilerplateisremoved.status === 'WARN') {
@@ -83,6 +82,7 @@ export default class AmpLinterCheck {
 
     return {
       data: {
+        isAmp: apiResult.isAmp,
         usesHttps:
           apiResult.url != undefined && apiResult.url.startsWith('https:'),
         noRenderBlockingExtension: !(

--- a/pixi/src/checks/AmpLinterCheck.test.js
+++ b/pixi/src/checks/AmpLinterCheck.test.js
@@ -9,6 +9,7 @@ import {
   apiResponsePassAll,
   apiResponseFailAll,
   apiResponseInfoBoilerplate,
+  apiResponseNoAmp,
 } from '../../mocks/ampLinterCheck/apiResponse.js';
 
 import pixiConfig from '../../config.js';
@@ -67,6 +68,14 @@ describe('Linter check', () => {
     const report = await linterCheck.run('http://example.com');
     expect(report.data.boilerplateIsRemoved).toBe(false);
     expect(report.data.updateOptimizerForBoilerplateRemoval).not.toBe(true);
+  });
+
+  it('returns object with only the isAmp flag', async () => {
+    fetchMock.mock(`begin:${apiEndpoint}`, apiResponseNoAmp);
+
+    const report = await linterCheck.run('http://example.com');
+    expect(report.data.isAmp).toBe(false);
+    expect(report.data.isValid).toBeUndefined();
   });
 
   it('throws for invalid API response', async () => {


### PR DESCRIPTION
The linter api now first checks if the page is a declared AMP page and only if that is true the linter checks are executed.

This PR also has the imported release schedule updated, which I did not really want to include here, but should do no harm.