### PR TITLE
Fix CSS error

### DIFF
--- a/examples/source/1.components/amp-script/index.html
+++ b/examples/source/1.components/amp-script/index.html
@@ -83,7 +83,8 @@ author:
 
       #carousel-button {
         top: -100px;
-        
+      }
+
       #live-blog-start {
         margin-top: 0;
       }


### PR DESCRIPTION
Fixes CSS error in amp-script samples.

This actually doesn't affect the main samples page. But if you pull an individual sample into the playground, the error isn't corrected.