### PR TITLE
⚡️ Stop preloading fonts in favor of font-display: swap

### DIFF
--- a/frontend/templates/layouts/default.j2
+++ b/frontend/templates/layouts/default.j2
@@ -72,11 +72,6 @@
 
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/>
 
-    <link rel="preload" href="/static/fonts/noto-sans-v7-latin-regular.woff2" as="font" crossorigin>
-    <link rel="preload" href="/static/fonts/noto-sans-v7-latin-700.woff2" as="font" crossorigin>
-    <link rel="preload" href="/static/fonts/poppins-v5-latin-700.woff2" as="font" crossorigin>
-    <link rel="preload" href="/static/fonts/fira-mono-v7-latin-500.woff2" as="font" crossorigin>
-
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>
     <noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     {% endblock %}

--- a/playground/src/index.hbs
+++ b/playground/src/index.hbs
@@ -42,13 +42,6 @@
     <!-- Color the status bar on mobile devices -->
     <meta name="theme-color" content="#ffffff">
 
-    {{^htmlWebpackPlugin.options.embed}}
-    <link rel="preload" href="https://amp.dev/static/fonts/noto-sans-v7-latin-regular.woff2" as="font" crossorigin>
-    <link rel="preload" href="https://amp.dev/static/fonts/noto-sans-v7-latin-700.woff2" as="font" crossorigin>
-    <link rel="preload" href="https://amp.dev/static/fonts/poppins-v5-latin-700.woff2" as="font" crossorigin>
-    <link rel="preload" href="https://amp.dev/static/fonts/fira-mono-v7-latin-500.woff2" as="font" crossorigin>
-    {{/htmlWebpackPlugin.options.embed}}
-
     <script async src="https://www.googletagmanager.com/gtag/js?id={{htmlWebpackPlugin.options.gaTrackingId}}"></script>
   </head>
   <body class="{{#htmlWebpackPlugin.options.embed}}embed{{/htmlWebpackPlugin.options.embed}}{{#htmlWebpackPlugin.options.validator}}validator{{/htmlWebpackPlugin.options.validator}}">


### PR DESCRIPTION
`font-display: swap;` is already set, this simply removes the preload statements.