### PR TITLE
Revert "♻️ Stop replacing HTML entities in Pixi"

### DIFF
--- a/pixi/src/utils/texts.js
+++ b/pixi/src/utils/texts.js
@@ -12,17 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const htmlEntityMapping = {
+  // we will not use the html inside attributes
+  // so here we can use the normal characters...
+  '&quot;': '"',
+  '&#39;': "'",
+  // since the following caracters can not be used unescaped
+  // we use unicode replacements...
+  '&gt;': '\uFE65', // small greater than sign
+  '&lt;': '\uFE64', // small less than sign
+  '&amp;': '\uFF06', // fullwidth ampersand
+};
+
+const entitySearchPattern = new RegExp(
+  Object.keys(htmlEntityMapping).join('|'),
+  'g'
+);
+
 /**
- * This method is a workaround for
- * https://github.com/ampproject/amphtml/issues/30273
+ * This method is a workaround for this bug: https://github.com/ampproject/amphtml/issues/27153
+ * and this bug: https://github.com/ampproject/amphtml/issues/30273
  *
+ * It replaces the html entities that are required when escaping text for html
+ * so that can the code can be used with amp-script as innerHtml but not as attributes.
  * Also all empty span tags (which are created by grow markdown.extensions.codehilite) are removed.
  */
 export const cleanCodeForInnerHtml = (html) => {
   if (!html) {
     return '';
   }
-  return html.replace(/<span>\s*<\/span>/g, '');
+  const result = html.replace(
+    entitySearchPattern,
+    (match) => htmlEntityMapping[match]
+  );
+  return result.replace(/<span>\s*<\/span>/g, '');
 };
 
 /**

--- a/pixi/src/utils/texts.test.js
+++ b/pixi/src/utils/texts.test.js
@@ -1,6 +1,11 @@
 import {cleanCodeForInnerHtml, addTargetBlankToLinks} from './texts';
 
 describe('cleanCodeForInnerHtml', () => {
+  it('converts specific html entities', async () => {
+    const result = cleanCodeForInnerHtml('&#39; &quot; &amp; &lt; &gt;');
+    expect(result.trim()).toEqual('\' " \uFF06 \uFE64 \uFE65');
+  });
+
   it('removes empty span tags', async () => {
     const result = cleanCodeForInnerHtml('<pre><span> </span></pre>');
     expect(result.trim()).toEqual('<pre></pre>');

--- a/platform/lib/routers/growPages.js
+++ b/platform/lib/routers/growPages.js
@@ -252,10 +252,6 @@ growPages.get(/^(.*\/)?([^\/\.]+|.+\.html|.*\/|$)$/, async (req, res, next) => {
       const params = {
         experimentEsm,
         preloadHeroImage,
-        rtv: true,
-        // TODO: Revert once this is the production release
-        // to be evergreen again
-        ampRuntimeVersion: '002009190410000',
       };
       renderedTemplate = await optimizer.transformHtml(
         renderedTemplate,


### PR DESCRIPTION
Reverts ampproject/amp.dev#4649, setting specific RTVs is invalid AMP.