### PR TITLE
keep pixi rec titles bold

### DIFF
--- a/frontend/scss/components/molecules/pixi-recommendations-item.scss
+++ b/frontend/scss/components/molecules/pixi-recommendations-item.scss
@@ -28,15 +28,12 @@
     &-title {
       width: 80%;
       max-width: 720px;
-
-      p {
-        margin: 0;
-        font-family: Poppins;
-        font-size: 22px;
-        font-weight: bold;
-        line-height: 1.3;
-        color: color('black');
-      }
+      margin: 0;
+      font-family: Poppins;
+      font-size: 22px;
+      font-weight: bold;
+      line-height: 1.3;
+      color: color('black');
     }
 
     &-toggle {


### PR DESCRIPTION
fixes #4567

marked wraps stuff in a `<p>` by default, so [this change](https://github.com/ampproject/amp.dev/pull/4563/files#diff-0b2fa57cd60a2e58bc20dd3389c45111L88) broke it