### PR TITLE
Pixi: Remove GH issue link from status when there are recommendations to give

### DIFF
--- a/pages/content/pixi/status-banners/cache-failed-no-info.md
+++ b/pages/content/pixi/status-banners/cache-failed-no-info.md
@@ -3,4 +3,4 @@ $title: Your cached AMP page needs improvement(s).
 type: error
 ---
 
-Your AMP page from origin has a good [page experience](https://developers.google.com/search/docs/guides/page-experience), but the cached AMP page needs work. Don't fret, we have some recommendations to help you improve! However, since it's rare that we see a cached AMP page fail page experience. Please [file a GitHub issue](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type:+Page+experience&template=page-experience.md&title=Page+experience+issue) so that we can take a look and see how AMP can help.
+Your AMP page from origin has a good [page experience](https://developers.google.com/search/docs/guides/page-experience), but the cached AMP page needs work. Don't fret, we have some recommendations to help you improve! However, it's rare that we see a cached AMP page fail page experience. Please [file a GitHub issue](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type:+Page+experience&template=page-experience.md&title=Page+experience+issue) so that we can take a look and see how AMP can help.

--- a/pages/content/pixi/status-banners/cache-failed-with-info.md
+++ b/pages/content/pixi/status-banners/cache-failed-with-info.md
@@ -3,4 +3,4 @@ $title: Your cached AMP page needs improvement(s).
 type: error
 ---
 
-Your AMP page from origin has a good [page experience](https://developers.google.com/search/docs/guides/page-experience), but the cached AMP page needs work. Don't fret, we have some recommendations to help you improve! However, since it's rare that we see a cached AMP page fail page experience. Please [file a GitHub issue](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type:+Page+experience&template=page-experience.md&title=Page+experience+issue) so that we can take a look and see how AMP can help.
+Your AMP page from origin has a good [page experience](https://developers.google.com/search/docs/guides/page-experience), but the cached AMP page needs work. Don't fret, we have some recommendations to help you improve! However, it's rare that we see a cached AMP page fail page experience. Please [file a GitHub issue](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type:+Page+experience&template=page-experience.md&title=Page+experience+issue) so that we can take a look and see how AMP can help.

--- a/pages/content/pixi/status-banners/failed-no-info.md
+++ b/pages/content/pixi/status-banners/failed-no-info.md
@@ -4,4 +4,6 @@ type: error
 ---
 
 Unfortunately, this page has a poor
-[page experience](https://developers.google.com/search/docs/guides/page-experience). Don't fret, we have some recommendations to help you improve! However, since it's rare that we see a cached AMP page fail page experience. Please [file a GitHub issue](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type:+Page+experience&template=page-experience.md&title=Page+experience+issue) so that we can take a look and see how AMP can help.
+[page experience](https://developers.google.com/search/docs/guides/page-experience) and we have no
+recommendations to offer. Sorry about that!
+Please [file a GitHub issue](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type%3A+Page+experience&template=page-experience.md&title=Page+experience+issue) so that we can take a look and see how AMP can improve.

--- a/pages/content/pixi/status-banners/failed-with-info.md
+++ b/pages/content/pixi/status-banners/failed-with-info.md
@@ -4,4 +4,4 @@ type: error
 ---
 
 Unfortunately, this page has a poor
-[page experience](https://developers.google.com/search/docs/guides/page-experience). Don't fret, we have some recommendations to help you improve! However, since it's rare that we see a cached AMP page fail page experience. Please [file a GitHub issue](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type:+Page+experience&template=page-experience.md&title=Page+experience+issue) so that we can take a look and see how AMP can help.
+[page experience](https://developers.google.com/search/docs/guides/page-experience). Don't fret, we have some recommendations to help you improve!


### PR DESCRIPTION
Fixes #4662
- Also removes `since` from the other edited files wherein it was making it not a sentence.