### PR TITLE
🐛 Use safe light-gray instead of removed boulder color

### DIFF
--- a/frontend/scss/components/molecules/pixi-recommendations-item.scss
+++ b/frontend/scss/components/molecules/pixi-recommendations-item.scss
@@ -84,7 +84,7 @@
   }
 
   &-body + &-tags {
-    border-top: solid 1px color('boulder');
+    border-top: solid 1px safeColor('light-gray');
   }
 
   &.expanded {


### PR DESCRIPTION
Fixes

```
[20:19:14] Finished 'templates' after 550 ms
[20:19:14] Finished 'icons' after 582 ms
WARNING: Unknown `boulder` in $colors.
         on line 12 of frontend/scss/_functions.scss, in function `color`
         from line 87 of frontend/scss/components/molecules/pixi-recommendations-item.scss
```