### PR TITLE
Open links in new tab and replace checked url placeholder in links

### DIFF
--- a/pixi/src/ui/PageExperience.js
+++ b/pixi/src/ui/PageExperience.js
@@ -101,6 +101,7 @@ export default class PageExperience {
     if (recommendations.length > 0) {
       this.recommendationsView.render(
         recommendations,
+        pageUrl,
         this.reportViews.pageExperience.coreWebVitalViews
       );
     }

--- a/pixi/src/ui/StatusIntroView.js
+++ b/pixi/src/ui/StatusIntroView.js
@@ -14,7 +14,7 @@
 
 import i18n from './I18n';
 import {fixedRecommendations} from '../utils/checkAggregation/recommendations';
-import {cleanCodeForInnerHtml} from '../utils/texts';
+import {addTargetBlankToLinks, cleanCodeForInnerHtml} from '../utils/texts';
 
 const classNameMapping = {
   error: 'fail',
@@ -72,12 +72,15 @@ export default class StatusIntroView {
     this.container.classList.remove('loading');
     this.container.classList.add(classNameMapping[statusBanner.type]);
 
+    let bodyHtml = cleanCodeForInnerHtml(statusBanner.body);
+    bodyHtml = addTargetBlankToLinks(bodyHtml);
+
     const banner = this.bannerLoading.cloneNode(true);
     banner.id = 'status-intro-banner';
     const bannerTitle = banner.querySelector('h3');
     const bannerText = banner.querySelector('p');
     bannerTitle.textContent = statusBanner.title;
-    bannerText.innerHTML = cleanCodeForInnerHtml(statusBanner.body);
+    bannerText.innerHTML = bodyHtml;
 
     const shareButton = banner.querySelector('button');
     const anchor = banner.querySelector('a');

--- a/pixi/src/ui/recommendations/RecommendationsView.js
+++ b/pixi/src/ui/recommendations/RecommendationsView.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import i18n from '../I18n.js';
-import {cleanCodeForInnerHtml} from '../../utils/texts';
+import {addTargetBlankToLinks, cleanCodeForInnerHtml} from '../../utils/texts';
 
 export default class RecommendationsView {
   constructor(doc) {
@@ -45,7 +45,7 @@ export default class RecommendationsView {
     }
   }
 
-  render(recommendationList, metricUis) {
+  render(recommendationList, pageURL, metricUis) {
     this.container.classList.remove('pristine');
     const recommendations = i18n.getSortedRecommendations(recommendationList);
     const tagIdCounts = {};
@@ -85,8 +85,12 @@ export default class RecommendationsView {
       header.setAttribute('aria-controls', body.id);
       body.setAttribute('aria-labelledby', header.id);
 
+      let bodyHtml = cleanCodeForInnerHtml(value.body);
+      bodyHtml = bodyHtml.replace(/\$\{URL\}/g, encodeURIComponent(pageURL));
+      bodyHtml = addTargetBlankToLinks(bodyHtml);
+
       title.innerHTML = value.title;
-      body.innerHTML = cleanCodeForInnerHtml(value.body);
+      body.innerHTML = bodyHtml;
 
       for (const tagId of value.tags) {
         const tag = this.tag.cloneNode(true);

--- a/pixi/src/utils/texts.js
+++ b/pixi/src/utils/texts.js
@@ -47,3 +47,17 @@ export const cleanCodeForInnerHtml = (html) => {
   );
   return result.replace(/<span>\s*<\/span>/g, '');
 };
+
+/**
+ * Add target=_blank to all link tags that do not have a target attribute
+ * and do have a href attribute that is not empty and not an anchor
+ */
+export const addTargetBlankToLinks = (html) => {
+  if (!html) {
+    return html;
+  }
+  return html.replace(
+    /<a\s(?![^>]*\btarget\s*=)(?=[^>]*\bhref\s*=\s*['"][^#"'])/g,
+    '<a target="_blank" '
+  );
+};

--- a/pixi/src/utils/texts.test.js
+++ b/pixi/src/utils/texts.test.js
@@ -1,4 +1,4 @@
-import {cleanCodeForInnerHtml} from './texts';
+import {cleanCodeForInnerHtml, addTargetBlankToLinks} from './texts';
 
 describe('cleanCodeForInnerHtml', () => {
   it('converts specific html entities', async () => {
@@ -9,5 +9,38 @@ describe('cleanCodeForInnerHtml', () => {
   it('removes empty span tags', async () => {
     const result = cleanCodeForInnerHtml('<pre><span> </span></pre>');
     expect(result.trim()).toEqual('<pre></pre>');
+  });
+});
+
+describe('addTargetBlankToLinks', () => {
+  it('add target blank', async () => {
+    expect(addTargetBlankToLinks('<a href="link">')).toEqual(
+      '<a target="_blank" href="link">'
+    );
+    expect(addTargetBlankToLinks('<a href="link#anchor">')).toEqual(
+      '<a target="_blank" href="link#anchor">'
+    );
+    expect(addTargetBlankToLinks('<a class="x" href="link" name="y">')).toEqual(
+      '<a target="_blank" class="x" href="link" name="y">'
+    );
+    expect(
+      addTargetBlankToLinks('<a href="l1"></a> <a href="l2"></a>')
+    ).toEqual(
+      '<a target="_blank" href="l1"></a> <a target="_blank" href="l2"></a>'
+    );
+  });
+
+  it('do not add target blank', async () => {
+    const expectUnchanged = (html) => {
+      expect(addTargetBlankToLinks(html)).toEqual(html);
+    };
+    expectUnchanged('<a>'); // empty tag
+    expectUnchanged('<a name="x">'); // no href
+    expectUnchanged('<a href="">'); // empty link
+    expectUnchanged('<a href="#anchor">'); // only anchor
+    expectUnchanged('<a href="link" target="_top">');
+    expectUnchanged('<a target="_top" href="link">');
+    expectUnchanged('<a target = "_top" href="link">');
+    expectUnchanged("<a target='_top' href='link'>");
   });
 });


### PR DESCRIPTION
All links in recommendations and the status banner will open with target _blank.
Fixes #4573 

Also the "Publish valid cached AMP" recommendation now opens the validator URL with the submitted url.
