### PR TITLE
Implement isCacheUrl check and rule for status banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "not dead"
   ],
   "dependencies": {
+    "@ampproject/toolbox-cache-list": "2.6.0",
     "@ampproject/toolbox-cors": "2.6.0",
     "@ampproject/toolbox-linter": "2.7.0-alpha.3",
     "@ampproject/toolbox-optimizer": "2.6.0",

--- a/pages/content/pixi/status-banners/amp-cache-url.md
+++ b/pages/content/pixi/status-banners/amp-cache-url.md
@@ -1,6 +1,6 @@
 ---
 $title: This URL is the cached version of an AMP page.
 type: error
+hide_share: true
 ---
-
 Sorry, this tool is designed for AMP pages on origin, not their cached counterparts. Did you mean to analyze the origin URL for your AMP page instead?

--- a/pixi/backend/api.test.js
+++ b/pixi/backend/api.test.js
@@ -36,15 +36,16 @@ test('returns only the isAmp result with no linter data', (done) => {
       expect(res.body.redirected).toBe(false);
       expect(res.body.url).toBe('https://www.test');
       expect(res.body.isAmp).toBe(false);
+      expect(res.body.isCacheUrl).toBe(false);
       expect(res.body.components).toBeUndefined();
       expect(res.body.data).toBeUndefined();
       done();
     });
 });
 
-test('returns linter result and page info with no components', (done) => {
+test('returns linter result and page info with cache flag and no components', (done) => {
   mockResponse = {
-    url: 'https://www.test',
+    url: 'https://www-test.cdn.ampproject.org/c/s/www.test/',
     redirected: false,
     text: () => '<html amp><head></head><body></body></html>',
   };
@@ -55,14 +56,17 @@ test('returns linter result and page info with no components', (done) => {
   });
 
   request(app)
-    .get('/lint?url=https://www.test')
+    .get('/lint?url=https://www-test.cdn.ampproject.org/c/s/www.test/')
     .expect('Content-Type', /json/)
     .expect(200)
     .then((res) => {
       expect(res.body.status).toBe('ok');
       expect(res.body.redirected).toBe(false);
-      expect(res.body.url).toBe('https://www.test');
+      expect(res.body.url).toBe(
+        'https://www-test.cdn.ampproject.org/c/s/www.test/'
+      );
       expect(res.body.isAmp).toBe(true);
+      expect(res.body.isCacheUrl).toBe(true);
       expect(res.body.components).toEqual({});
       expect(res.body.data.isvalid.status).toBe('FAIL');
       done();
@@ -91,6 +95,7 @@ test('returns linter result and redirected page with 1 component info', (done) =
       expect(res.body.redirected).toBe(true);
       expect(res.body.url).toBe('http://www.test');
       expect(res.body.isAmp).toBe(true);
+      expect(res.body.isCacheUrl).toBe(false);
       expect(res.body.components).toEqual({'amp-script': '0.1'});
       expect(res.body.data.isvalid.status).toBe('PASS');
       done();

--- a/pixi/mocks/ampLinterCheck/apiResponse.js
+++ b/pixi/mocks/ampLinterCheck/apiResponse.js
@@ -3,6 +3,7 @@ const apiResponsePassAll = {
   redirected: true,
   url: 'https://amp.dev/',
   isAmp: true,
+  isCacheUrl: false,
   components: {
     'amp-install-serviceworker': '0.1',
     'amp-consent': '0.1',
@@ -47,8 +48,9 @@ const apiResponsePassAll = {
 const apiResponseFailAll = {
   status: 'ok',
   redirected: true,
-  url: 'http://example.com',
+  url: 'http://www-test.cdn.ampproject.org/c/s/www.test/',
   isAmp: true,
+  isCacheUrl: true,
   components: {
     'amp-experiment': '0.1',
     'amp-access': '0.1',
@@ -97,6 +99,7 @@ const apiResponseInfoBoilerplate = {
   redirected: true,
   url: 'http://example.com',
   isAmp: true,
+  isCacheUrl: false,
   components: {},
   data: {
     boilerplateisremoved: {
@@ -110,6 +113,7 @@ const apiResponseNoAmp = {
   redirected: true,
   url: 'http://example.com',
   isAmp: false,
+  isCacheUrl: false,
 };
 
 const apiResponseError = {

--- a/pixi/src/checkAggregation/statusBanner.js
+++ b/pixi/src/checkAggregation/statusBanner.js
@@ -29,6 +29,9 @@ const getStatusId = async (
     if (!linter.isAmp) {
       return 'no-amp';
     }
+    if (!linter.isNotCacheUrl) {
+      return 'amp-cache-url';
+    }
 
     // We need to check all promises for general error
     // (promise can be rejected or error is set in result)

--- a/pixi/src/checkAggregation/statusBanner.js
+++ b/pixi/src/checkAggregation/statusBanner.js
@@ -29,7 +29,7 @@ const getStatusId = async (
     if (!linter.isAmp) {
       return 'no-amp';
     }
-    if (!linter.isNotCacheUrl) {
+    if (!linter.isOriginUrl) {
       return 'amp-cache-url';
     }
 

--- a/pixi/src/checkAggregation/statusBanner.test.js
+++ b/pixi/src/checkAggregation/statusBanner.test.js
@@ -8,6 +8,7 @@ const passedLinterPromise = Promise.resolve({
   isAmp: true,
   isValid: true,
   usesHttps: true,
+  isNotCacheUrl: true,
 });
 
 const passedMobileFriendlinessPromise = Promise.resolve({
@@ -40,10 +41,26 @@ describe('getStatusId', () => {
       Promise.resolve({
         isLoaded: true,
         isAmp: false,
+        isNotCacheUrl: true,
       }),
       pendingPromise
     );
     expect(statusId).toBe('no-amp');
+  });
+
+  it('returns amp-cache-url', async () => {
+    const statusId = await getStatusId(
+      pendingPromise,
+      pendingPromise,
+      pendingPromise,
+      Promise.resolve({
+        isLoaded: true,
+        isAmp: true,
+        isNotCacheUrl: false,
+      }),
+      pendingPromise
+    );
+    expect(statusId).toBe('amp-cache-url');
   });
 
   it('returns invalid-amp', async () => {
@@ -64,6 +81,7 @@ describe('getStatusId', () => {
       Promise.resolve({
         isLoaded: true,
         isAmp: true,
+        isNotCacheUrl: true,
         isValid: false,
       }),
       passedMobileFriendlinessPromise
@@ -377,6 +395,7 @@ describe('getStatusId', () => {
       Promise.resolve({
         isLoaded: true,
         isAmp: true,
+        isNotCacheUrl: true,
         isValid: true,
         usesHttps: false,
       }),

--- a/pixi/src/checkAggregation/statusBanner.test.js
+++ b/pixi/src/checkAggregation/statusBanner.test.js
@@ -8,7 +8,7 @@ const passedLinterPromise = Promise.resolve({
   isAmp: true,
   isValid: true,
   usesHttps: true,
-  isNotCacheUrl: true,
+  isOriginUrl: true,
 });
 
 const passedMobileFriendlinessPromise = Promise.resolve({
@@ -41,7 +41,7 @@ describe('getStatusId', () => {
       Promise.resolve({
         isLoaded: true,
         isAmp: false,
-        isNotCacheUrl: true,
+        isOriginUrl: true,
       }),
       pendingPromise
     );
@@ -56,7 +56,7 @@ describe('getStatusId', () => {
       Promise.resolve({
         isLoaded: true,
         isAmp: true,
-        isNotCacheUrl: false,
+        isOriginUrl: false,
       }),
       pendingPromise
     );
@@ -81,7 +81,7 @@ describe('getStatusId', () => {
       Promise.resolve({
         isLoaded: true,
         isAmp: true,
-        isNotCacheUrl: true,
+        isOriginUrl: true,
         isValid: false,
       }),
       passedMobileFriendlinessPromise
@@ -395,7 +395,7 @@ describe('getStatusId', () => {
       Promise.resolve({
         isLoaded: true,
         isAmp: true,
-        isNotCacheUrl: true,
+        isOriginUrl: true,
         isValid: true,
         usesHttps: false,
       }),

--- a/pixi/src/checks/AmpLinterCheck.js
+++ b/pixi/src/checks/AmpLinterCheck.js
@@ -88,7 +88,7 @@ export default class AmpLinterCheck {
       data: {
         isLoaded: true,
         isAmp: apiResult.isAmp,
-        isNotCacheUrl: !apiResult.isCacheUrl,
+        isOriginUrl: !apiResult.isCacheUrl,
         usesHttps:
           apiResult.url != undefined && apiResult.url.startsWith('https:'),
         noRenderBlockingExtension: !(

--- a/pixi/src/checks/AmpLinterCheck.js
+++ b/pixi/src/checks/AmpLinterCheck.js
@@ -88,6 +88,7 @@ export default class AmpLinterCheck {
       data: {
         isLoaded: true,
         isAmp: apiResult.isAmp,
+        isNotCacheUrl: !apiResult.isCacheUrl,
         usesHttps:
           apiResult.url != undefined && apiResult.url.startsWith('https:'),
         noRenderBlockingExtension: !(

--- a/pixi/src/checks/AmpLinterCheck.test.js
+++ b/pixi/src/checks/AmpLinterCheck.test.js
@@ -29,6 +29,7 @@ describe('Linter check', () => {
     const report = await linterCheck.run('http://example.com');
     expect(report.data.isLoaded).toBe(true);
     expect(report.data.isAmp).toBe(true);
+    expect(report.data.isNotCacheUrl).toBe(true);
     expect(report.data.usesHttps).toBe(true);
     expect(report.data.isValid).toBe(true);
     expect(report.data.runtimeIsPreloaded).toBe(true);
@@ -48,9 +49,12 @@ describe('Linter check', () => {
   it('returns object with all checks failed', async () => {
     fetchMock.mock(`begin:${apiEndpoint}`, apiResponseFailAll);
 
-    const report = await linterCheck.run('http://example.com');
+    const report = await linterCheck.run(
+      'http://www-test.cdn.ampproject.org/c/s/www.test/'
+    );
     expect(report.data.isLoaded).toBe(true);
     expect(report.data.isAmp).toBe(true);
+    expect(report.data.isNotCacheUrl).toBe(false);
     expect(report.data.usesHttps).toBe(false);
     expect(report.data.isValid).toBe(false);
     expect(report.data.runtimeIsPreloaded).toBe(false);

--- a/pixi/src/checks/AmpLinterCheck.test.js
+++ b/pixi/src/checks/AmpLinterCheck.test.js
@@ -29,7 +29,7 @@ describe('Linter check', () => {
     const report = await linterCheck.run('http://example.com');
     expect(report.data.isLoaded).toBe(true);
     expect(report.data.isAmp).toBe(true);
-    expect(report.data.isNotCacheUrl).toBe(true);
+    expect(report.data.isOriginUrl).toBe(true);
     expect(report.data.usesHttps).toBe(true);
     expect(report.data.isValid).toBe(true);
     expect(report.data.runtimeIsPreloaded).toBe(true);
@@ -54,7 +54,7 @@ describe('Linter check', () => {
     );
     expect(report.data.isLoaded).toBe(true);
     expect(report.data.isAmp).toBe(true);
-    expect(report.data.isNotCacheUrl).toBe(false);
+    expect(report.data.isOriginUrl).toBe(false);
     expect(report.data.usesHttps).toBe(false);
     expect(report.data.isValid).toBe(false);
     expect(report.data.runtimeIsPreloaded).toBe(false);

--- a/pixi/src/ui/InputBar.js
+++ b/pixi/src/ui/InputBar.js
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 /* eslint-disable max-len */
-const URL_VALIDATION_REGEX = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/gm;
-const AMP_PROJECT_CDN_URL = 'cdn.ampproject.org';
+const URL_VALIDATION_REGEX = /^(?:https?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w._~:/?#\[\]@!$&'()*+,;=-]+$/gm;
 
 export default class InputBar {
   constructor(doc, callback) {
@@ -53,10 +52,6 @@ export default class InputBar {
       value.startsWith('http://') || value.startsWith('https://')
         ? value
         : `http://${value}`;
-
-    if (pageUrl.includes(AMP_PROJECT_CDN_URL)) {
-      return;
-    }
 
     if (!this.isValidUrl(pageUrl)) {
       return;

--- a/pixi/src/ui/PageExperience.js
+++ b/pixi/src/ui/PageExperience.js
@@ -155,7 +155,7 @@ export default class PageExperience {
 
     const linter = await linterDataPromise;
     let cacheReport = null;
-    if (!linter.isAmp || !linter.isValid || !linter.isNotCacheUrl) {
+    if (!linter.isAmp || !linter.isValid || !linter.isOriginUrl) {
       cacheReport = Promise.resolve({data: {}});
     } else {
       cacheReport = await this.pageExperienceCacheCheck.run(
@@ -208,7 +208,7 @@ export default class PageExperience {
       console.error('Could not perform AMP Linter check', error);
       return {error};
     }
-    if (data.isAmp && data.isNotCacheUrl) {
+    if (data.isAmp && data.isOriginUrl) {
       this.reports.classList.remove('pristine');
       this.reportViews.httpsCheck.render(data.usesHttps);
     }

--- a/pixi/src/ui/PageExperience.js
+++ b/pixi/src/ui/PageExperience.js
@@ -155,7 +155,7 @@ export default class PageExperience {
 
     const linter = await linterDataPromise;
     let cacheReport = null;
-    if (!linter.isAmp || !linter.isValid) {
+    if (!linter.isAmp || !linter.isValid || !linter.isNotCacheUrl) {
       cacheReport = Promise.resolve({data: {}});
     } else {
       cacheReport = await this.pageExperienceCacheCheck.run(
@@ -208,7 +208,7 @@ export default class PageExperience {
       console.error('Could not perform AMP Linter check', error);
       return {error};
     }
-    if (data.isAmp) {
+    if (data.isAmp && data.isNotCacheUrl) {
       this.reports.classList.remove('pristine');
       this.reportViews.httpsCheck.render(data.usesHttps);
     }


### PR DESCRIPTION
The check is implemented in the linter backend api as isCacheUrl.
The frontend linter check component translates this into isNotCacheURL to have all successful checks "true".
The difference is mostly due to the fact that we use the prod api on stage and with this setup pixi will not show the "cache url" status when the new flag is not in the linter api response.

So having said that, **please remember the linter will only show the "amp-cache-url" status in production mode (local or on stage) when this is deployed on prod.**

Fixes #4438 