### PR TITLE
ws=>wss scheme for websockets

### DIFF
--- a/platform/config/environments/local.json
+++ b/platform/config/environments/local.json
@@ -17,7 +17,7 @@
       "port": "8080"
     },
     "websocket": {
-      "scheme": "http",
+      "scheme": "ws",
       "host": "localhost",
       "port": "8080"
     },

--- a/platform/config/environments/production.json
+++ b/platform/config/environments/production.json
@@ -17,7 +17,7 @@
 			"port": ""
     },
 		"websocket": {
-			"scheme": "ws",
+			"scheme": "wss",
 			"host": "amp.dev",
 			"port": ""
     },

--- a/platform/config/environments/staging.json
+++ b/platform/config/environments/staging.json
@@ -17,7 +17,7 @@
 			"port": ""
     },
 		"websocket": {
-			"scheme": "ws",
+			"scheme": "wss",
 			"host": "amp-dev-staging.appspot.com",
 			"port": ""
     },


### PR DESCRIPTION
I couldn't test this locally because I hit an error being emitted by AMP Optimizer. Don't know if others are having this issue or not. Is there a missing `}` in the CSS?

Regardless, I did test this locally and I think it will fix https://github.com/ampproject/amp.dev/issues/4457 .

Let me know though if something in my environment might be causing this error :)

```
AMP Optimizer SeparateKeyframes WARNING Failed to process CSS f.charCodeAt is not a function
[7:23:49 PM] › ✖  error     [OPTIMIZER] { CssSyntaxError: <css input>:49:7: Unclosed block
    at Input.error (/Users/morss/Sites/docs/node_modules/rcs-core/node_modules/postcss/lib/input.js:130:16)
    at Parser.unclosedBlock (/Users/morss/Sites/docs/node_modules/rcs-core/node_modules/postcss/lib/parser.js:572:22)
    at Parser.endFile (/Users/morss/Sites/docs/node_modules/rcs-core/node_modules/postcss/lib/parser.js:393:35)
    at Parser.parse (/Users/morss/Sites/docs/node_modules/rcs-core/node_modules/postcss/lib/parser.js:82:10)
    at Function.parse (/Users/morss/Sites/docs/node_modules/rcs-core/node_modules/postcss/lib/parse.js:17:12)
    at IdSelectorLibrary.fillLibrary (/Users/morss/Sites/docs/node_modules/rcs-core/dest/attributeLibrary.js:139:30)
    at result.selectors.reduce (/Users/morss/Sites/docs/node_modules/rcs-core/dest/selectorsLibrary.js:36:24)
    at Array.reduce (<anonymous>)
    at SelectorsLibrary.callOnBoth (/Users/morss/Sites/docs/node_modules/rcs-core/dest/selectorsLibrary.js:31:35)
    at SelectorsLibrary.fillLibrary (/Users/morss/Sites/docs/node_modules/rcs-core/dest/selectorsLibrary.js:64:10)
    at Object.exports.default [as fillLibraries] (/Users/morss/Sites/docs/node_modules/rcs-core/dest/fillLibraries.js:59:30)
    at CssTransformer.transform (/Users/morss/Sites/docs/platform/lib/utils/cssTransformer.js:133:9)
    at sequence (/Users/morss/Sites/docs/node_modules/@ampproject/toolbox-optimizer/lib/DomTransformer.js:141:26)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```