### PR TITLE
Pixi: Surface "Nothing to do" for good performing metrics with no recommendations

### DIFF
--- a/pixi/src/ui/report/CoreWebVitalsReportView.js
+++ b/pixi/src/ui/report/CoreWebVitalsReportView.js
@@ -125,10 +125,12 @@ class CoreWebVitalView {
 
     this.scale.render(data, unit);
 
-    const responseCategory = data.category.toLowerCase();
-    this.performanceCategory = i18n.getText(`categories.${responseCategory}`);
-    this.container.classList.add(responseCategory);
-    this.category.textContent = this.performanceCategory;
+    this.performanceCategory = data.category.toLowerCase();
+    const displayCategory = i18n.getText(
+      `categories.${this.performanceCategory}`
+    );
+    this.container.classList.add(this.performanceCategory);
+    this.category.textContent = displayCategory;
 
     const score = (data.numericValue / unit.conversion).toFixed(unit.digits);
     this.score.textContent = `${score} ${unit.name}`;


### PR DESCRIPTION
Prior to this PR the comparison to surface "Nothing to do" versus "File an issue on GH" for individual metrics' "Take action" field -- we are checking `"Fast" === "fast"` which always failed... Now we are comparing the correct lowercase, non-translated value. :) 

Fixes #4619