### PR TITLE
Pixi status banner rules

### DIFF
--- a/pixi/mocks/ampLinterCheck/apiResponse.js
+++ b/pixi/mocks/ampLinterCheck/apiResponse.js
@@ -112,9 +112,15 @@ const apiResponseNoAmp = {
   isAmp: false,
 };
 
+const apiResponseError = {
+  status: 'error',
+  errorId: 'NO_SUCCESS_RESPONSE',
+};
+
 module.exports = {
   apiResponsePassAll,
   apiResponseFailAll,
   apiResponseInfoBoilerplate,
   apiResponseNoAmp,
+  apiResponseError,
 };

--- a/pixi/src/checkAggregation/recommendations.test.js
+++ b/pixi/src/checkAggregation/recommendations.test.js
@@ -1,0 +1,234 @@
+import getRecommendationIds from './recommendations';
+
+describe('getRecommendationIds', () => {
+  it('returns https', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        usesHttps: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['https']);
+  });
+
+  it('returns valid-cached-amp', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        isValid: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['valid-cached-amp']);
+  });
+
+  it('returns preload-amp-runtime', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        runtimeIsPreloaded: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['preload-amp-runtime']);
+  });
+
+  it('returns preload-render-blocking-extensions', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        blockingExtensionsPreloaded: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['preload-render-blocking-extensions']);
+  });
+
+  it('returns preload-web-fonts', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        fontsArePreloaded: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['preload-web-fonts']);
+  });
+
+  it('returns fast-font-display', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        fastGoogleFontsDisplay: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['fast-font-display']);
+  });
+
+  it('returns preconnect-google-fonts', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        googleFontPreconnect: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['preconnect-google-fonts']);
+  });
+
+  it('returns use-amp-optimizer', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        isTransformedAmp: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['use-amp-optimizer']);
+  });
+
+  it('returns upgrade-amp-optimizer (module runtime)', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        moduleRuntimeIsUsed: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['upgrade-amp-optimizer']);
+  });
+
+  it('returns hero-images', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        heroImageIsDefined: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['hero-images']);
+  });
+
+  it('returns amp-boilerplate-removal', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        boilerplateIsRemoved: false,
+        updateOptimizerForBoilerplateRemoval: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['amp-boilerplate-removal']);
+  });
+
+  it('returns upgrade-amp-optimizer (boilerplate removal)', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        boilerplateIsRemoved: false,
+        updateOptimizerForBoilerplateRemoval: true,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['upgrade-amp-optimizer']);
+  });
+
+  it('returns prevent-render-blocking-extensions', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        noRenderBlockingExtension: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['prevent-render-blocking-extensions']);
+  });
+
+  it('returns dynamic-layout-extensions', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        noDynamicLayoutExtensions: false,
+      }),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['dynamic-layout-extensions']);
+  });
+
+  it('returns safe-browsing', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({
+        safeBrowsing: false,
+      }),
+      Promise.resolve({}),
+      Promise.resolve({})
+    );
+    expect(ids).toEqual(['safe-browsing']);
+  });
+
+  it('returns mobile-friendly', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({}),
+      Promise.resolve({
+        mobileFriendly: false,
+      })
+    );
+    expect(ids).toEqual(['mobile-friendly']);
+  });
+
+  it('returns multiple recommendations', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({
+        safeBrowsing: false,
+      }),
+      Promise.resolve({
+        usesHttps: false,
+        isValid: false,
+      }),
+      Promise.resolve({
+        mobileFriendly: false,
+      })
+    );
+    expect(ids).toContain('safe-browsing');
+    expect(ids).toContain('https');
+    expect(ids).toContain('valid-cached-amp');
+    expect(ids).toContain('mobile-friendly');
+  });
+
+  it('returns no recommendations', async () => {
+    const ids = await getRecommendationIds(
+      Promise.resolve({}),
+      Promise.resolve({
+        safeBrowsing: true,
+      }),
+      Promise.resolve({
+        usesHttps: true,
+        isValid: true,
+      }),
+      Promise.resolve({
+        mobileFriendly: true,
+      })
+    );
+    expect(ids).toEqual([]);
+  });
+});

--- a/pixi/src/checkAggregation/recommendations.test.js
+++ b/pixi/src/checkAggregation/recommendations.test.js
@@ -1,5 +1,7 @@
 import getRecommendationIds from './recommendations';
 
+const fixedRecommendations = ['intrusive-interstitials'];
+
 describe('getRecommendationIds', () => {
   it('returns https', async () => {
     const ids = await getRecommendationIds(
@@ -10,7 +12,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['https']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('https');
   });
 
   it('returns valid-cached-amp', async () => {
@@ -22,7 +25,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['valid-cached-amp']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('valid-cached-amp');
   });
 
   it('returns preload-amp-runtime', async () => {
@@ -34,7 +38,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['preload-amp-runtime']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('preload-amp-runtime');
   });
 
   it('returns preload-render-blocking-extensions', async () => {
@@ -46,7 +51,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['preload-render-blocking-extensions']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('preload-render-blocking-extensions');
   });
 
   it('returns preload-web-fonts', async () => {
@@ -58,7 +64,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['preload-web-fonts']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('preload-web-fonts');
   });
 
   it('returns fast-font-display', async () => {
@@ -70,7 +77,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['fast-font-display']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('fast-font-display');
   });
 
   it('returns preconnect-google-fonts', async () => {
@@ -82,7 +90,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['preconnect-google-fonts']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('preconnect-google-fonts');
   });
 
   it('returns use-amp-optimizer', async () => {
@@ -94,7 +103,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['use-amp-optimizer']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('use-amp-optimizer');
   });
 
   it('returns upgrade-amp-optimizer (module runtime)', async () => {
@@ -106,7 +116,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['upgrade-amp-optimizer']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('upgrade-amp-optimizer');
   });
 
   it('returns hero-images', async () => {
@@ -118,7 +129,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['hero-images']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('hero-images');
   });
 
   it('returns amp-boilerplate-removal', async () => {
@@ -131,7 +143,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['amp-boilerplate-removal']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('amp-boilerplate-removal');
   });
 
   it('returns upgrade-amp-optimizer (boilerplate removal)', async () => {
@@ -144,7 +157,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['upgrade-amp-optimizer']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('upgrade-amp-optimizer');
   });
 
   it('returns prevent-render-blocking-extensions', async () => {
@@ -156,7 +170,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['prevent-render-blocking-extensions']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('prevent-render-blocking-extensions');
   });
 
   it('returns dynamic-layout-extensions', async () => {
@@ -168,7 +183,8 @@ describe('getRecommendationIds', () => {
       }),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['dynamic-layout-extensions']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('dynamic-layout-extensions');
   });
 
   it('returns safe-browsing', async () => {
@@ -180,7 +196,8 @@ describe('getRecommendationIds', () => {
       Promise.resolve({}),
       Promise.resolve({})
     );
-    expect(ids).toEqual(['safe-browsing']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('safe-browsing');
   });
 
   it('returns mobile-friendly', async () => {
@@ -192,7 +209,8 @@ describe('getRecommendationIds', () => {
         mobileFriendly: false,
       })
     );
-    expect(ids).toEqual(['mobile-friendly']);
+    expect(ids.length).toBe(fixedRecommendations.length + 1);
+    expect(ids).toContain('mobile-friendly');
   });
 
   it('returns multiple recommendations', async () => {
@@ -209,13 +227,14 @@ describe('getRecommendationIds', () => {
         mobileFriendly: false,
       })
     );
+    expect(ids.length).toBe(fixedRecommendations.length + 4);
     expect(ids).toContain('safe-browsing');
     expect(ids).toContain('https');
     expect(ids).toContain('valid-cached-amp');
     expect(ids).toContain('mobile-friendly');
   });
 
-  it('returns no recommendations', async () => {
+  it('returns fixed recommendations', async () => {
     const ids = await getRecommendationIds(
       Promise.resolve({}),
       Promise.resolve({
@@ -229,6 +248,9 @@ describe('getRecommendationIds', () => {
         mobileFriendly: true,
       })
     );
-    expect(ids).toEqual([]);
+    expect(ids.length).toBe(fixedRecommendations.length);
+    for (let i = 0; i < fixedRecommendations.length; i++) {
+      expect(ids).toContain(fixedRecommendations[i]);
+    }
   });
 });

--- a/pixi/src/checkAggregation/statusBanner.js
+++ b/pixi/src/checkAggregation/statusBanner.js
@@ -17,7 +17,7 @@ export default async function getStatusId(
   pageExperiencePromise,
   safeBrowsingPromise,
   linterPromise,
-  mobileFriendlinessPromise,
+  mobileFriendlinessPromise
 ) {
   try {
     const linter = await linterPromise;

--- a/pixi/src/checkAggregation/statusBanner.js
+++ b/pixi/src/checkAggregation/statusBanner.js
@@ -1,0 +1,57 @@
+// Copyright 2020 The AMPHTML Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default async function getStatusId(
+  recommendationsPromise,
+  pageExperiencePromise,
+  safeBrowsingPromise,
+  linterPromise,
+  mobileFriendlinessPromise,
+) {
+  try {
+    const linter = await linterPromise;
+    if (!linter.isLoaded) {
+      return 'invalid-url';
+    }
+    if (!linter.isAmp) {
+      return 'no-amp';
+    }
+    if (!linter.isValid) {
+      return 'invalid-amp';
+    }
+
+    // We need to check all promises for general error (handled by catch below)
+    // But we only use the results of the first two
+    const [recommendations, pageExperience] = await Promise.all([
+      recommendationsPromise,
+      pageExperiencePromise,
+      safeBrowsingPromise,
+      mobileFriendlinessPromise,
+    ]);
+
+    // This here is only to silence the linter complaining about unused vars
+    if (!pageExperience) {
+      // TODO: specific page experience results
+      return 'failed-with-info';
+    }
+
+    // if we reach this point all the page has passed the tests...
+    if (recommendations.length > 0) {
+      return 'passed-with-info';
+    }
+    return 'all-passed';
+  } catch (err) {
+    return 'api-error';
+  }
+}

--- a/pixi/src/checkAggregation/statusBanner.test.js
+++ b/pixi/src/checkAggregation/statusBanner.test.js
@@ -1,0 +1,103 @@
+import getStatusId from './statusBanner.js';
+
+const pendingPromise = new Promise(() => {});
+
+describe('getStatusId', () => {
+  it('returns invalid-url', async () => {
+    const statusId = await getStatusId(
+      pendingPromise,
+      pendingPromise,
+      pendingPromise,
+      Promise.resolve({
+        isLoaded: false,
+      }),
+      pendingPromise
+    );
+    expect(statusId).toBe('invalid-url');
+  });
+
+  it('returns no-amp', async () => {
+    const statusId = await getStatusId(
+      pendingPromise,
+      pendingPromise,
+      pendingPromise,
+      Promise.resolve({
+        isLoaded: true,
+        isAmp: false,
+      }),
+      pendingPromise
+    );
+    expect(statusId).toBe('no-amp');
+  });
+
+  it('returns invalid-amp', async () => {
+    const statusId = await getStatusId(
+      pendingPromise,
+      pendingPromise,
+      pendingPromise,
+      Promise.resolve({
+        isLoaded: true,
+        isAmp: true,
+        isValid: false,
+      }),
+      pendingPromise
+    );
+    expect(statusId).toBe('invalid-amp');
+  });
+
+  it('returns api-error for linter error', async () => {
+    const statusId = await getStatusId(
+      pendingPromise,
+      pendingPromise,
+      pendingPromise,
+      Promise.reject(new Error('error')),
+      pendingPromise
+    );
+    expect(statusId).toBe('api-error');
+  });
+
+  it('returns api-error for page experience error', async () => {
+    const statusId = await getStatusId(
+      pendingPromise,
+      Promise.reject(new Error('error')),
+      pendingPromise,
+      Promise.resolve({
+        isLoaded: true,
+        isAmp: true,
+        isValid: true,
+      }),
+      pendingPromise
+    );
+    expect(statusId).toBe('api-error');
+  });
+
+  it('returns api-error for safe browsing error', async () => {
+    const statusId = await getStatusId(
+      pendingPromise,
+      pendingPromise,
+      Promise.reject(new Error('error')),
+      Promise.resolve({
+        isLoaded: true,
+        isAmp: true,
+        isValid: true,
+      }),
+      pendingPromise
+    );
+    expect(statusId).toBe('api-error');
+  });
+
+  it('returns api-error for mobile friendliness error', async () => {
+    const statusId = await getStatusId(
+      pendingPromise,
+      pendingPromise,
+      pendingPromise,
+      Promise.resolve({
+        isLoaded: true,
+        isAmp: true,
+        isValid: true,
+      }),
+      Promise.reject(new Error('error'))
+    );
+    expect(statusId).toBe('api-error');
+  });
+});

--- a/pixi/src/checks/AmpLinterCheck.js
+++ b/pixi/src/checks/AmpLinterCheck.js
@@ -44,8 +44,8 @@ export default class AmpLinterCheck {
   }
 
   parseApiResult(apiResult) {
-    if (apiResult.status != 'ok') {
-      return this.createError(new Error(apiResult.message));
+    if (apiResult.status !== 'ok') {
+      return {data: {isLoaded: false}};
     }
 
     return this.createReportData(apiResult);
@@ -82,6 +82,7 @@ export default class AmpLinterCheck {
 
     return {
       data: {
+        isLoaded: true,
         isAmp: apiResult.isAmp,
         usesHttps:
           apiResult.url != undefined && apiResult.url.startsWith('https:'),
@@ -100,16 +101,10 @@ export default class AmpLinterCheck {
 
   async fetchJson() {
     try {
-      const response = await fetch(this.apiUrl);
-
-      if (!response.ok) {
-        throw new Error(
-          `AmpLinterCheck failed: response failed with status ${response.status}`
-        );
-      }
+      const response = await fetch(this.apiUrl.href);
       return response.json();
     } catch (e) {
-      throw new Error('AmpLinterCheck failed:', e);
+      throw new Error(`AmpLinterCheck failed: ${e.message}`);
     }
   }
 }

--- a/pixi/src/checks/AmpLinterCheck.test.js
+++ b/pixi/src/checks/AmpLinterCheck.test.js
@@ -10,6 +10,7 @@ import {
   apiResponseFailAll,
   apiResponseInfoBoilerplate,
   apiResponseNoAmp,
+  apiResponseError,
 } from '../../mocks/ampLinterCheck/apiResponse.js';
 
 import pixiConfig from '../../config.js';
@@ -26,6 +27,8 @@ describe('Linter check', () => {
     fetchMock.mock(`begin:${apiEndpoint}`, apiResponsePassAll);
 
     const report = await linterCheck.run('http://example.com');
+    expect(report.data.isLoaded).toBe(true);
+    expect(report.data.isAmp).toBe(true);
     expect(report.data.usesHttps).toBe(true);
     expect(report.data.isValid).toBe(true);
     expect(report.data.runtimeIsPreloaded).toBe(true);
@@ -46,6 +49,8 @@ describe('Linter check', () => {
     fetchMock.mock(`begin:${apiEndpoint}`, apiResponseFailAll);
 
     const report = await linterCheck.run('http://example.com');
+    expect(report.data.isLoaded).toBe(true);
+    expect(report.data.isAmp).toBe(true);
     expect(report.data.usesHttps).toBe(false);
     expect(report.data.isValid).toBe(false);
     expect(report.data.runtimeIsPreloaded).toBe(false);
@@ -70,11 +75,21 @@ describe('Linter check', () => {
     expect(report.data.updateOptimizerForBoilerplateRemoval).not.toBe(true);
   });
 
-  it('returns object with only the isAmp flag', async () => {
+  it('returns object with only the isAmp and isLoaded flag', async () => {
     fetchMock.mock(`begin:${apiEndpoint}`, apiResponseNoAmp);
 
     const report = await linterCheck.run('http://example.com');
+    expect(report.data.isLoaded).toBe(true);
     expect(report.data.isAmp).toBe(false);
+    expect(report.data.isValid).toBeUndefined();
+  });
+
+  it('returns object with only the isLoaded flag', async () => {
+    fetchMock.mock(`begin:${apiEndpoint}`, apiResponseError);
+
+    const report = await linterCheck.run('http://example.com');
+    expect(report.data.isLoaded).toBe(false);
+    expect(report.data.isAmp).toBeUndefined();
     expect(report.data.isValid).toBeUndefined();
   });
 


### PR DESCRIPTION
Basic pixi status banner rules

Changed AmpLinterCheck to not throw when the url could not be loaded in order to handle this case like any other check.

Also added unit test for recommendations rules.

The status banner rules are currently not used in the frontend.