### PR TITLE
Pixi: Display messages for 0 recommendations

### DIFF
--- a/frontend/scss/components/molecules/pixi-primary-metric.scss
+++ b/frontend/scss/components/molecules/pixi-primary-metric.scss
@@ -99,11 +99,10 @@
         margin-right: 20px;
       }
 
-      span,
+      a,
       svg {
         white-space: nowrap;
-        opacity: 0.3;
-        transition: opacity .3s ease;
+        transition: opacity 0.3s ease;
 
         .fast &,
         .average &,

--- a/frontend/templates/views/partials/pixi/primary-metric.j2
+++ b/frontend/templates/views/partials/pixi/primary-metric.j2
@@ -37,12 +37,12 @@
         {% include 'views/partials/pixi/analyzing-dots.j2' %}
       </div>
 
-      <div on="tap:recommendations.scrollTo(duration=400),
-              recommendations.toggleClass(class={{ primary_metric.title.id|slug }})"
-            aria-label="{{ _('Filter by') + primary_metric.title.id|slug }}"
-            role="button">
+      <div>
         <strong>{{ _('Take action') }}:</strong>
-        <span class="ap-m-pixi-primary-metric-recommendations">{{ _('Analyzing') }}</span>
+        <span class="ap-m-pixi-primary-metric-recommendations"
+         on="tap:recommendations.scrollTo(duration=400)"
+            aria-label="{{ _('Filter by') + primary_metric.title.id|slug }}"
+            role="button">{{ _('Analyzing') }}</span>
         {% include 'views/partials/pixi/analyzing-dots.j2' %}
         {% do doc.icons.useIcon('icons/arrow-down.svg') %}
         <svg>

--- a/frontend/templates/views/partials/pixi/primary-metric.j2
+++ b/frontend/templates/views/partials/pixi/primary-metric.j2
@@ -39,10 +39,7 @@
 
       <div>
         <strong>{{ _('Take action') }}:</strong>
-        <span class="ap-m-pixi-primary-metric-recommendations"
-         on="tap:recommendations.scrollTo(duration=400)"
-            aria-label="{{ _('Filter by ') + primary_metric.title.id|slug }}"
-        >{{ _('Analyzing') }}</span>
+        <a href="#recommendations" class="ap-m-pixi-primary-metric-recommendations">{{ _('Analyzing') }}</a>
         {% include 'views/partials/pixi/analyzing-dots.j2' %}
         {% do doc.icons.useIcon('icons/arrow-down.svg') %}
         <svg>

--- a/frontend/templates/views/partials/pixi/primary-metric.j2
+++ b/frontend/templates/views/partials/pixi/primary-metric.j2
@@ -41,8 +41,8 @@
         <strong>{{ _('Take action') }}:</strong>
         <span class="ap-m-pixi-primary-metric-recommendations"
          on="tap:recommendations.scrollTo(duration=400)"
-            aria-label="{{ _('Filter by') + primary_metric.title.id|slug }}"
-            role="button">{{ _('Analyzing') }}</span>
+            aria-label="{{ _('Filter by ') + primary_metric.title.id|slug }}"
+        >{{ _('Analyzing') }}</span>
         {% include 'views/partials/pixi/analyzing-dots.j2' %}
         {% do doc.icons.useIcon('icons/arrow-down.svg') %}
         <svg>

--- a/pages/content/pixi/index.md
+++ b/pages/content/pixi/index.md
@@ -21,6 +21,8 @@ staticText:
     failed: Failed
     passed: Passed
     none: None
+    nothingToDo: Nothing to do
+    fileAnIssue: File an issue with AMP
     recommendation: recommendation
     recommendations: recommendations
   tags:

--- a/pixi/src/ui/recommendations/RecommendationsView.js
+++ b/pixi/src/ui/recommendations/RecommendationsView.js
@@ -108,20 +108,9 @@ export default class RecommendationsView {
 
     for (const key of Object.keys(metricUis)) {
       const metricUi = metricUis[key];
-      const count = tagIdCounts[metricUi.metric];
-      if (!count) {
-        metricUi.setRecommendationStatus(false, i18n.getText('status.none'));
-      } else if (count === 1) {
-        metricUi.setRecommendationStatus(
-          true,
-          `${count} ${i18n.getText('status.recommendation')}`
-        );
-      } else {
-        metricUi.setRecommendationStatus(
-          true,
-          `${count} ${i18n.getText('status.recommendations')}`
-        );
-      }
+      const metricToUse = metricUi.metric === 'tbt' ? 'fid' : metricUi.metric;
+      const count = tagIdCounts[metricToUse];
+      metricUi.setRecommendationStatus(count);
     }
 
     this.pill.classList.add('filtered');

--- a/pixi/src/ui/report/CoreWebVitalsReportView.js
+++ b/pixi/src/ui/report/CoreWebVitalsReportView.js
@@ -19,6 +19,8 @@ const CATEGORIES = {
   average: 'Needs Improvement',
   slow: 'Poor',
 };
+const FILE_ISSUE_URL =
+  'https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type%3A+Page+experience&template=page-experience.md&title=Page+experience+issue';
 
 class WeightedScale {
   constructor(container) {
@@ -104,6 +106,12 @@ class CoreWebVitalView {
     this.recommendations = this.container.querySelector(
       '.ap-m-pixi-primary-metric-recommendations'
     );
+    this.defaultAttrs = {
+      on: this.recommendations.getAttribute('on'),
+      text: this.recommendations.getAttribute('aria-label'),
+    };
+    this.recommendations.removeAttribute('on');
+    this.recommendations.removeAttribute('aria-label');
   }
 
   render(metric, cacheMetric) {
@@ -147,10 +155,22 @@ class CoreWebVitalView {
     if (!count) {
       if (this.performanceCategory === CATEGORIES.fast) {
         this.recommendations.textContent = i18n.getText('status.nothingToDo');
-      } else {
-        this.recommendations.textContent = i18n.getText('status.fileAnIssue');
+        return;
       }
-    } else if (count === 1) {
+      const fileIssueText = i18n.getText('status.fileAnIssue');
+      this.recommendations.setAttribute('aria-label', fileIssueText);
+      this.recommendations.setAttribute(
+        'on',
+        `tap:AMP.navigateTo(url="${FILE_ISSUE_URL}", target="_blank")`
+      );
+      this.recommendations.setAttribute('role', 'button');
+      this.recommendations.textContent = fileIssueText;
+      return;
+    }
+    this.recommendations.setAttribute('aria-label', this.defaultAttrs.text);
+    this.recommendations.setAttribute('on', this.defaultAttrs.on);
+    this.recommendations.setAttribute('role', 'button');
+    if (count === 1) {
       this.recommendations.textContent = `${count} ${i18n.getText(
         'status.recommendation'
       )}`;
@@ -168,6 +188,9 @@ class CoreWebVitalView {
     this.score.textContent = i18n.getText('status.analyzing');
     this.improvement.textContent = i18n.getText('status.calculating');
     this.recommendations.textContent = i18n.getText('status.analyzing');
+    this.recommendations.removeAttribute('on');
+    this.recommendations.removeAttribute('aria-label');
+    this.recommendations.removeAttribute('role');
 
     this.toggleLoading(true);
   }

--- a/pixi/src/ui/report/CoreWebVitalsReportView.js
+++ b/pixi/src/ui/report/CoreWebVitalsReportView.js
@@ -106,12 +106,8 @@ class CoreWebVitalView {
     this.recommendations = this.container.querySelector(
       '.ap-m-pixi-primary-metric-recommendations'
     );
-    this.defaultAttrs = {
-      on: this.recommendations.getAttribute('on'),
-      text: this.recommendations.getAttribute('aria-label'),
-    };
-    this.recommendations.removeAttribute('on');
-    this.recommendations.removeAttribute('aria-label');
+    this.defaultHref = this.recommendations.getAttribute('href');
+    this.recommendations.removeAttribute('href');
   }
 
   render(metric, cacheMetric) {
@@ -157,19 +153,12 @@ class CoreWebVitalView {
         this.recommendations.textContent = i18n.getText('status.nothingToDo');
         return;
       }
-      const fileIssueText = i18n.getText('status.fileAnIssue');
-      this.recommendations.setAttribute('aria-label', fileIssueText);
-      this.recommendations.setAttribute(
-        'on',
-        `tap:AMP.navigateTo(url="${FILE_ISSUE_URL}", target="_blank")`
-      );
-      this.recommendations.setAttribute('role', 'button');
-      this.recommendations.textContent = fileIssueText;
+      this.recommendations.setAttribute('href', FILE_ISSUE_URL);
+      this.recommendations.setAttribute('target', '_blank');
+      this.recommendations.textContent = i18n.getText('status.fileAnIssue');
       return;
     }
-    this.recommendations.setAttribute('aria-label', this.defaultAttrs.text);
-    this.recommendations.setAttribute('on', this.defaultAttrs.on);
-    this.recommendations.setAttribute('role', 'button');
+    this.recommendations.setAttribute('href', this.defaultHref);
     if (count === 1) {
       this.recommendations.textContent = `${count} ${i18n.getText(
         'status.recommendation'
@@ -188,9 +177,8 @@ class CoreWebVitalView {
     this.score.textContent = i18n.getText('status.analyzing');
     this.improvement.textContent = i18n.getText('status.calculating');
     this.recommendations.textContent = i18n.getText('status.analyzing');
-    this.recommendations.removeAttribute('on');
-    this.recommendations.removeAttribute('aria-label');
-    this.recommendations.removeAttribute('role');
+    this.recommendations.removeAttribute('href');
+    this.recommendations.removeAttribute('target');
 
     this.toggleLoading(true);
   }

--- a/pixi/src/ui/report/CoreWebVitalsReportView.js
+++ b/pixi/src/ui/report/CoreWebVitalsReportView.js
@@ -91,6 +91,7 @@ class CoreWebVitalView {
       this.scale = new WeightedScale(container);
     }
 
+    this.performanceCategory = null;
     this.category = this.container.querySelector(
       '.ap-m-pixi-primary-metric-category'
     );
@@ -111,9 +112,9 @@ class CoreWebVitalView {
     this.scale.render(data, unit);
 
     const responseCategory = data.category.toLowerCase();
-    const displayCategory = CATEGORIES[responseCategory];
+    this.performanceCategory = CATEGORIES[responseCategory];
     this.container.classList.add(responseCategory);
-    this.category.textContent = displayCategory;
+    this.category.textContent = this.performanceCategory;
 
     const score = (data.numericValue / unit.conversion).toFixed(unit.digits);
     this.score.textContent = `${score} ${unit.name}`;
@@ -141,9 +142,23 @@ class CoreWebVitalView {
     this.container.parentNode.classList.add('error');
   }
 
-  setRecommendationStatus(hasStatus, text) {
-    this.recommendations.textContent = text;
-    this.container.classList.toggle('has-status', hasStatus);
+  setRecommendationStatus(count) {
+    this.container.classList.toggle('has-status', !!count);
+    if (!count) {
+      if (this.performanceCategory === CATEGORIES.fast) {
+        this.recommendations.textContent = i18n.getText('status.nothingToDo');
+      } else {
+        this.recommendations.textContent = i18n.getText('status.fileAnIssue');
+      }
+    } else if (count === 1) {
+      this.recommendations.textContent = `${count} ${i18n.getText(
+        'status.recommendation'
+      )}`;
+    } else {
+      this.recommendations.textContent = `${count} ${i18n.getText(
+        'status.recommendations'
+      )}`;
+    }
   }
 
   reset() {


### PR DESCRIPTION
The "Take action" text updates with the following when there are 0 recommendations surfaced for a given category:
- Good status => "Nothing to do"
- Else => "File an issue with AMP" + link to GH issue template

This PR also:
- Removes AMP action `scrollTo` in favor of header hyperlink. This fixes #4505