### PR TITLE
Pixi: Improve accessibility for status buttons

### DIFF
--- a/frontend/templates/views/partials/pixi/share-dialog.j2
+++ b/frontend/templates/views/partials/pixi/share-dialog.j2
@@ -1,17 +1,26 @@
 {% do doc.styles.addCssFile('css/components/molecules/pixi-share-dialog.css') %}
 
-<amp-lightbox id="share-dialog" layout="nodisplay">
+<amp-lightbox id="share-dialog" layout="nodisplay" on="lightboxClose:share-button.focus">
   <div class="ap-m-share-dialog"
-      role="button"
-      tabindex="0">
+      role="dialog" aria-labelledby="share-dialog-title" aria-describedby="share-dialog-title">
     <div class="ap-m-share-dialog-container">
-      <h2>{{ pixi.staticText.shareDialog.headline }}</h2>
+      <button class="ap-m-share-dialog-container-close"
+          on="tap:share-dialog.close"
+          type="button"
+          name="button"
+          tabindex="0"
+          aria-label="{{ pixi.staticText.shareDialog.close }}">
+        {% do doc.icons.useIcon('icons/close.svg') %}
+        <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close"></use></svg>
+      </button>
+      <h2 id="share-dialog-title">{{ pixi.staticText.shareDialog.headline }}</h2>
       <input class="ap-m-share-dialog-container-textarea"
           type="text"
           value=""
           [value]="pixi.shareUrl"
           readonly>
       <amp-iframe class="ap-m-share-dialog-container-copy-button"
+          title="{{ pixi.staticText.shareDialog.copyToClipboard }}"
           width="300px"
           height="75"
           layout="fixed"
@@ -20,14 +29,6 @@
           [src]="'{{ podspec.base_urls.platform }}/shared/copy-pixi-url/#' + pixi.shareUrl">
         <div placeholder></div>
       </amp-iframe>
-      <button class="ap-m-share-dialog-container-close"
-          on="tap:share-dialog.close"
-          type="button"
-          name="button"
-          tabindex="1">
-        {% do doc.icons.useIcon('icons/close.svg') %}
-        <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close"></use></svg>
-      </button>
     </div>
   </div>
 </amp-lightbox>

--- a/frontend/templates/views/partials/pixi/status-intro.j2
+++ b/frontend/templates/views/partials/pixi/status-intro.j2
@@ -19,12 +19,10 @@
         {{ pixi.staticText.statusIntro.loadingCopy|replace('${finishedChecks}', '<span id="finished-checks">0</span>')|replace('${totalChecks}','<span id="total-checks">0</span>')|safe }}
       </p>
       <div class="ap-m-pixi-status-intro-banner-ctas">
-        <button class="ap-a-btn"
-            on="tap:recommendations.scrollTo(duration=400)"
-            type="button"
-            name="button">
+        <a href="#recommendations" class="ap-a-btn"
+            type="button">
           {{ pixi.staticText.statusIntro.buttonFixIt }}
-        </button>
+        </a>
         <button class="ap-a-btn ap-a-btn-light"
             on="tap:share-dialog"
             type="button"

--- a/frontend/templates/views/partials/pixi/status-intro.j2
+++ b/frontend/templates/views/partials/pixi/status-intro.j2
@@ -24,6 +24,7 @@
           {{ pixi.staticText.statusIntro.buttonFixIt }}
         </a>
         <button class="ap-a-btn ap-a-btn-light"
+            id="share-button"
             on="tap:share-dialog"
             type="button"
             name="button">

--- a/pages/content/pixi/index.md
+++ b/pages/content/pixi/index.md
@@ -7,6 +7,8 @@ staticText:
     button: Analyze
   shareDialog:
     headline: Copy & paste URL
+    close: Close navigation
+    copyToClipboard: Copy to clipboard
   statusIntro:
     headline: Please wait a moment
     headline2: We are currently analyzing your page

--- a/pixi/src/ui/StatusIntroView.js
+++ b/pixi/src/ui/StatusIntroView.js
@@ -79,14 +79,15 @@ export default class StatusIntroView {
     bannerTitle.textContent = statusBanner.title;
     bannerText.innerHTML = marked(statusBanner.body);
 
-    const buttons = banner.querySelectorAll('button');
+    const shareButton = banner.querySelector('button');
+    const anchor = banner.querySelector('a');
     if (hideFixButton) {
-      buttons[0].classList.add('pristine');
+      anchor.classList.add('pristine');
       // make second button primary
-      buttons[1].classList.remove('ap-a-btn-light');
+      shareButton.classList.remove('ap-a-btn-light');
     }
     if (statusBanner.hideShare) {
-      buttons[1].classList.add('pristine');
+      shareButton.classList.add('pristine');
     }
 
     this.bannerLoading.classList.add('pristine');


### PR DESCRIPTION
This PR will update the "Fix It Now" button to an anchor link instead of an AMP `scrollTo` action to the same header element. The share button dialog contents will also now be appropriately focusable.

Fixes #4498, fixes #4493