### PR TITLE
Pixi: Correctly identify CTA buttons

### DIFF
--- a/frontend/templates/views/partials/pixi/status-intro.j2
+++ b/frontend/templates/views/partials/pixi/status-intro.j2
@@ -19,12 +19,12 @@
         {{ pixi.staticText.statusIntro.loadingCopy|replace('${finishedChecks}', '<span id="finished-checks">0</span>')|replace('${totalChecks}','<span id="total-checks">0</span>')|safe }}
       </p>
       <div class="ap-m-pixi-status-intro-banner-ctas">
-        <a class="ap-a-btn pristine" data-cta>{{ pixi.staticText.statusIntro.buttonInvestigate }}</a>
-        <a href="#recommendations" class="ap-a-btn" data-cta
+        <a class="ap-a-btn pristine" id="investigate-button">{{ pixi.staticText.statusIntro.buttonInvestigate }}</a>
+        <a href="#recommendations" class="ap-a-btn" id="fix-it-button"
             type="button">
           {{ pixi.staticText.statusIntro.buttonFixIt }}
         </a>
-        <button class="ap-a-btn ap-a-btn-light" data-cta
+        <button class="ap-a-btn ap-a-btn-light" id="share-button"
             id="share-button"
             on="tap:share-dialog"
             type="button"

--- a/frontend/templates/views/partials/pixi/status-intro.j2
+++ b/frontend/templates/views/partials/pixi/status-intro.j2
@@ -19,12 +19,12 @@
         {{ pixi.staticText.statusIntro.loadingCopy|replace('${finishedChecks}', '<span id="finished-checks">0</span>')|replace('${totalChecks}','<span id="total-checks">0</span>')|safe }}
       </p>
       <div class="ap-m-pixi-status-intro-banner-ctas">
-        <a class="ap-a-btn pristine">{{ pixi.staticText.statusIntro.buttonInvestigate }}</a>
-        <a href="#recommendations" class="ap-a-btn"
+        <a class="ap-a-btn pristine" data-cta>{{ pixi.staticText.statusIntro.buttonInvestigate }}</a>
+        <a href="#recommendations" class="ap-a-btn" data-cta
             type="button">
           {{ pixi.staticText.statusIntro.buttonFixIt }}
         </a>
-        <button class="ap-a-btn ap-a-btn-light"
+        <button class="ap-a-btn ap-a-btn-light" data-cta
             id="share-button"
             on="tap:share-dialog"
             type="button"

--- a/pixi/src/ui/StatusIntroView.js
+++ b/pixi/src/ui/StatusIntroView.js
@@ -86,14 +86,15 @@ export default class StatusIntroView {
     bannerTitle.textContent = statusBanner.title;
     bannerText.innerHTML = bodyHtml;
 
-    const shareButton = banner.querySelector('button[data-cta]');
-    const anchors = banner.querySelectorAll('a[data-cta]');
+    const shareButton = banner.querySelector('#share-button');
     if (statusBanner.investigate) {
-      anchors[0].setAttribute('href', statusBanner.investigate);
-      anchors[0].classList.remove('pristine');
+      const investigateButton = banner.querySelector('#investigate-button');
+      investigateButton.setAttribute('href', statusBanner.investigate);
+      investigateButton.classList.remove('pristine');
     }
     if (hideFixButton) {
-      anchors[1].classList.add('pristine');
+      const fixItButton = banner.querySelector('#fix-it-button');
+      fixItButton.classList.add('pristine');
       // make second button primary
       shareButton.classList.remove('ap-a-btn-light');
     }

--- a/pixi/src/ui/StatusIntroView.js
+++ b/pixi/src/ui/StatusIntroView.js
@@ -86,8 +86,8 @@ export default class StatusIntroView {
     bannerTitle.textContent = statusBanner.title;
     bannerText.innerHTML = bodyHtml;
 
-    const shareButton = banner.querySelector('button');
-    const anchors = banner.querySelectorAll('a');
+    const shareButton = banner.querySelector('button[data-cta]');
+    const anchors = banner.querySelectorAll('a[data-cta]');
     if (statusBanner.investigate) {
       anchors[0].setAttribute('href', statusBanner.investigate);
       anchors[0].classList.remove('pristine');


### PR DESCRIPTION
Add `data-cta` attribute to the targeted anchor elements we want to modify. This fixes #4602, which was a consequence of the inline text having a hyperlink of its own (to PSI).