### PR TITLE
Pixi: Hide metric elements for field data error state

### DIFF
--- a/frontend/scss/components/molecules/pixi-primary-metric.scss
+++ b/frontend/scss/components/molecules/pixi-primary-metric.scss
@@ -163,6 +163,7 @@
 
     & > div {
       opacity: 0;
+      visibility: hidden;
     }
   }
 }


### PR DESCRIPTION
Fixes #4636