### PR TITLE
Feature/pixi extract dynamic texts

### DIFF
--- a/frontend/templates/views/partials/pixi/basic-metric.j2
+++ b/frontend/templates/views/partials/pixi/basic-metric.j2
@@ -6,7 +6,7 @@
     <br>
     <label class="ap-m-pixi-basic-metric-status">
       {% if not basic_metric.status %}
-      {{ pixi.staticText.status.analyzing }}
+      {{ pixi.scriptText.status.analyzing }}
       {% include 'views/partials/pixi/analyzing-dots.j2' %}
       {% else %}
       {{ basic_metric.status }}

--- a/frontend/templates/views/partials/pixi/primary-metric.j2
+++ b/frontend/templates/views/partials/pixi/primary-metric.j2
@@ -10,7 +10,7 @@
         {{ primary_metric.title.id }}
       </div>
       <label class="ap-m-pixi-primary-metric-header-title-status">
-        <span class="ap-m-pixi-primary-metric-category">{{ pixi.staticText.status.analyzing }}</span>
+        <span class="ap-m-pixi-primary-metric-category">{{ pixi.scriptText.status.analyzing }}</span>
         {% include 'views/partials/pixi/analyzing-dots.j2' %}
       </label>
     </h3>
@@ -27,19 +27,19 @@
     <div class="ap-m-pixi-primary-metric-body-result">
       <div>
         <strong>{{ pixi.staticText.coreWebVitals.resultLabels.score }}:</strong>
-        <span class="ap-m-pixi-primary-metric-score">{{ pixi.staticText.status.calculating }}</span>
+        <span class="ap-m-pixi-primary-metric-score">{{ pixi.scriptText.status.calculating }}</span>
         {% include 'views/partials/pixi/analyzing-dots.j2' %}
       </div>
 
       <div>
         <strong>{{ pixi.staticText.coreWebVitals.resultLabels.opportunity }}:</strong>
-        <span class="ap-m-pixi-primary-metric-improvement">{{ pixi.staticText.status.calculating }}</span>
+        <span class="ap-m-pixi-primary-metric-improvement">{{ pixi.scriptText.status.calculating }}</span>
         {% include 'views/partials/pixi/analyzing-dots.j2' %}
       </div>
 
       <div>
         <strong>{{ pixi.staticText.coreWebVitals.resultLabels.action }}:</strong>
-        <a href="#recommendations" class="ap-m-pixi-primary-metric-recommendations">{{ pixi.staticText.status.analyzing }}</a>
+        <a href="#recommendations" class="ap-m-pixi-primary-metric-recommendations">{{ pixi.scriptText.status.analyzing }}</a>
         {% include 'views/partials/pixi/analyzing-dots.j2' %}
         {% do doc.icons.useIcon('icons/arrow-down.svg') %}
         <svg>

--- a/pages/content/amp-dev/page-experience.html
+++ b/pages/content/amp-dev/page-experience.html
@@ -106,7 +106,7 @@ description: Coming soon - analyze and learn how to optimize your AMP pages for 
           "pageUrl": "[= query.url =]",
           "i18n": {
             "language": "{{ doc.locale }}",
-            "staticText": {{pixi.staticText|jsonify|safe}}
+            "scriptText": {{pixi.scriptText|jsonify|safe}}
           }
         }
       </script>

--- a/pages/content/pixi/index.md
+++ b/pages/content/pixi/index.md
@@ -4,7 +4,6 @@ staticText:
   inputBar:
     headline: Analyze your AMP page
     fieldPlaceholder: Enter URL
-    fieldError: Please enter a valid URL
     button: Analyze
   shareDialog:
     headline: Copy & paste URL
@@ -35,20 +34,30 @@ staticText:
     mobileFriendliness: Mobile Friendliness
     intrusiveInterstitials: Intrusive Interstitials
     checkManually: Check manually
+  recommendations:
+    headline: Take action. Improve your AMP site
+  tags:
+    all: All
+scriptText:
+  inputBar:
+    fieldError: Please enter a valid URL
   status:
     analyzing: Analyzing
     calculating: Calculating
+    error: Analysis failed
     failed: Failed
     passed: Passed
+    passedAddition: passed
     none: None
     nothingToDo: Nothing to do
     fileAnIssue: File an issue with AMP
     recommendation: recommendation
     recommendations: recommendations
-  recommendations:
-    headline: Take action. Improve your AMP site
+  categories:
+    fast: Good
+    average: Needs Improvement
+    slow: Poor
   tags:
-    all: All
     lcp: LCP
     fid: FID
     cls: CLS

--- a/pages/content/pixi/index@de.md
+++ b/pages/content/pixi/index@de.md
@@ -58,8 +58,17 @@ staticText:
     intrusiveInterstitials: Intrusive Interstitials
 ---
 
-The AMP page experience guide is a tool that shows AMP developers how their AMP pages are performing against the Google Search page experience ranking signal, and provides actionable feedback on how they can improve.
+Der AMP Page Experience Guide ist ein Werkzeug das Entwicklern zeigt
+wie ihre Seite beim Google Page Experience Ranking abschneidet und
+was sie tun können um das Ergebnis zu verbessern.
+ 
+Falls es uns nicht möglich ist verwertbare Erkenntnisse zu liefern,
+nutze bitte die Möglichkeit 
+[ein Ticket auf Github anzulegen](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type:+Page+experience&template=page-experience.md&title=Page+experience+issue),
+damit unser Team dir helfen kann, zu verstehen, wie deine AMP Seiten
+verbessert werden können.
 
-If we aren't able to provide you with actionable insights please use the available prompts to [file an issue on GitHub](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type:+Page+experience&template=page-experience.md&title=Page+experience+issue) so our team can help you understand how your AMP pages can be improved.
-
-We use publicly available APIs such as [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/), [Safe Browsing](https://developers.google.com/safe-browsing/v4/lookup-api), and [Mobile-friendliness Test](https://search.google.com/test/mobile-friendly).
+Wir nutzen öffentlich verfügbare APIs wie
+[PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/),
+[Safe Browsing](https://developers.google.com/safe-browsing/v4/lookup-api),
+und [Mobile-friendliness Test](https://search.google.com/test/mobile-friendly).

--- a/pages/content/pixi/index@de.md
+++ b/pages/content/pixi/index@de.md
@@ -3,8 +3,7 @@ $title: AMP Page Experience Guide
 staticText:
   inputBar:
     headline: Analysiere deine AMP Seite
-    fieldPlaceholder: Gib eine gültige URL ein
-    fieldError: Bitte gebe eine gültige URL ein
+    fieldPlaceholder: URL eingeben
     button: Analysieren
   shareDialog:
     headline: Copy & paste URL
@@ -35,18 +34,29 @@ staticText:
     mobileFriendliness: Mobile Friendliness
     intrusiveInterstitials: Intrusive Interstitials
     checkManually: Bitte manuell prüfen
+  recommendations:
+    headline: Jetzt handeln. Verbessere deine AMP Seite
+  tags:
+    all: Alle
+scriptText:
+  inputBar:
+    fieldError: Bitte gebe eine gültige URL ein
   status:
     analyzing: Analysiere
     calculating: Berechne
+    error: Analyse fehlgeschlagen
     failed: Nicht bestanden
     passed: Bestanden
+    passedAddition: bestanden
     none: Keins
     nothingToDo: Nichts zu tun
     fileAnIssue: Melde ein Problem bei AMP
     recommendation: Empfehlung
     recommendations: Empfehlungen
-  recommendations:
-    headline: Jetzt handeln. Verbessere deine AMP Seite
+  categories:
+    fast: Schnell
+    average: Verbesserungswürdig
+    slow: Schlecht
   tags:
     all: Alle
     lcp: LCP

--- a/pixi/src/ui/I18n.js
+++ b/pixi/src/ui/I18n.js
@@ -18,7 +18,7 @@ class I18n {
     ]);
     const i18nConfig = JSON.parse(pixiContent[0]);
     this.language = i18nConfig.language;
-    this.staticText = i18nConfig.staticText;
+    this.scriptText = i18nConfig.scriptText;
     this.statusBanners = JSON.parse(pixiContent[1]);
     this.recommendations = JSON.parse(pixiContent[2]);
     this.infoTexts = JSON.parse(pixiContent[3]);
@@ -28,7 +28,7 @@ class I18n {
     const keys = textKey.split('.');
     return keys.reduce(
       (node, key) => (node && node[key]) || '',
-      this.staticText
+      this.scriptText
     );
   }
 

--- a/pixi/src/ui/report/BooleanCheckReportView.js
+++ b/pixi/src/ui/report/BooleanCheckReportView.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import i18n from '../I18n';
+
 export default class BooleanCheckReportView {
   constructor(doc, id) {
     this.container = doc.getElementById(id);
@@ -21,13 +23,13 @@ export default class BooleanCheckReportView {
 
   render(report) {
     if (report === true) {
-      this.label.textContent = 'Passed';
+      this.label.textContent = i18n.getText('status.passed');
       this.container.classList.add('passed');
     } else if (report === false) {
-      this.label.textContent = 'Failed';
+      this.label.textContent = i18n.getText('status.failed');
       this.container.classList.add('failed');
     } else {
-      this.label.textContent = 'Analysis failed';
+      this.label.textContent = i18n.getText('status.error');
       this.container.classList.add('error');
     }
 

--- a/pixi/src/ui/report/CoreWebVitalsReportView.js
+++ b/pixi/src/ui/report/CoreWebVitalsReportView.js
@@ -15,9 +15,9 @@
 import i18n from '../I18n.js';
 
 const CATEGORIES = {
-  fast: 'Good',
-  average: 'Needs Improvement',
-  slow: 'Poor',
+  fast: 'fast',
+  average: 'average',
+  slow: 'slow',
 };
 const FILE_ISSUE_URL =
   'https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type%3A+Page+experience&template=page-experience.md&title=Page+experience+issue';
@@ -74,7 +74,9 @@ class SimpleScale {
     const percentile = Math.round(data.proportion * 100);
 
     this.bar.style.width = `${percentile}%`;
-    this.label.textContent = `${percentile}% passed`;
+    this.label.textContent = `${percentile}% ${i18n.getText(
+      'status.passedAddition'
+    )}`;
     if (percentile < 30) {
       this.bar.classList.add('inversed');
     }
@@ -116,7 +118,7 @@ class CoreWebVitalView {
     this.scale.render(data, unit);
 
     const responseCategory = data.category.toLowerCase();
-    this.performanceCategory = CATEGORIES[responseCategory];
+    this.performanceCategory = i18n.getText(`categories.${responseCategory}`);
     this.container.classList.add(responseCategory);
     this.category.textContent = this.performanceCategory;
 


### PR DESCRIPTION
The texts in the index.md are now separated into staticText for the templates and scriptText for the scripts via amp-state.
There are two texts that are used in script and template. I opted in for simply using the scriptText in the template, since the main point in the separation is to only put the text in the amp-state that are needed by the script.

I also translated the intro text in the german index.md to avoid having mixed languages in one file.
(Unfortunately it is not possible to keep the body of a translated markdown file empty to use the body of the main language.)