### PR TITLE
Pixi: Lab data details

### DIFF
--- a/pixi/src/ui/report/CoreWebVitalsReportView.js
+++ b/pixi/src/ui/report/CoreWebVitalsReportView.js
@@ -28,9 +28,10 @@ class WeightedScale {
   }
 
   render(data, unit) {
-    this.pitch.style.left = `${
+    this.pitch.style.left = `${Math.min(
+      100,
       (data.numericValue / data.proportion.slow) * 100
-    }%`;
+    )}%`;
     this.pitch.textContent = `${(data.numericValue / unit.conversion).toFixed(
       unit.digits
     )} ${unit.name}`;

--- a/pixi/src/ui/report/CoreWebVitalsReportView.js
+++ b/pixi/src/ui/report/CoreWebVitalsReportView.js
@@ -114,7 +114,7 @@ class CoreWebVitalView {
       !cacheMetric.data ||
       cacheMetric.data.improvement == undefined
     ) {
-      this.improvement.textContent = 'Check recommendations';
+      this.improvement.textContent = '---';
     } else if (cacheMetric.data.improvement === 0) {
       this.improvement.textContent = 'None';
     } else if (!Number.isNaN(cacheMetric.data.improvement)) {
@@ -123,7 +123,7 @@ class CoreWebVitalView {
       ).toFixed(unit.digits);
       this.improvement.textContent = `${improvement} ${unit.name}`;
     } else {
-      this.improvement.textContent = 'Check recommendations';
+      this.improvement.textContent = '---';
     }
 
     this.recommendations.textContent = 'Not yet implemented';


### PR DESCRIPTION
- Do not plot extreme values beyond 100% of the graph size.
- Display `---` as the "Opportunity to improve" for edge cases
- Modify the lab data metric status to resolve accurately (-> currently it's always "Good" regardless of score)

Fixes #4450