### PR TITLE
Pixi: Manage info tip focus

### DIFF
--- a/frontend/scss/components/molecules/pixi-tooltip.scss
+++ b/frontend/scss/components/molecules/pixi-tooltip.scss
@@ -79,13 +79,12 @@
     line-height: 1.57;
     background: color('white');
     pointer-events: none;
-    opacity: 0;
+    display: none;
     filter: drop-shadow(0 0 20px transparentize(color('black'), 0.8));
 
     @media (min-width: 575px) {
       position: absolute;
       top: 25px;
-      display: flex;
       flex-direction: row-reverse;
       width: 300px;
       height: auto;
@@ -129,7 +128,6 @@
     }
 
     .invert & {
-
       @media (min-width: 575px) {
         transform: translateX(70%);
       }
@@ -144,6 +142,7 @@
     #{$tooltip}-tip {
       opacity: 1;
       pointer-events: all;
+      display: flex;
     }
 
     & + #{$tooltip}-background {

--- a/frontend/templates/views/partials/pixi/tooltip.j2
+++ b/frontend/templates/views/partials/pixi/tooltip.j2
@@ -4,20 +4,30 @@
     class="ap-m-tooltip {% if tooltip.invert %}invert{% endif %}">
 
   <button class="ap-m-tooltip-toggle"
-      on="tap:tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}.toggleClass(class=active)">
+      id="tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}-open"
+      on="tap:tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}.toggleClass(class=active),AMP.setState({tooltip: tooltip ? !tooltip : true}),tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}-close.focus"
+      aria-label="{{ pixi.staticText.infoDialog.open }} {{ info_texts[tooltip.id].title }}">
     {% do doc.icons.useIcon('icons/questionmark-outline.svg') %}
     <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#questionmark-outline"></use></svg>
   </button>
 
-  <div class="ap-m-tooltip-tip">
-    <button class="ap-m-tooltip-close"
-        on="tap:tooltip-{{ tooltip.id|replace(".", "-")  + tooltip.type|default('') }}.toggleClass(class=active)">
+  <div class="ap-m-tooltip-tip" role="dialog" 
+    aria-labelledby="tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}-title"
+    aria-describedby="tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}-description">
+    <button class="ap-m-tooltip-close" 
+        aria-label="{{ pixi.staticText.infoDialog.close }}"
+        id="tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}-close"
+        on="tap:tooltip-{{ tooltip.id|replace(".", "-")  + tooltip.type|default('') }}.toggleClass(class=active),tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}-open.focus">
       {% do doc.icons.useIcon('/icons/close.svg') %}
       <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close"></use></svg>
     </button>
     <div>
-      <h2>{{ info_texts[tooltip.id].title|markdown|safe }}</h2>
-      {{ info_texts[tooltip.id].body|markdown|safe }}
+      <h2 id="tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}-title">
+        {{ info_texts[tooltip.id].title|markdown|safe }}
+      </h2>
+      <div id="tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}-description">
+        {{ info_texts[tooltip.id].body|markdown|safe }}
+      </div>
     </div>
   </div>
 </div>

--- a/pages/content/pixi/index.md
+++ b/pages/content/pixi/index.md
@@ -5,6 +5,9 @@ staticText:
     headline: Analyze your AMP page
     fieldPlaceholder: Enter URL
     button: Analyze
+  infoDialog:
+    open: Learn about
+    close: Close
   shareDialog:
     headline: Copy & paste URL
     close: Close navigation


### PR DESCRIPTION
Partial for #4500
This PR:
- Adds labels the open/close dialog buttons for info tips
- Hides the closed buttons from screen reader focus
- Focuses automatically on "Close" button after pressing "Open" and vice-versa

Still need to be done from #4500:
1. `the question mark button should not be focusable when the popup is open`
2. `It should not be possible to move keyboard focus outside the popup without the popup closing.`

I believe addressing (2) will also fix (1), by virtue of the question mark button being outside the popup. @robinvanopstal @matthiasrohmer For the above missing pieces, it seems we may have to register an event handler to do this. Are you familiar with any ways to track focus using just AMP HTML?