### PR TITLE
🎨 Let remote documents not break build

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-actions-and-events.md
@@ -63,9 +63,9 @@ See the table below for descriptions of each part of the syntax.
   <tr>
     <td><code>targetId</code></td>
     <td>yes</td>
-    <td>This is the DOM id for the element, or a predefined <a href="#special-targets">special target</a> you'd like to execute an action on  in response to the event. In the following example, the <code>targetId</code> is the DOM id of the <code>amp-lightbox</code> target, <code>photo-slides</code>.<br>
-    <code>&lt;amp-lightbox id="photo-slides">&lt;/amp-lightbox>
-&lt;button on="tap:photo-slides">Show Images&lt;/button></code>
+    <td>This is the DOM id for the element, or a predefined <a href="#special-targets">special target</a> you'd like to execute an action on  in response to the event. In the following example, the <code>targetId</code> is the DOM id of the <code>amp-lightbox</code> target, <code>photo-slides</code>.
+    <pre>&lt;amp-lightbox id="photo-slides">&lt;/amp-lightbox>
+&lt;button on="tap:photo-slides">Show Images&lt;/button></pre>
     </td>
   </tr>
   <tr>
@@ -154,10 +154,10 @@ For example, the following is possible in AMP:
     </td>
     <td><code>input</code></td>
     <td>
-      <code>event.min</code>
-      <code>event.max</code>
-      <code>event.value</code>
-      <code>event.valueAsNumber</code>
+      <pre>event.min
+event.max
+event.value
+event.valueAsNumber</pre>
     </td>
   </tr>
   <tr>
@@ -169,9 +169,9 @@ For example, the following is possible in AMP:
   <tr>
     <td><code>select</code></td>
     <td>
-      <code>event.min</code>
-      <code>event.max</code>
-      <code>event.value</code>
+      <pre>event.min
+event.max
+event.value</pre>
     </td>
   </tr>
   <!-- input-debounced -->
@@ -221,9 +221,8 @@ For example, the following is possible in AMP:
   <tr>
     <td><code>slideChange</code></td>
     <td>Fired when the carousel's current slide changes.</td>
-    <td>Slide number.<br>
-      <code>event.index</code>
-    </td>
+    <td><pre>// Slide number.
+event.index</pre></td>
   </tr>
 </table>
 
@@ -277,10 +276,11 @@ For example, the following is possible in AMP:
   <tr>
     <td><code>select</code></td>
     <td>Fired when an option is selected or deselected.</td>
-    <td>Target element's "option" attribute value.
-<code>event.targetOption</code><br>
-Array of "option" attribute values of all selected elements.
-<code>event.selectedOptions</code></td>
+    <td><pre>// Target element's "option" attribute value.
+event.targetOption
+
+// Array of "option" attribute values of all selected elements.
+event.selectedOptions</pre></td>
 
   </tr>
 </table>
@@ -356,16 +356,14 @@ Array of "option" attribute values of all selected elements.
   <tr>
     <td><code>submit-success</code></td>
     <td>Fired when the form submission response is success.</td>
-    <td>Response JSON.<br>
-        <code>event.response</code>
-    </td>
+    <td><pre>// Response JSON.
+event.response</pre></td>
   </tr>
   <tr>
     <td><code>submit-error</code></td>
     <td>Fired when the form submission response is an error.</td>
-    <td>Response JSON.<br>
-      <code>event.response</code>
-    </td>
+    <td><pre>// Response JSON.
+event.response</pre></td>
   </tr>
   <tr>
     <td><code>valid</code></td>
@@ -720,11 +718,17 @@ actions that apply to the whole document.
   </tr>
   <tr>
     <td><code>navigateTo(url=STRING, target=STRING, opener=BOOLEAN)</code></td>
-    <td>Navigates current window to given URL, to the optional specified target if given (currenly only supporting <code>_top</code> and <code>_blank </code>). The optional <code>opener</code> parameter can be specified when using a target of <code>_blank</code> to allow the newly opened page to access <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/opener"><code>window.opener<code></a>. Supports <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md">standard URL substitutions</a>.</td>
+    <td>
+      <p>Navigates current window to given URL, to the optional specified target if given (currenly only supporting <code>_top</code> and <code>_blank </code>). The optional <code>opener</code> parameter can be specified when using a target of <code>_blank</code> to allow the newly opened page to access <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/opener"><code>window.opener</code></a>. Supports <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md">standard URL substitutions</a>.</p>
+      <p><strong>Caveat:</strong> Using normal <code>&lt;a&gt;</code> links is recommended wherever possible since <code>AMP.navigateTo</code> is not recognized by web crawlers.</p>
+    </td>
   </tr>
   <tr>
     <td><code>closeOrNavigateTo(url=STRING, target=STRING, opener=BOOLEAN)</code></td>
-    <td>Tries to close the window if allowed, otherwise it navigates similar to <code>navigateTo</code> Action. Useful for use-cases where a "Back" button may need to close the window if it were opened in a new window from previous page or navigate if it wasn't opened.</td>
+    <td>
+      <p>Tries to close the window if allowed, otherwise it navigates similar to <code>navigateTo</code> Action. Useful for use-cases where a "Back" button may need to close the window if it were opened in a new window from previous page or navigate if it wasn't opened.</p>
+      <p><strong>Caveat:</strong> Using normal <code>&lt;a&gt;</code> links is recommended wherever possible since <code>AMP.closeOrNavigateTo</code> is not recognized by web crawlers.</p>
+    </td>
   </tr>
   <tr>
     <td><code>goBack</code></td>

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-email-actions-and-events.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-email-actions-and-events.md
@@ -560,4 +560,4 @@ actions that apply to the whole document.
   </tr>
 </table>
 
-<sup>1</sup>When used with <a href="#multiple-actions-for-one-event">multiple actions</a>, subsequent actions will wait for <code>setState()</code> or <code>pushState()</code> to complete before invocation. Only a single <code>setState()</code> or <code>pushState()</code> is allowed per event.
+<sup>1</sup>When used with <a href="#multiple-actions-for-one-event">multiple actions</a>, subsequent actions will wait for <code>setState()</code> to complete before invocation. Only a single <code>setState()</code> is allowed per event.

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-format.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-format.md
@@ -68,7 +68,7 @@ An AMP email message MUST
 - <a name="scrpt"></a>contain a `<script async src="https://cdn.ampproject.org/v0.js"></script>` tag inside their head tag. [🔗](#scrpt)
 - <a name="boilerplate"></a>contain amp4email boilerplate (`<style amp4email-boilerplate>body{visibility:hidden}</style>`) inside their head tag to initially hide the content until AMP JS is loaded. [🔗](#boilerplate)
 
-The entire AMPHTML markup must not exceed 102,400 bytes.
+The entire AMPHTML markup must not exceed 200,000 bytes.
 
 ## Structure and rendering <a name="structure-and-rendering"></a>
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state.md
@@ -1,6 +1,6 @@
 ---
 $title: Manage non-authenticated user state with AMP
-$order: 1000
+order: 2
 formats:
   - websites
 teaser:
@@ -29,6 +29,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+
 
 **Table of contents**
 
@@ -156,7 +158,7 @@ In walking through the technical guidance below, let's assume that you’ll be b
 For clarity throughout the rest of this document, we’ll call various strings of characters that are identifiers by more readable names preceded by a dollar sign (`$`):
 
 [sourcecode:text]
-n34ic982n2386n30 ⇒ \$sample_id
+n34ic982n2386n30 ⇒ $sample_id
 [/sourcecode]
 
 **Our use case:** Throughout this guide we will work on an example designed to achieve simple pageview tracking (i.e., analytics) in which we want to produce the most accurate user counting possible. This means that even if the user is accessing a particular publisher’s content from different contexts (including crossing between AMP and non-AMP pages), we want these visits to be counted toward a singular understanding of the user that is the same as if the user were browsing only on such publisher’s traditional non-AMP pages.
@@ -186,26 +188,23 @@ This means there are two cases for the state of non-AMP pages on the publisher o
 **Case #1: Initial visit.** Upon first landing on the non-AMP page, there will be no cookie. If you checked for the cookie before one was set, you’d see no values set in the cookie corresponding to the `uid`:
 
 [sourcecode:bash]
-
 > document.cookie
-> ""
-> [/sourcecode]
+  ""
+[/sourcecode]
 
 Sometime in the initial load, the cookie should be set, so that if you do this once the page is loaded, you will see a value has been set:
 
 [sourcecode:bash]
-
 > document.cookie
-> "uid=\$publisher_origin_identifier"
-> [/sourcecode]
+  "uid=$publisher_origin_identifier"
+[/sourcecode]
 
 **Case #2: Non-initial visit.** There will be a cookie set. Thus, if you open the developer console on the page, you’d see:
 
 [sourcecode:bash]
-
 > document.cookie
-> "uid=\$publisher_origin_identifier"
-> [/sourcecode]
+  "uid=$publisher_origin_identifier"
+[/sourcecode]
 
 ##### Send analytics pings <a name="send-analytics-pings"></a>
 
@@ -220,7 +219,7 @@ https://analytics.example.com/ping?type=pageview&user_id=$publisher_origin_ident
 Note that in the above example the identifier for the user is indicated by a specific query param, `user_id`:
 
 [sourcecode:text]
-user_id=\$publisher_origin_identifier
+user_id=$publisher_origin_identifier
 [/sourcecode]
 
 The use of “`user_id`” here should be determined by what your analytics server expects to process and is not specifically tied to what you call the cookie that stores the identifier locally.
@@ -397,33 +396,30 @@ Our approach will take advantage of two types of [AMP variable substitutions](ht
 
 [sourcecode:html]
 <a
-href="https://example.com/step2.html?ref_id=CLIENT_ID(uid)"
-data-amp-replace="CLIENT_ID"
-
-> </a>
-> [/sourcecode]
+  href="https://example.com/step2.html?ref_id=CLIENT_ID(uid)"
+  data-amp-replace="CLIENT_ID"
+></a>
+[/sourcecode]
 
 **Alternative solution for passing Client ID to the outgoing links:** Define the new query parameter `ref_id` as part of the data attribute `data-amp-addparams` and for queries that needs parameter substitution provide those details as part of `data-amp-replace`. With this approach the URL would look clean and the parameters specified on `data-amp-addparams` will be dynamically added
 
 [sourcecode:html]
 <a
-href="https://example.com/step2.html"
-data-amp-addparams="ref_id=CLIENT_ID(uid)"
-data-amp-replace="CLIENT_ID"
-
-> </a>
-> [/sourcecode]
+  href="https://example.com/step2.html"
+  data-amp-addparams="ref_id=CLIENT_ID(uid)"
+  data-amp-replace="CLIENT_ID"
+></a>
+[/sourcecode]
 
 For passing multiple query parameters through `data-amp-addparams` have those `&` separated like
 
 [sourcecode:html]
 <a
-href="https://example.com/step2.html"
-data-amp-addparams="ref_id=CLIENT_ID(uid)&pageid=p123"
-data-amp-replace="CLIENT_ID"
-
-> </a>
-> [/sourcecode]
+  href="https://example.com/step2.html"
+  data-amp-addparams="ref_id=CLIENT_ID(uid)&pageid=p123"
+  data-amp-replace="CLIENT_ID"
+></a>
+[/sourcecode]
 
 **To update form inputs to use a Client ID substitution:** Define a name for the input field, such as `orig_user_id`. Specify the `default-value` of the form field to be the value of AMP’s Client ID substitution:
 

--- a/pages/content/amp-dev/support/index.md
+++ b/pages/content/amp-dev/support/index.md
@@ -32,7 +32,7 @@ If you are looking for help to get started using AMP on your site or you are hav
 - [Pre-styled templates and components](https://amp.dev/documentation/templates/) that you can use to create styled AMP sites from scratch.
 - [AMP tools](https://amp.dev/documentation/tools) helping you get started with building AMP pages.
 - [AMP supported browsers](https://amp.dev/support/faq/supported-browsers) to learn which browsers support AMP.
-- [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP; since members of the AMP Project community regularly monitor Stack Overflow you will probably receive the fastest response to your questions there.
+- [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP. Since members of the AMP Project community regularly monitor Stack Overflow, you will probably receive the fastest response to your questions there.
 - For AMP on Google Search questions or issues, please use [Google's AMP forum](https://goo.gl/utQ1KZ).
 - To check the status of AMP serving and its related services, see the [AMP Status](https://status.ampproject.org/) page.
 

--- a/pages/shared/data/recent-guides.yaml
+++ b/pages/shared/data/recent-guides.yaml
@@ -1,3 +1,11 @@
+- path: /content/amp-dev/documentation/guides-and-tutorials/learn/cors-in-email.md
+  date: '2020-09-15 17:04:24 +0100'
+- path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-optimizer-guide/explainer.md
+  date: '2020-08-14 13:04:30 +0200'
+- path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-optimizer-guide/index.md
+  date: '2020-08-14 13:04:30 +0200'
+- path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-optimizer-guide/node-amp-optimizer.md
+  date: '2020-08-14 13:04:30 +0200'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/email_sender_distribution.md
   date: '2020-06-18 00:18:31 -0700'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/amp-email-actions-and-events.md
@@ -44,8 +52,6 @@
   date: '2019-06-27 08:15:24 +0200'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure.md
   date: '2019-06-27 08:15:24 +0200'
-- path: /content/amp-dev/documentation/guides-and-tutorials/optimize-measure/server-side-rendering.md
-  date: '2019-06-05 18:32:02 +0200'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-format.md
   date: '2019-06-04 19:47:32 +0100'
 - path: /content/amp-dev/documentation/guides-and-tutorials/develop/custom-javascript-tutorial.md
@@ -242,18 +248,6 @@
   date: '2018-12-01 01:12:23 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate.md
   date: '2018-12-01 01:12:23 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/building-page.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/congratulations.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/discoverable.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/index.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/resolving-errors.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/setting-up.md
-  date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/adding_carousels.md
   date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/adding_components.md
@@ -272,6 +266,18 @@
   date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/tracking_data.md
   date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/building-page.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/congratulations.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/discoverable.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/index.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/resolving-errors.md
+  date: '2018-11-30 08:03:59 -0800'
+- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/setting-up.md
+  date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/create/basic_markup.md
   date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/create/include_image.md
@@ -285,16 +291,4 @@
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/create/preview_and_validate.md
   date: '2018-11-30 08:03:59 -0800'
 - path: /content/amp-dev/documentation/guides-and-tutorials/start/create/publish.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/building-page.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/congratulations.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/discoverable.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/index.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/resolving-errors.md
-  date: '2018-11-30 08:03:59 -0800'
-- path: /content/amp-dev/documentation/guides-and-tutorials/start/converting/setting-up.md
   date: '2018-11-30 08:03:59 -0800'

--- a/platform/lib/tools/growReferenceChecker.js
+++ b/platform/lib/tools/growReferenceChecker.js
@@ -322,10 +322,11 @@ class GrowReferenceChecker {
     if (errorLocales.length > 0) {
       if (
         IMPORTED_DOCS.includes(sourcePath) ||
-        (sourcePath.match(IGNORED_PATH_PATTERNS) && !sourcePath.includes('@'))
+        sourcePath.match(IGNORED_PATH_PATTERNS) ||
+        sourcePath.includes('@')
       ) {
         log.warn(
-          'anchor not found in imported document',
+          'anchor not found in imported/translated document',
           anchor,
           '\n',
           'found in:',


### PR DESCRIPTION
Currently imported documents can break amp.dev's build if they contain invalid anchors. This problem extends to translated documents as they are not checked for integrity during translation.

This PR updates all imported documents and lets translated documents (containing a `@` in their filename) bypass the checks.