### PR TITLE
Pixi URL validation allows URLs with %

### DIFF
--- a/pixi/src/ui/InputBar.js
+++ b/pixi/src/ui/InputBar.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /* eslint-disable max-len */
-const URL_VALIDATION_REGEX = /^(?:https?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w._~:/?#\[\]@!$&'()*+,;=-]+$/gm;
+const URL_VALIDATION_REGEX = /^(?:https?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w._~:/?#\[\]@!$%&'()*+,;=-]+$/gm;
 
 export default class InputBar {
   constructor(doc, callback) {


### PR DESCRIPTION
This is related to https://github.com/ampproject/amp.dev/issues/4477 and the URLs Patrick send should validate now.
But maybe we want to keep the ticket open until we have a final decision if we can use the URL class or not.