### PR TITLE
🐛 Do not take AMP.getState returning something for granted in Pixi

### DIFF
--- a/pixi/src/ui/I18n.js
+++ b/pixi/src/ui/I18n.js
@@ -26,12 +26,18 @@ class I18n {
   }
 
   async init() {
-    const pixiContent = await Promise.all([
-      AMP.getState('pixi.i18n'),
-      AMP.getState('pixiStatusBanners'),
-      AMP.getState('pixiRecommendations'),
-      AMP.getState('pixiInfoTexts'),
-    ]);
+    let pixiContent = [];
+    try {
+      pixiContent = await Promise.all([
+        AMP.getState('pixi.i18n'),
+        AMP.getState('pixiStatusBanners'),
+        AMP.getState('pixiRecommendations'),
+        AMP.getState('pixiInfoTexts'),
+      ]);
+    } catch (e) {
+      console.error('Failed to initialize translations', e);
+    }
+
     const i18nConfig = JSON.parse(pixiContent[0]);
     this.language = i18nConfig.language;
     this.scriptText = i18nConfig.scriptText;

--- a/pixi/src/ui/StatusIntroView.js
+++ b/pixi/src/ui/StatusIntroView.js
@@ -64,9 +64,13 @@ export default class StatusIntroView {
 
     const statusBannerId = await this.determineBannerId(statusBannerIdPromise);
     const statusBanner = i18n.getStatusBanner(statusBannerId);
-    const shareUrl = new URL(await AMP.getState('pixi.baseUrl'));
-    shareUrl.searchParams.set('url', pageUrl);
-    AMP.setState({pixi: {shareUrl: shareUrl.toString()}});
+    try {
+      const shareUrl = new URL(await AMP.getState('pixi.baseUrl'));
+      shareUrl.searchParams.set('url', pageUrl);
+      AMP.setState({pixi: {shareUrl: shareUrl.toString()}});
+    } catch (e) {
+      console.error('Failed to set share Url from StatusIntroView', e);
+    }
 
     this.finishedChecks = null;
     this.container.classList.remove('loading');


### PR DESCRIPTION
Had no luck reproducing #4458 specifically but my best guess is that `AMP.getState` sometimes throws instead of returning something. We've guarded this for the `InputBar` but didn't for the other occurrences until now.