### PR TITLE
Fix/pixi text problems

### DIFF
--- a/pages/content/pixi/recommendations/fast-font-display.md
+++ b/pages/content/pixi/recommendations/fast-font-display.md
@@ -4,3 +4,5 @@ $order: 130
 tags:
   - lcp
 ---
+Leverage the font-display CSS feature to ensure text is user-visible while
+webfonts are loading. [Learn more](https://web.dev/font-display/).

--- a/pixi/src/ui/I18n.js
+++ b/pixi/src/ui/I18n.js
@@ -1,3 +1,19 @@
+// Copyright 2020 The AMPHTML Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import marked from 'marked';
+
 const DEFAULT_LANGUAGE = 'en';
 
 class I18n {
@@ -45,7 +61,7 @@ class I18n {
         const {body, ...props} = recommendation;
         result.push({
           id,
-          body: body || item.description,
+          body: body || marked(item.description),
           ...props,
         });
       } else {

--- a/pixi/src/ui/StatusIntroView.js
+++ b/pixi/src/ui/StatusIntroView.js
@@ -14,6 +14,7 @@
 
 import i18n from './I18n';
 import {fixedRecommendations} from '../utils/checkAggregation/recommendations';
+import {cleanCodeForInnerHtml} from '../utils/texts';
 
 const classNameMapping = {
   error: 'fail',
@@ -76,7 +77,7 @@ export default class StatusIntroView {
     const bannerTitle = banner.querySelector('h3');
     const bannerText = banner.querySelector('p');
     bannerTitle.textContent = statusBanner.title;
-    bannerText.innerHTML = statusBanner.body;
+    bannerText.innerHTML = cleanCodeForInnerHtml(statusBanner.body);
 
     const shareButton = banner.querySelector('button');
     const anchor = banner.querySelector('a');

--- a/pixi/src/ui/recommendations/RecommendationsView.js
+++ b/pixi/src/ui/recommendations/RecommendationsView.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import i18n from '../I18n.js';
+import {cleanCodeForInnerHtml} from '../../utils/texts';
 
 export default class RecommendationsView {
   constructor(doc) {
@@ -85,7 +86,7 @@ export default class RecommendationsView {
       body.setAttribute('aria-labelledby', header.id);
 
       title.innerHTML = value.title;
-      body.innerHTML = value.body;
+      body.innerHTML = cleanCodeForInnerHtml(value.body);
 
       for (const tagId of value.tags) {
         const tag = this.tag.cloneNode(true);

--- a/pixi/src/utils/texts.js
+++ b/pixi/src/utils/texts.js
@@ -1,0 +1,49 @@
+// Copyright 2020 The AMPHTML Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const htmlEntityMapping = {
+  // we will not use the html inside attributes
+  // so here we can use the normal characters...
+  '&quot;': '"',
+  '&#39;': "'",
+  // since the following caracters can not be used unescaped
+  // we use unicode replacements...
+  '&gt;': '\uFE65', // small greater than sign
+  '&lt;': '\uFE64', // small less than sign
+  '&amp;': '\uFF06', // fullwidth ampersand
+};
+
+const entitySearchPattern = new RegExp(
+  Object.keys(htmlEntityMapping).join('|'),
+  'g'
+);
+
+/**
+ * This method is a workaround for this bug: https://github.com/ampproject/amphtml/issues/27153
+ * and this bug: https://github.com/ampproject/amphtml/issues/30273
+ *
+ * It replaces the html entities that are required when escaping text for html
+ * so that can the code can be used with amp-script as innerHtml but not as attributes.
+ * Also all empty span tags (which are created by grow markdown.extensions.codehilite) are removed.
+ */
+export const cleanCodeForInnerHtml = (html) => {
+  if (!html) {
+    return '';
+  }
+  const result = html.replace(
+    entitySearchPattern,
+    (match) => htmlEntityMapping[match]
+  );
+  return result.replace(/<span>\s*<\/span>/g, '');
+};

--- a/pixi/src/utils/texts.test.js
+++ b/pixi/src/utils/texts.test.js
@@ -1,0 +1,13 @@
+import {cleanCodeForInnerHtml} from './texts';
+
+describe('cleanCodeForInnerHtml', () => {
+  it('converts specific html entities', async () => {
+    const result = cleanCodeForInnerHtml('&#39; &quot; &amp; &lt; &gt;');
+    expect(result.trim()).toEqual('\' " \uFF06 \uFE64 \uFE65');
+  });
+
+  it('removes empty span tags', async () => {
+    const result = cleanCodeForInnerHtml('<pre><span> </span></pre>');
+    expect(result.trim()).toEqual('<pre></pre>');
+  });
+});


### PR DESCRIPTION
Fix test display problems:
- fast-font-display body not displayed when fired by Linter check
- Code blocks not displayed correctly in recommendations
- Markdown recommendations from PSI where not converted to html

This PR adresses problems described here:
https://github.com/ampproject/amp.dev/issues/4522

But as soon as amp-script problems are solved things done here should be changed!