### PR TITLE
make intrusive interstitial warning more explict about not scanning

### DIFF
--- a/pages/content/pixi/recommendations/intrusive-interstitials.md
+++ b/pages/content/pixi/recommendations/intrusive-interstitials.md
@@ -1,11 +1,12 @@
 ---
-$title: Remove intrusive interstitials 
+$title: Ensure there are no intrusive interstitials
 $order: 900
 tags:
 - intrusiveInterstitials
 ---
-This can frustrate users because
-they are unable to easily access the content that they were expecting when they
-navigated to your page. Please [manually
+We cannot automaticallly check this, but it is important to manually
+confirm your site has no intrusive interstitials. These can frustrate
+users because they are unable to easily access the content that they
+were expecting when they navigated to your page. Please [manually
 check](https://www.google.com/webmasters/tools/ad-experience-mobile-unverified?hl=en-GB)
 to ensure that your page does not contain any intrusive interstitials.


### PR DESCRIPTION
When testing a site that has a failure, the language of the current version seems to imply that the scanner has found intrusive interstitials. It seems as though it was very easily become confusing as to what was being refer to to someone who doesn't know that we are not actually scanning for this.