### PR TITLE
Pixi: Accessibility improvements

### DIFF
--- a/frontend/scss/components/molecules/pixi-status-intro.scss
+++ b/frontend/scss/components/molecules/pixi-status-intro.scss
@@ -27,7 +27,8 @@
         margin-left: 30px;
       }
 
-      h4, p {
+      h3,
+      p {
         color: color('white');
       }
     }

--- a/frontend/scss/components/templates/pixi.scss
+++ b/frontend/scss/components/templates/pixi.scss
@@ -111,7 +111,7 @@
         background: linear-gradient(
           225deg,
           color('robins-egg') 10%,
-          color('blue-ribbon') 45%
+          color('blue-ribbon') 50%
         );
         clip-path: polygon(0% 40%, 100% 35%, 100% 92%, 0% 100%);
 

--- a/frontend/scss/components/templates/pixi.scss
+++ b/frontend/scss/components/templates/pixi.scss
@@ -110,8 +110,8 @@
         height: 100%;
         background: linear-gradient(
           225deg,
-          color('robins-egg') 20%,
-          color('blue-ribbon') 75%
+          color('robins-egg') 10%,
+          color('blue-ribbon') 45%
         );
         clip-path: polygon(0% 40%, 100% 35%, 100% 92%, 0% 100%);
 

--- a/frontend/templates/views/partials/banner.j2
+++ b/frontend/templates/views/partials/banner.j2
@@ -14,7 +14,7 @@
     {{ _('Do you build things with AMP? Fill out the new AMP Developer Survey!') }}
   </a>
 {% if banner_closeable %}
-  <button class="ap-m-banner-dismiss" on="tap:{{ banner_notification_id }}.dismiss">
+  <button class="ap-m-banner-dismiss" on="tap:{{ banner_notification_id }}.dismiss" aria-label="{{ _('Dismiss message') }}">
     {% do doc.icons.useIcon('/icons/close.svg') %}
     <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close"></use></svg>
   </button>

--- a/frontend/templates/views/partials/pixi/input-bar.j2
+++ b/frontend/templates/views/partials/pixi/input-bar.j2
@@ -4,7 +4,7 @@
   <h2 class="ap-m-input-bar-title">{{ _('Analyze your AMP page') }}</h2>
   <div class="ap-m-input-bar-container">
     <div class="ap-m-input-bar-textbox">
-      <input id="input-field" class="ap-m-input-bar-textbox-field" type="url" name="url" placeholder="{{ _('Enter your URL') }}" value="[= query.url =]">
+      <input id="input-field" class="ap-m-input-bar-textbox-field" type="url" name="url" placeholder="{{ _('Enter your URL') }}" value="[= query.url =]" aria-label="{{ _('Enter your URL') }}">
     </div>
     <button id="input-submit" on="tap:pixi-checks.scrollTo(duration=300)" class="ap-m-input-bar-submit" name="button">
       {{ _('Analyze') }}

--- a/frontend/templates/views/partials/pixi/status-intro.j2
+++ b/frontend/templates/views/partials/pixi/status-intro.j2
@@ -3,15 +3,15 @@
 <section id="status-intro" class="ap-m-pixi-status-intro">
   <div class="ap-m-pixi-status-intro-text">
     <div class="ap-m-pixi-status-intro-text-item">
-      <h4>Why is it important</h4>
+      <h3>Why is it important</h3>
       <p>Web Vitals is an initiative by Google to provide unified guidance for quality signals that are essential to delivering a great user experience on the web.</p>
     </div>
     <div class="ap-m-pixi-status-intro-text-item">
-      <h4>The checks</h4>
+      <h3>The checks</h3>
       <p>Talk about which checks will be done.  Lorem ipsum dolor sit amet, consectetur adip iscing elit, sed do eiusmod tempor inci didunt ut labore et dolore magna aliqua eres est.</p>
     </div>
     <div class="ap-m-pixi-status-intro-text-item">
-      <h4>The recommendations</h4>
+      <h3>The recommendations</h3>
       <p>That recommendations will come up Lorem ipsum dolor sit amet, consectetur adipis cing elit, sed do eiusmod tempor incididunt.</p>
     </div>
   </div>


### PR DESCRIPTION
- Adds aria labels to the input bar and site-level survey banner.
- Replaces `h4` with `h3` to follow sequential hierarchy of heading importance.
- LH score prior to these changes was 84 and 97 after:
![image](https://user-images.githubusercontent.com/10456171/92019007-edf33a00-ed23-11ea-9a8c-5b8dbe42b299.png)

# Note on the two remaining failures:

## Color contrast
The first is regarding color contrast of the white text over the gradient background. Lighthouse cannot detect the color contrast of text over image, therefore it assumes the text (white) is over the page's off-white `background-color`, resulting in a very low contrast of 1.04. 

While the automated score fails this, the actual manual check reveals that the score is about 5.64 (more than sufficient) in the deepest blue and 2.33 in the lightest. For accessibility purposes I changed the gradient ratio such that the lightest portion underneath white text will have at least a 3:1 ratio region to meet color contrast best practices, however this will not correct the automated findings.
![image](https://user-images.githubusercontent.com/10456171/92019335-74a81700-ed24-11ea-8a75-abbefe5c48b0.png)
![image](https://user-images.githubusercontent.com/10456171/92021789-4a585880-ed28-11ea-9c05-5820d0efb2de.png)

Note also that `text-shadow: 0 0 1px #000` did not appear to solve the issue.

## Sequential headings
The header for `Follow us` in the site-level footer is `h5`, thus the test auto detects that `h4` is skipped. It would fix the audit if we replaced the tag with `<h4>` for this specific page or `<header>` to generically fix all pages, but I'm not sure if this will have adverse affects on the rest of the site. Filed #4431 to follow up.
![image](https://user-images.githubusercontent.com/10456171/92019322-6eb23600-ed24-11ea-92eb-e2e43e36a6d4.png)
