### PR TITLE
a11y radio-selector

### DIFF
--- a/examples/source/1.components/amp-selector.html
+++ b/examples/source/1.components/amp-selector.html
@@ -59,12 +59,6 @@ author: sebastianbenz
   border-right: 2px solid var(--color-primary);
   height: 60px;
 }
-.radio-selector [option][selected] {
-  outline: none;
-}
-.radio-selector [option][selected]:focus {
-  outline: 1px solid blue;
-}
 .radio-selector [option] {
   display: flex;
   align-items: center;

--- a/examples/source/1.components/amp-selector.html
+++ b/examples/source/1.components/amp-selector.html
@@ -62,6 +62,9 @@ author: sebastianbenz
 .radio-selector [option][selected] {
   outline: none;
 }
+.radio-selector [option][selected]:focus {
+  outline: 1px solid blue;
+}
 .radio-selector [option] {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Selected elements should have an indication that it is on focus for a11y.

WebAIM suggests to avoid using `Avoid outline:0 or similar styles on links and other elements that can receive keyboard focus.`

Full description is below.

> **Focus indicators**

> A keyboard user typically uses the Tab key to navigate through interactive elements on a web page—links, buttons, fields for inputting text, etc. When an item has keyboard "focus", it can be activated or manipulated with the keyboard. A sighted keyboard user must be provided with a visual indicator of the element that currently has keyboard focus. A basic focus indicator is provided automatically by the web browser and is typically shown as a border (called an outline) around the focused element. However, these outlines can be hidden by applying outline:0 or outline:none CSS to focusable elements.
> In addition to the default outline, you can use CSS to make the focus indicator more visually apparent and keyboard-friendly by adding a background color or other visual style to links, and other controls that will receive keyboard focus. The outline can be styled to match your site design.
> 

References: https://webaim.org/techniques/keyboard/