### PR TITLE
Pixi: Display invalid AMP status after other tests have run.

### DIFF
--- a/pixi/src/checkAggregation/statusBanner.js
+++ b/pixi/src/checkAggregation/statusBanner.js
@@ -29,9 +29,6 @@ const getStatusId = async (
     if (!linter.isAmp) {
       return 'no-amp';
     }
-    if (!linter.isValid) {
-      return 'invalid-amp';
-    }
 
     // We need to check all promises for general error
     // (promise can be rejected or error is set in result)
@@ -46,6 +43,10 @@ const getStatusId = async (
       safeBrowsingPromise,
       mobileFriendlinessPromise,
     ]);
+
+    if (!linter.isValid) {
+      return 'invalid-amp';
+    }
 
     if (
       linter.error ||

--- a/pixi/src/checkAggregation/statusBanner.test.js
+++ b/pixi/src/checkAggregation/statusBanner.test.js
@@ -48,15 +48,25 @@ describe('getStatusId', () => {
 
   it('returns invalid-amp', async () => {
     const statusId = await getStatusId(
-      pendingPromise,
-      pendingPromise,
-      pendingPromise,
+      Promise.resolve(fixedRecommendations),
+      Promise.resolve({
+        pageExperience: {
+          fieldData: {
+            isAllFast: true,
+          },
+          labData: {
+            isAllFast: true,
+          },
+          source: 'fieldData',
+        },
+      }),
+      passedSafeBrowsingPromise,
       Promise.resolve({
         isLoaded: true,
         isAmp: true,
         isValid: false,
       }),
-      pendingPromise
+      passedMobileFriendlinessPromise
     );
     expect(statusId).toBe('invalid-amp');
   });


### PR DESCRIPTION
It seems kind of confusing to show the invalid AMP status while tests are still running, as well as with recommendations still on the way. This way, even though we know a page is invalid, the user can still keep up with progress.