### PR TITLE
Update link to AMP blog

### DIFF
--- a/frontend/templates/views/partials/footer.j2
+++ b/frontend/templates/views/partials/footer.j2
@@ -22,7 +22,7 @@
             </a>
           </li>
           <li class="ap-o-footer-follow-item">
-            <a class="ap-a-ico ap-o-footer-follow-icon" href="https://amphtml.wordpress.com/" rel="noopener">
+            <a class="ap-a-ico ap-o-footer-follow-icon" href="https://blog.amp.dev/" rel="noopener">
               <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#wordpress" title="WordPress"></use></svg>
             </a>
           </li>


### PR DESCRIPTION
The AMP blog is no longer located at amphtml.wordpress.com. The footer link needs to now point to blog.amp.dev. This is where users are redirected to anyway.