### PR TITLE
pixi: remove marked from client. transform in jinja

### DIFF
--- a/pages/content/amp-dev/page-experience.html
+++ b/pages/content/amp-dev/page-experience.html
@@ -15,7 +15,7 @@ description: Coming soon - analyze and learn how to optimize your AMP pages for 
     'title': node.title,
     'type': node.type,
     'hideShare': node.hide_share == true,
-    'body': node.body
+    'body': node.body|markdown
   } %}
   {% set x=status_banners.__setitem__(node.base, nodeDict) %}
 {% endfor %}
@@ -27,7 +27,7 @@ description: Coming soon - analyze and learn how to optimize your AMP pages for 
     'title': node.title,
     'order': node.order,
     'tags': node.tags if node.tags else [],
-    'body': node.body
+    'body': node.body|markdown
   } %}
   {% set x=recommendations.__setitem__(node.base, nodeDict) %}
 {% endfor %}

--- a/pixi/src/ui/StatusIntroView.js
+++ b/pixi/src/ui/StatusIntroView.js
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import marked from 'marked';
 import i18n from './I18n';
 import {fixedRecommendations} from '../utils/checkAggregation/recommendations';
 
@@ -77,7 +76,7 @@ export default class StatusIntroView {
     const bannerTitle = banner.querySelector('h3');
     const bannerText = banner.querySelector('p');
     bannerTitle.textContent = statusBanner.title;
-    bannerText.innerHTML = marked(statusBanner.body);
+    bannerText.innerHTML = statusBanner.body;
 
     const buttons = banner.querySelectorAll('button');
     if (hideFixButton) {

--- a/pixi/src/ui/recommendations/RecommendationsView.js
+++ b/pixi/src/ui/recommendations/RecommendationsView.js
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import marked from 'marked';
 import i18n from '../I18n.js';
 
 export default class RecommendationsView {
@@ -85,8 +84,8 @@ export default class RecommendationsView {
       header.setAttribute('aria-controls', body.id);
       body.setAttribute('aria-labelledby', header.id);
 
-      title.innerHTML = marked(value.title);
-      body.innerHTML = marked(value.body);
+      title.innerHTML = value.title;
+      body.innerHTML = value.body;
 
       for (const tagId of value.tags) {
         const tag = this.tag.cloneNode(true);


### PR DESCRIPTION
**summary**
Fixes: https://github.com/ampproject/amp.dev/issues/4522

The status quo is that recommendation text is written by amp.dev authors in markdown. The markdown is stringified and thrown into a [json map](https://github.com/ampproject/amp.dev/blob/b6e17cef6d530146a6a10a48d3d9b6ceb5b07931/pages/content/amp-dev/page-experience.html#L23-L33), then inserted as `<amp-state>` in the page. If the analyzer api returns that the site deserves said recommendations, it'll run the appropriate rules [through marked](https://github.com/ampproject/amp.dev/blob/de5892187a2fc6ce8d39a2375ffdec3b494fb49d/pixi/src/ui/recommendations/RecommendationsView.js#L88-L89). Due to the convergence of [marked encoding html entities](https://github.com/markedjs/marked/issues/1737) and `worker-dom` [not supporting them](https://github.com/ampproject/worker-dom/issues/613), entities are appearing in the browser html encoded.

We have the opportunity to solve this at many layers, although I think the biggest win is actually moving the markdown conversion from runtime js into the jinja template. It helps with both bundle size and runtime performance.

Let me know what y'all think!