### PR TITLE
🔧  Fetch amp-youtube from master

### DIFF
--- a/platform/config/imports/componentReference.json
+++ b/platform/config/imports/componentReference.json
@@ -1,4 +1,4 @@
 {
 	"only": [],
-	"fetchFromMaster": ["amp-access-laterpay", "amp-app-banner", "amp-script", "amp-carousel", "amp-consent", "amp-bind", "amp-story", "amp-subscriptions", "amp-list", "amp-script"]
+	"fetchFromMaster": ["amp-youtube", "amp-access-laterpay", "amp-app-banner", "amp-script", "amp-carousel", "amp-consent", "amp-bind", "amp-story", "amp-subscriptions", "amp-list", "amp-script"]
 }


### PR DESCRIPTION
The `amp-youtube` reference doc is corrupt, which breaks the build - @patrickkettner already did the required fixes in https://github.com/ampproject/amphtml/commit/7a07338fd83ddcaafb2fb5c9f57a4a50474f4c5c we now just need to import the doc from `master`...