### PR TITLE
Pixi: Reset styles in lab data scales between runs

### DIFF
--- a/pixi/src/ui/report/CoreWebVitalsReportView.js
+++ b/pixi/src/ui/report/CoreWebVitalsReportView.js
@@ -44,7 +44,7 @@ class WeightedScale {
     this.indicator.classList.add(data.category.toLowerCase());
     if (score < 40) {
       this.indicator.classList.add('inversed');
-    } else if (score > 100) {
+    } else if (score === 100) {
       this.indicator.classList.add('max');
     }
 

--- a/pixi/src/ui/report/CoreWebVitalsReportView.js
+++ b/pixi/src/ui/report/CoreWebVitalsReportView.js
@@ -41,6 +41,7 @@ class WeightedScale {
       data.numericValue / unit.conversion
     ).toFixed(unit.digits)} ${unit.name}`;
 
+    this.resetStyles();
     this.indicator.classList.add(data.category.toLowerCase());
     if (score < 40) {
       this.indicator.classList.add('inversed');
@@ -60,6 +61,12 @@ class WeightedScale {
         data.proportion[type] / unit.conversion.toFixed(unit.digits)
       } ${unit.name}`;
     }
+  }
+
+  resetStyles() {
+    this.indicator.classList.remove(...Object.keys(CATEGORIES));
+    this.indicator.classList.remove('inversed');
+    this.indicator.classList.remove('max');
   }
 }
 


### PR DESCRIPTION
This PR also checks for a score of `=== 100` not `> 100` for the `V` indicator to go `>`. Fixes #4616 
![image](https://user-images.githubusercontent.com/10456171/93820499-42a31a00-fc2b-11ea-9a4e-c34a64a00f2c.png)
![image](https://user-images.githubusercontent.com/10456171/93820637-73834f00-fc2b-11ea-9fef-cc64198da83b.png)
