### PR TITLE
Pixi: Increase contrast in CSS

### DIFF
--- a/frontend/scss/_variables.scss
+++ b/frontend/scss/_variables.scss
@@ -47,6 +47,7 @@ $colors: (
   'mine-shaft':      #3E3E3E,
   'river-bed':       #48525C,
   'limed-spruce':    #333D47,
+  'boulder':         #767676,
   'oslo-gray':       #91979D,
   'gray-chateau':    #A3A8AD,
   'silver':          #CCCCCC,

--- a/frontend/scss/_variables.scss
+++ b/frontend/scss/_variables.scss
@@ -67,6 +67,7 @@ $colors: (
   'robins-egg':      #00DCC0,
   'emerald':         #38CA71,
   'malachite':       #00CD3C,
+  'green-haze':      #00AD20,
   'forest-green':    #2DB932,
   'fruit-salad':     #4D9F66,
   'shamrock':        #2ECC71,

--- a/frontend/scss/_variables.scss
+++ b/frontend/scss/_variables.scss
@@ -80,6 +80,7 @@ $colors: (
   'school-bus':      #FFDC00,
   'manz':            #F1F068,
   'pizazz':          #FF8F00,
+  'christine':       #E26E08,
   'zest':            #E67E22,
   'buttercup':       #F39C12,
   'carnation':       #F56C64,

--- a/frontend/scss/components/atoms/pill.scss
+++ b/frontend/scss/components/atoms/pill.scss
@@ -16,7 +16,7 @@
   @include txt-2;
   @include txt-strong;
   @include filter-bubble-shadow-regular;
-  color: color('oslo-gray');
+  color: color('boulder');
   font-family: 'Noto Sans', sans-serif;
   transition: background-color .2s ease-in, color .2s ease-in, box-shadow .25s ease-in;
   cursor: pointer;

--- a/frontend/scss/components/atoms/pixi-scale.scss
+++ b/frontend/scss/components/atoms/pixi-scale.scss
@@ -70,11 +70,11 @@
         }
       }
 
-      &[data-type="fast"] {
-        background: color('malachite');
+      &[data-type='fast'] {
+        background: color('green-haze');
 
         span {
-          border-color: color('malachite');
+          border-color: color('green-haze');
         }
       }
 
@@ -134,7 +134,7 @@
       font-size: 14px;
       white-space: nowrap;
       font-weight: bold;
-      color: color('malachite');
+      color: color('green-haze');
       transform: translateX(7px);
 
       &:after {

--- a/frontend/scss/components/atoms/pixi-scale.scss
+++ b/frontend/scss/components/atoms/pixi-scale.scss
@@ -79,10 +79,10 @@
       }
 
       &[data-type="average"] {
-        background: color('buttercup');
+        background: color('christine');
 
         span {
-          border-color: color('buttercup');
+          border-color: color('christine');
         }
       }
 
@@ -148,7 +148,7 @@
       }
 
       &.average {
-        color: color('buttercup');
+        color: color('christine');
       }
 
       &.slow {

--- a/frontend/scss/components/molecules/input-bar.scss
+++ b/frontend/scss/components/molecules/input-bar.scss
@@ -116,11 +116,11 @@
     }
 
     &[disabled] {
-      background: #767676;
+      background: color('boulder');
     }
 
     &.loading {
-      background: #767676;
+      background: color('boulder');
 
       #{$inputBar}-submit-title {
         font-size: 0;

--- a/frontend/scss/components/molecules/input-bar.scss
+++ b/frontend/scss/components/molecules/input-bar.scss
@@ -57,7 +57,7 @@
       height: 2px;
       background: color('red');
       opacity: 0;
-      transition: opacity .3s ease-in-out;
+      transition: opacity 0.3s ease-in-out;
 
       @media (min-width: 1024px) {
         left: 25px;
@@ -116,11 +116,11 @@
     }
 
     &[disabled] {
-      background: color('mercury');
+      background: #767676;
     }
 
     &.loading {
-      background: color('mercury');
+      background: #767676;
 
       #{$inputBar}-submit-title {
         font-size: 0;
@@ -143,7 +143,7 @@
     padding-left: 25px;
     color: color('red');
     opacity: 0;
-    transition: transform .3s ease, opacity .2s ease;
+    transition: transform 0.3s ease, opacity 0.2s ease;
   }
 
   &.error {

--- a/frontend/scss/components/molecules/pixi-basic-metric.scss
+++ b/frontend/scss/components/molecules/pixi-basic-metric.scss
@@ -10,7 +10,7 @@
   padding: 15px 20px;
   font-size: 16px;
   background: color('white');
-  border-bottom: solid 2px color('boulder');
+  border-bottom: solid 1px color('boulder');
 
   &:last-child {
     border-bottom: 0;

--- a/frontend/scss/components/molecules/pixi-basic-metric.scss
+++ b/frontend/scss/components/molecules/pixi-basic-metric.scss
@@ -40,7 +40,7 @@
 
   &.passed {
     label {
-      color: color('malachite');
+      color: color('green-haze');
     }
   }
 

--- a/frontend/scss/components/molecules/pixi-basic-metric.scss
+++ b/frontend/scss/components/molecules/pixi-basic-metric.scss
@@ -10,7 +10,7 @@
   padding: 15px 20px;
   font-size: 16px;
   background: color('white');
-  border-bottom: solid 2px color('mercury');
+  border-bottom: solid 2px color('boulder');
 
   &:last-child {
     border-bottom: 0;
@@ -29,14 +29,13 @@
     padding: 25px 20px 25px 35px;
   }
 
-
   &-title {
     margin: 0;
     font-size: 18px;
   }
 
   &-status {
-    color: color('silver');
+    color: color('boulder');
   }
 
   &.passed {

--- a/frontend/scss/components/molecules/pixi-primary-metric.scss
+++ b/frontend/scss/components/molecules/pixi-primary-metric.scss
@@ -17,7 +17,7 @@
   }
 
   & + & {
-    border-top: solid 2px color('mercury');
+    border-top: solid 1px color('boulder');
   }
 
   &:nth-child(2) {
@@ -62,7 +62,7 @@
 
       &-status {
         display: block;
-        color: color('silver');
+        color: color('boulder');
 
         .fast & {
           color: color('malachite');

--- a/frontend/scss/components/molecules/pixi-primary-metric.scss
+++ b/frontend/scss/components/molecules/pixi-primary-metric.scss
@@ -65,7 +65,7 @@
         color: color('boulder');
 
         .fast & {
-          color: color('malachite');
+          color: color('green-haze');
         }
 
         .average & {
@@ -130,7 +130,7 @@
       #{$primary-metric}-score {
         .fast & {
           font-weight: bold;
-          color: color('malachite');
+          color: color('green-haze');
         }
 
         .average & {

--- a/frontend/scss/components/molecules/pixi-primary-metric.scss
+++ b/frontend/scss/components/molecules/pixi-primary-metric.scss
@@ -69,7 +69,7 @@
         }
 
         .average & {
-          color: color('buttercup');
+          color: color('christine');
         }
 
         .slow & {
@@ -135,7 +135,7 @@
 
         .average & {
           font-weight: bold;
-          color: color('buttercup');
+          color: color('christine');
         }
 
         .slow & {

--- a/frontend/scss/components/molecules/pixi-recommendations-item.scss
+++ b/frontend/scss/components/molecules/pixi-recommendations-item.scss
@@ -7,7 +7,7 @@
   $root: &;
   margin-top: 30px;
   padding: 30px 18px;
-  border: solid 2px color('mercury');
+  border: solid 1px color('boulder');
   border-radius: 8px;
   transition: transform .25s ease-in, background .25s ease-in, box-shadow .3s ease-in, border-color .3s ease-in;
 
@@ -58,17 +58,17 @@
 
   &-tags {
     padding-top: 15px;
-    border-top: solid 2px color('mercury');
+    border-top: solid 1px color('boulder');
 
     span {
       height: 30px;
       margin: 15px 8px 15px 0;
       padding: 3px 10px;
-      border: 1px solid color('silver');
+      border: 1px solid color('boulder');
       border-radius: 15px;
       font-size: 12px;
       font-weight: bold;
-      color: color('silver');
+      color: color('boulder');
 
       &:first-child {
         display: none;

--- a/frontend/scss/components/molecules/pixi-share-dialog.scss
+++ b/frontend/scss/components/molecules/pixi-share-dialog.scss
@@ -47,10 +47,10 @@
       width: 100%;
       margin: 10px 0 20px;
       padding: 10px 15px;
-      border: 1px solid color('silver');
+      border: 1px solid color('boulder');
       border-radius: 4px;
       font-family: Noto Sans;
-      color: color('gray-chateau');
+      color: color('boulder');
     }
 
     &-copy-button {

--- a/frontend/scss/components/molecules/pixi-status-intro.scss
+++ b/frontend/scss/components/molecules/pixi-status-intro.scss
@@ -125,7 +125,7 @@
   &.loading {
     h3,
     p {
-      color: color('silver');
+      color: color('boulder');
     }
   }
 

--- a/frontend/scss/components/molecules/pixi-tooltip.scss
+++ b/frontend/scss/components/molecules/pixi-tooltip.scss
@@ -19,8 +19,8 @@
     svg {
       width: 100%;
       height: 100%;
-      opacity: .3;
-      transition: opacity .2s ease-in-out;
+      opacity: 0.3;
+      transition: opacity 0.2s ease-in-out;
     }
 
     #{$tooltip}.active &,
@@ -63,7 +63,7 @@
 
     pointer-events: none;
     opacity: 0;
-    filter: drop-shadow(0 0 20px transparentize(color('black'), 0.80));
+    filter: drop-shadow(0 0 20px transparentize(color('black'), 0.8));
 
     @media (min-width: 575px) {
       position: absolute;
@@ -100,7 +100,7 @@
     h2 {
       margin-bottom: 30px;
       padding-bottom: 30px;
-      border-bottom: 1px solid color('mercury');
+      border-bottom: 1px solid color('boulder');
 
       @media (min-width: 575px) {
         display: none;


### PR DESCRIPTION
Fixes #4487, fixes #4509, fixes #4488, fixes #4506, addresses #4501 (but need verification of fix)

Prior contrast (See input bar and button as example):
![image](https://user-images.githubusercontent.com/10456171/93101042-cf703580-f677-11ea-9e68-bebf890d51ec.png)

Increased contrast:
![image](https://user-images.githubusercontent.com/10456171/93101060-d434e980-f677-11ea-91fc-ac96a124f2d5.png)

Increased contrast performance-based colors (orange and green):
![image](https://user-images.githubusercontent.com/10456171/93130152-212cb600-f6a0-11ea-994e-3616d2931141.png)
