### PR TITLE
Pixi: Granular status resolution of cache and origin data

### DIFF
--- a/pixi/mocks/pageExperienceCheck/reportData.json
+++ b/pixi/mocks/pageExperienceCheck/reportData.json
@@ -36,7 +36,8 @@
 					"category": "FAST",
 					"proportion": 0.816381257056831
 				}
-			}
+			},
+			"isAllFast": true
 		},
 		"labData": {
 			"lcp": {
@@ -86,15 +87,10 @@
 					},
 					"category": "FAST"
 				}
-			}
+			},
+			"isAllFast": true
 		},
-		"summary": {
-			"source": "fieldData",
-			"isAllFast": {
-				"fieldData": true,
-				"labData": true
-			}
-		}
+		"source": "fieldData"
 	},
 	"textCompression": true,
 	"fastServerResponse": true,

--- a/pixi/mocks/pageExperienceCheck/reportData.json
+++ b/pixi/mocks/pageExperienceCheck/reportData.json
@@ -88,7 +88,13 @@
 				}
 			}
 		},
-		"isAllFast": true
+		"summary": {
+			"source": "fieldData",
+			"isAllFast": {
+				"fieldData": true,
+				"labData": true
+			}
+		}
 	},
 	"textCompression": true,
 	"fastServerResponse": true,

--- a/pixi/mocks/pageExperienceCheck/reportDataErrors.json
+++ b/pixi/mocks/pageExperienceCheck/reportDataErrors.json
@@ -36,7 +36,8 @@
 					"category": "FAST",
 					"proportion": 0.932653831634579
 				}
-			}
+			},
+			"isAllFast": false
 		},
 		"labData": {
 			"lcp": {
@@ -86,15 +87,10 @@
 					},
 					"category": "FAST"
 				}
-			}
+			},
+			"isAllFast": false
 		},
-		"summary": {
-			"source": "fieldData",
-			"isAllFast": {
-				"fieldData": false,
-				"labData": false
-			}
-		}
+		"source": "fieldData"
 	},
 	"textCompression": false,
 	"fastServerResponse": false,

--- a/pixi/mocks/pageExperienceCheck/reportDataErrors.json
+++ b/pixi/mocks/pageExperienceCheck/reportDataErrors.json
@@ -88,7 +88,13 @@
 				}
 			}
 		},
-		"isAllFast": false
+		"summary": {
+			"source": "fieldData",
+			"isAllFast": {
+				"fieldData": false,
+				"labData": false
+			}
+		}
 	},
 	"textCompression": false,
 	"fastServerResponse": false,

--- a/pixi/mocks/pageExperienceCheck/reportDataNoFieldData.json
+++ b/pixi/mocks/pageExperienceCheck/reportDataNoFieldData.json
@@ -48,14 +48,10 @@
 					},
 					"category": "FAST"
 				}
-			}
+			},
+			"isAllFast": true
 		},
-		"summary": {
-			"source": "labData",
-			"isAllFast": {
-				"labData": true
-			}
-		}
+		"source": "labData"
 	},
 	"textCompression": true,
 	"fastServerResponse": true,

--- a/pixi/mocks/pageExperienceCheck/reportDataNoFieldData.json
+++ b/pixi/mocks/pageExperienceCheck/reportDataNoFieldData.json
@@ -50,7 +50,12 @@
 				}
 			}
 		},
-		"isAllFast": true
+		"summary": {
+			"source": "labData",
+			"isAllFast": {
+				"labData": true
+			}
+		}
 	},
 	"textCompression": true,
 	"fastServerResponse": true,

--- a/pixi/src/checkAggregation/statusBanner.js
+++ b/pixi/src/checkAggregation/statusBanner.js
@@ -65,11 +65,13 @@ const getStatusId = async (
       safeBrowsing.safeBrowsing &&
       linter.usesHttps;
 
-    const pagePassedAll = pageExperience.isAllFast && passedOtherCriteria;
+    const dataType = pageExperience.summary.source;
+    const pagePassedAll =
+      pageExperience.summary.isAllFast[dataType] && passedOtherCriteria;
 
-    if (cacheExperience) {
-      const cachePassedAll = cacheExperience.isAllFast && passedOtherCriteria;
-
+    if (cacheExperience[dataType] !== undefined) {
+      const cachePassedAll =
+        cacheExperience.summary.isAllFast[dataType] && passedOtherCriteria;
       if (cachePassedAll && !pagePassedAll) {
         if (recommendations.length > fixedRecommendations.length) {
           return 'origin-failed-with-info';

--- a/pixi/src/checkAggregation/statusBanner.js
+++ b/pixi/src/checkAggregation/statusBanner.js
@@ -65,13 +65,13 @@ const getStatusId = async (
       safeBrowsing.safeBrowsing &&
       linter.usesHttps;
 
-    const dataType = pageExperience.summary.source;
+    const dataType = pageExperience.source;
     const pagePassedAll =
-      pageExperience.summary.isAllFast[dataType] && passedOtherCriteria;
+      pageExperience[dataType].isAllFast && passedOtherCriteria;
 
     if (cacheExperience && cacheExperience[dataType] !== undefined) {
       const cachePassedAll =
-        cacheExperience.summary.isAllFast[dataType] && passedOtherCriteria;
+        cacheExperience[dataType].isAllFast && passedOtherCriteria;
       if (cachePassedAll && !pagePassedAll) {
         if (recommendations.length > fixedRecommendations.length) {
           return 'origin-failed-with-info';

--- a/pixi/src/checkAggregation/statusBanner.js
+++ b/pixi/src/checkAggregation/statusBanner.js
@@ -69,7 +69,7 @@ const getStatusId = async (
     const pagePassedAll =
       pageExperience.summary.isAllFast[dataType] && passedOtherCriteria;
 
-    if (cacheExperience[dataType] !== undefined) {
+    if (cacheExperience && cacheExperience[dataType] !== undefined) {
       const cachePassedAll =
         cacheExperience.summary.isAllFast[dataType] && passedOtherCriteria;
       if (cachePassedAll && !pagePassedAll) {

--- a/pixi/src/checkAggregation/statusBanner.test.js
+++ b/pixi/src/checkAggregation/statusBanner.test.js
@@ -66,23 +66,22 @@ describe('getStatusId', () => {
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: true,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
         pageExperienceCached: {
-          fieldData: {},
-          summary: {
-            isAllFast: {
-              fieldData: false,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: false,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -97,23 +96,19 @@ describe('getStatusId', () => {
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: undefined,
-              labData: true,
-            },
-            source: 'labData',
+          labData: {
+            isAllFast: true,
           },
+          source: 'labData',
         },
         pageExperienceCached: {
-          labData: {},
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: false,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: true,
           },
+          labData: {
+            isAllFast: false,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -128,23 +123,22 @@ describe('getStatusId', () => {
       Promise.resolve(['one-more', ...fixedRecommendations]),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: true,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
         pageExperienceCached: {
-          fieldData: {},
-          summary: {
-            isAllFast: {
-              fieldData: false,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: false,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -159,23 +153,19 @@ describe('getStatusId', () => {
       Promise.resolve(['one-more', ...fixedRecommendations]),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: undefined,
-              labData: true,
-            },
-            source: 'labData',
+          labData: {
+            isAllFast: true,
           },
+          source: 'labData',
         },
         pageExperienceCached: {
-          labData: {},
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: false,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: true,
           },
+          labData: {
+            isAllFast: false,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -190,23 +180,22 @@ describe('getStatusId', () => {
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: false,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: false,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
         pageExperienceCached: {
-          fieldData: {},
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: false,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: true,
           },
+          labData: {
+            isAllFast: false,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -221,23 +210,19 @@ describe('getStatusId', () => {
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: undefined,
-              labData: false,
-            },
-            source: 'labData',
+          labData: {
+            isAllFast: false,
           },
+          source: 'labData',
         },
         pageExperienceCached: {
-          labData: {},
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: false,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -252,23 +237,22 @@ describe('getStatusId', () => {
       Promise.resolve(['one-more', ...fixedRecommendations]),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: false,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: false,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
         pageExperienceCached: {
-          fieldData: {},
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: false,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: true,
           },
+          labData: {
+            isAllFast: false,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -283,23 +267,19 @@ describe('getStatusId', () => {
       Promise.resolve(['one-more', ...fixedRecommendations]),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: undefined,
-              labData: false,
-            },
-            source: 'labData',
+          labData: {
+            isAllFast: false,
           },
+          source: 'labData',
         },
         pageExperienceCached: {
-          labData: {},
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: false,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -314,13 +294,13 @@ describe('getStatusId', () => {
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: false,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: false,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -335,13 +315,13 @@ describe('getStatusId', () => {
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: true,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
       }),
       Promise.resolve({}),
@@ -356,13 +336,13 @@ describe('getStatusId', () => {
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: true,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -377,13 +357,10 @@ describe('getStatusId', () => {
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: undefined,
-              labData: false,
-            },
-            source: 'labData',
+          labData: {
+            isAllFast: true,
           },
+          source: 'labData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -403,13 +380,13 @@ describe('getStatusId', () => {
       Promise.resolve(['one-more', ...fixedRecommendations]),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: false,
-              labData: true,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: false,
           },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -424,13 +401,13 @@ describe('getStatusId', () => {
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: false,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: true,
           },
+          labData: {
+            isAllFast: false,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,
@@ -445,13 +422,13 @@ describe('getStatusId', () => {
       Promise.resolve(['one-more', ...fixedRecommendations]),
       Promise.resolve({
         pageExperience: {
-          summary: {
-            isAllFast: {
-              fieldData: true,
-              labData: false,
-            },
-            source: 'fieldData',
+          fieldData: {
+            isAllFast: true,
           },
+          labData: {
+            isAllFast: false,
+          },
+          source: 'fieldData',
         },
       }),
       passedSafeBrowsingPromise,

--- a/pixi/src/checkAggregation/statusBanner.test.js
+++ b/pixi/src/checkAggregation/statusBanner.test.js
@@ -61,12 +61,29 @@ describe('getStatusId', () => {
     expect(statusId).toBe('invalid-amp');
   });
 
-  it('returns cache-failed-no-info', async () => {
+  it('returns cache-failed-no-info based on field data', async () => {
     const statusId = await getStatusId(
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
-        pageExperience: {isAllFast: true},
-        pageExperienceCached: {isAllFast: false},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
+        pageExperienceCached: {
+          fieldData: {},
+          summary: {
+            isAllFast: {
+              fieldData: false,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
       }),
       passedSafeBrowsingPromise,
       passedLinterPromise,
@@ -75,12 +92,60 @@ describe('getStatusId', () => {
     expect(statusId).toBe('cache-failed-no-info');
   });
 
-  it('returns cache-failed-with-info', async () => {
+  it('returns cache-failed-no-info based on lab data', async () => {
+    const statusId = await getStatusId(
+      Promise.resolve(fixedRecommendations),
+      Promise.resolve({
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: undefined,
+              labData: true,
+            },
+            source: 'labData',
+          },
+        },
+        pageExperienceCached: {
+          labData: {},
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: false,
+            },
+            source: 'fieldData',
+          },
+        },
+      }),
+      passedSafeBrowsingPromise,
+      passedLinterPromise,
+      passedMobileFriendlinessPromise
+    );
+    expect(statusId).toBe('cache-failed-no-info');
+  });
+
+  it('returns cache-failed-with-info based on field data', async () => {
     const statusId = await getStatusId(
       Promise.resolve(['one-more', ...fixedRecommendations]),
       Promise.resolve({
-        pageExperience: {isAllFast: true},
-        pageExperienceCached: {isAllFast: false},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
+        pageExperienceCached: {
+          fieldData: {},
+          summary: {
+            isAllFast: {
+              fieldData: false,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
       }),
       passedSafeBrowsingPromise,
       passedLinterPromise,
@@ -89,12 +154,60 @@ describe('getStatusId', () => {
     expect(statusId).toBe('cache-failed-with-info');
   });
 
-  it('returns origin-failed-no-info', async () => {
+  it('returns cache-failed-with-info based on lab data', async () => {
+    const statusId = await getStatusId(
+      Promise.resolve(['one-more', ...fixedRecommendations]),
+      Promise.resolve({
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: undefined,
+              labData: true,
+            },
+            source: 'labData',
+          },
+        },
+        pageExperienceCached: {
+          labData: {},
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: false,
+            },
+            source: 'fieldData',
+          },
+        },
+      }),
+      passedSafeBrowsingPromise,
+      passedLinterPromise,
+      passedMobileFriendlinessPromise
+    );
+    expect(statusId).toBe('cache-failed-with-info');
+  });
+
+  it('returns origin-failed-no-info for field data', async () => {
     const statusId = await getStatusId(
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
-        pageExperience: {isAllFast: false},
-        pageExperienceCached: {isAllFast: true},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: false,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
+        pageExperienceCached: {
+          fieldData: {},
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: false,
+            },
+            source: 'fieldData',
+          },
+        },
       }),
       passedSafeBrowsingPromise,
       passedLinterPromise,
@@ -103,12 +216,91 @@ describe('getStatusId', () => {
     expect(statusId).toBe('origin-failed-no-info');
   });
 
-  it('returns origin-failed-with-info', async () => {
+  it('returns origin-failed-no-info for lab data', async () => {
+    const statusId = await getStatusId(
+      Promise.resolve(fixedRecommendations),
+      Promise.resolve({
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: undefined,
+              labData: false,
+            },
+            source: 'labData',
+          },
+        },
+        pageExperienceCached: {
+          labData: {},
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
+      }),
+      passedSafeBrowsingPromise,
+      passedLinterPromise,
+      passedMobileFriendlinessPromise
+    );
+    expect(statusId).toBe('origin-failed-no-info');
+  });
+
+  it('returns origin-failed-with-info for field data', async () => {
     const statusId = await getStatusId(
       Promise.resolve(['one-more', ...fixedRecommendations]),
       Promise.resolve({
-        pageExperience: {isAllFast: false},
-        pageExperienceCached: {isAllFast: true},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: false,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
+        pageExperienceCached: {
+          fieldData: {},
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: false,
+            },
+            source: 'fieldData',
+          },
+        },
+      }),
+      passedSafeBrowsingPromise,
+      passedLinterPromise,
+      passedMobileFriendlinessPromise
+    );
+    expect(statusId).toBe('origin-failed-with-info');
+  });
+
+  it('returns origin-failed-with-info for lab data', async () => {
+    const statusId = await getStatusId(
+      Promise.resolve(['one-more', ...fixedRecommendations]),
+      Promise.resolve({
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: undefined,
+              labData: false,
+            },
+            source: 'labData',
+          },
+        },
+        pageExperienceCached: {
+          labData: {},
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
       }),
       passedSafeBrowsingPromise,
       passedLinterPromise,
@@ -121,7 +313,15 @@ describe('getStatusId', () => {
     const statusId = await getStatusId(
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
-        pageExperience: {isAllFast: false},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: false,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
       }),
       passedSafeBrowsingPromise,
       passedLinterPromise,
@@ -134,7 +334,15 @@ describe('getStatusId', () => {
     const statusId = await getStatusId(
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
-        pageExperience: {isAllFast: true},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
       }),
       Promise.resolve({}),
       passedLinterPromise,
@@ -147,7 +355,15 @@ describe('getStatusId', () => {
     const statusId = await getStatusId(
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
-        pageExperience: {isAllFast: true},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
       }),
       passedSafeBrowsingPromise,
       passedLinterPromise,
@@ -160,7 +376,15 @@ describe('getStatusId', () => {
     const statusId = await getStatusId(
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
-        pageExperience: {isAllFast: true},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: undefined,
+              labData: false,
+            },
+            source: 'labData',
+          },
+        },
       }),
       passedSafeBrowsingPromise,
       Promise.resolve({
@@ -178,7 +402,15 @@ describe('getStatusId', () => {
     const statusId = await getStatusId(
       Promise.resolve(['one-more', ...fixedRecommendations]),
       Promise.resolve({
-        pageExperience: {isAllFast: false},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: false,
+              labData: true,
+            },
+            source: 'fieldData',
+          },
+        },
       }),
       passedSafeBrowsingPromise,
       passedLinterPromise,
@@ -191,7 +423,15 @@ describe('getStatusId', () => {
     const statusId = await getStatusId(
       Promise.resolve(fixedRecommendations),
       Promise.resolve({
-        pageExperience: {isAllFast: true},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: false,
+            },
+            source: 'fieldData',
+          },
+        },
       }),
       passedSafeBrowsingPromise,
       passedLinterPromise,
@@ -204,7 +444,15 @@ describe('getStatusId', () => {
     const statusId = await getStatusId(
       Promise.resolve(['one-more', ...fixedRecommendations]),
       Promise.resolve({
-        pageExperience: {isAllFast: true},
+        pageExperience: {
+          summary: {
+            isAllFast: {
+              fieldData: true,
+              labData: false,
+            },
+            source: 'fieldData',
+          },
+        },
       }),
       passedSafeBrowsingPromise,
       passedLinterPromise,

--- a/pixi/src/checks/PageExperienceCheck.js
+++ b/pixi/src/checks/PageExperienceCheck.js
@@ -91,7 +91,7 @@ export default class PageExperienceCheck {
   isFastData(metrics, checkId) {
     if (!metrics) {
       // no error when we have no data
-      return true;
+      return undefined;
     }
     return metrics[checkId].data.category === Category.FAST;
   }
@@ -146,20 +146,25 @@ export default class PageExperienceCheck {
       },
     };
 
-    const isAllFast =
-      this.isFastData(fieldData, 'cls') &&
-      this.isFastData(fieldData, 'fid') &&
-      this.isFastData(fieldData, 'lcp') &&
-      this.isFastData(labData, 'cls') &&
-      this.isFastData(labData, 'tbt') &&
-      this.isFastData(labData, 'lcp');
-
+    const summary = {
+      isAllFast: {
+        fieldData:
+          this.isFastData(fieldData, 'cls') &&
+          this.isFastData(fieldData, 'fid') &&
+          this.isFastData(fieldData, 'lcp'),
+        labData:
+          this.isFastData(labData, 'cls') &&
+          this.isFastData(labData, 'tbt') &&
+          this.isFastData(labData, 'lcp'),
+      },
+      source: fieldData ? 'fieldData' : 'labData',
+    };
     return {
       data: {
         pageExperience: {
           fieldData,
           labData,
-          isAllFast,
+          summary,
         },
         textCompression:
           this.getAuditScore(auditsOrigin, 'uses-text-compression') === 1,

--- a/pixi/src/checks/PageExperienceCheck.js
+++ b/pixi/src/checks/PageExperienceCheck.js
@@ -146,25 +146,26 @@ export default class PageExperienceCheck {
       },
     };
 
-    const summary = {
-      isAllFast: {
-        fieldData:
-          this.isFastData(fieldData, 'cls') &&
-          this.isFastData(fieldData, 'fid') &&
-          this.isFastData(fieldData, 'lcp'),
-        labData:
-          this.isFastData(labData, 'cls') &&
-          this.isFastData(labData, 'tbt') &&
-          this.isFastData(labData, 'lcp'),
-      },
-      source: fieldData ? 'fieldData' : 'labData',
-    };
     return {
       data: {
         pageExperience: {
-          fieldData,
-          labData,
-          summary,
+          fieldData: fieldData
+            ? {
+                isAllFast:
+                  this.isFastData(fieldData, 'cls') &&
+                  this.isFastData(fieldData, 'fid') &&
+                  this.isFastData(fieldData, 'lcp'),
+                ...fieldData,
+              }
+            : undefined,
+          labData: {
+            isAllFast:
+              this.isFastData(labData, 'cls') &&
+              this.isFastData(labData, 'tbt') &&
+              this.isFastData(labData, 'lcp'),
+            ...labData,
+          },
+          source: fieldData ? 'fieldData' : 'labData',
         },
         textCompression:
           this.getAuditScore(auditsOrigin, 'uses-text-compression') === 1,


### PR DESCRIPTION
Prior to this PR, the `isAllFast` property equally considered field and lab data results. This PR modifies the status return to differentiate between the findings from field data and the findings from lab data, in order to more directly compare them across cached and origin versions of a page.

We want to surface results in the following way:
- Prioritize whether a given origin page has returned field data. If so, this should be used to resolve the final status without consideration for its lab data.
- Compare origin field data only to cache field data, and origin lab data only to cache lab data. 

Using the above principles, if an origin page returns field data and its cache page does not, the only statuses we might render passing or failing, no cache-to-origin comparison info in the final status.

Other edge cases:
- If an origin page has passing field data and failing lab data, it should still resolve to "Your page has good page experience." 
- If an origin page has no field data and its cache page does have field data, the status should fallback to comparing lab data from both to resolve the final outcome.