### PR TITLE
Pixi: Give tooltip elements unique ids

### DIFF
--- a/frontend/templates/views/partials/pixi/basic-metric.j2
+++ b/frontend/templates/views/partials/pixi/basic-metric.j2
@@ -15,7 +15,7 @@
   </h3>
 
   {% with tooltip = {
-    'id': basic_metric.id
+    'id': basic_metric.id,
   } %}
   {% include 'views/partials/pixi/tooltip.j2' %}
   {% endwith %}

--- a/frontend/templates/views/partials/pixi/basic-metric.j2
+++ b/frontend/templates/views/partials/pixi/basic-metric.j2
@@ -15,7 +15,7 @@
   </h3>
 
   {% with tooltip = {
-    'id': basic_metric.id,
+    'id': basic_metric.id
   } %}
   {% include 'views/partials/pixi/tooltip.j2' %}
   {% endwith %}

--- a/frontend/templates/views/partials/pixi/primary-checks.j2
+++ b/frontend/templates/views/partials/pixi/primary-checks.j2
@@ -48,6 +48,7 @@
   <div class="ap-o-pixi-primary-checks-data">
     {% with primary_metric = {
       'id': 'labData.lcp',
+      'type': '-lab',
       'title': {
         'full': _('Loading speed'),
         'id': 'LCP'
@@ -59,6 +60,7 @@
 
     {% with primary_metric = {
       'id': 'labData.fid',
+      'type': '-lab',
       'title': {
         'full': _('Interactivity'),
         'id': 'TBT'
@@ -70,6 +72,7 @@
 
     {% with primary_metric = {
       'id': 'labData.cls',
+      'type': '-lab',
       'title': {
         'full': _('Visual stability'),
         'id': 'CLS'

--- a/frontend/templates/views/partials/pixi/primary-metric.j2
+++ b/frontend/templates/views/partials/pixi/primary-metric.j2
@@ -16,7 +16,8 @@
     </h3>
 
     {% with tooltip = {
-      'id': primary_metric.title.id|lower
+      'id': primary_metric.title.id|lower,
+      'type': primary_metric.type
     } %}
     {% include 'views/partials/pixi/tooltip.j2' %}
     {% endwith %}

--- a/frontend/templates/views/partials/pixi/tooltip.j2
+++ b/frontend/templates/views/partials/pixi/tooltip.j2
@@ -1,17 +1,17 @@
 {% do doc.styles.addCssFile('css/components/molecules/pixi-tooltip.css') %}
 
-<div id="tooltip-{{ tooltip.id|replace(".", "-") }}"
+<div id="tooltip-{{ tooltip.id|replace(".", "-")  + tooltip.type|default('') }}"
     class="ap-m-tooltip">
 
   <button class="ap-m-tooltip-toggle"
-      on="tap:tooltip-{{ tooltip.id|replace(".", "-") }}.toggleClass(class=active)">
+      on="tap:tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}.toggleClass(class=active)">
     {% do doc.icons.useIcon('icons/questionmark-outline.svg') %}
     <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#questionmark-outline"></use></svg>
   </button>
 
   <div class="ap-m-tooltip-tip">
     <button class="ap-m-tooltip-close"
-        on="tap:tooltip-{{ tooltip.id|replace(".", "-") }}.toggleClass(class=active)">
+        on="tap:tooltip-{{ tooltip.id|replace(".", "-")  + tooltip.type|default('') }}.toggleClass(class=active)">
       {% do doc.icons.useIcon('/icons/close.svg') %}
       <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close"></use></svg>
     </button>


### PR DESCRIPTION
This fixes a bug where the lab data tooltips for `LCP` and `CLS` are toggling the tooltip elements associated with their field data counterparts. 