### PR TITLE
Pixi: Hide status texts with visibility property

### DIFF
--- a/frontend/scss/components/molecules/pixi-status-intro.scss
+++ b/frontend/scss/components/molecules/pixi-status-intro.scss
@@ -58,7 +58,8 @@
     background-position: 60px 50px;
     background-color: color('white');
     pointer-events: none;
-    display: none;
+    display: flex;
+    visibility: hidden;
     transition: opacity 0.2s ease-in-out, transform 0.3s ease-in-out;
 
     @media (min-width: 768px) {
@@ -110,11 +111,11 @@
   &.pass {
     #{$status-intro} {
       &-text {
-        display: none;
+        visibility: hidden;
       }
       &-banner {
         pointer-events: all;
-        display: flex;
+        visibility: visible;
         transform: translateY(-6px);
         box-shadow: 0 10px 25px 0 transparentize(color('black'), 0.7);
       }


### PR DESCRIPTION
This fixes the original a11y issue addressed in #4559 through another means, as well as hides the resurfaced loading banner that was an unintended bug from #4559 (notice how it looks like there are two white cards at the bottom):
![image](https://user-images.githubusercontent.com/10456171/93511772-511ec800-f8f1-11ea-8f18-ca919e93df75.png)

@matthiasrohmer Can you confirm if this also fixes the transitions?