### PR TITLE
♻️ Run linter check first and in blocking manner for Pixi

### DIFF
--- a/pixi/src/ui/PageExperience.js
+++ b/pixi/src/ui/PageExperience.js
@@ -78,10 +78,7 @@ export default class PageExperience {
     // checks superfluous
     const linter = await linterPromise;
     if (!linter.isLoaded || !linter.isAmp || !linter.isOriginUrl) {
-      this.runStatusBannerResult(
-        pageUrl,
-        {linter: linterPromise}
-      );
+      this.runStatusBannerResult(pageUrl, {linter: linterPromise});
 
       this.running = false;
       return;
@@ -125,24 +122,25 @@ export default class PageExperience {
     this.running = false;
   }
 
-  async runStatusBannerResult(
-    pageUrl,
-    checkPromises,
-    recommendationsPromise
-  ) {
-    checkPromises = Object.assign({}, {
-      pageExperience: Promise.resolve({}),
-      linter: Promise.resolve({}),
-      mobileFriendliness: Promise.resolve({}),
-      safeBrowsing: Promise.resolve({}),
-    }, checkPromises);
-    recommendationsPromise = recommendationsPromise || Promise.resolve({});
+  async runStatusBannerResult(pageUrl, checkPromises, recommendationsPromise) {
+    checkPromises = Object.assign(
+      {},
+      {
+        pageExperience: Promise.resolve({}),
+        linter: Promise.resolve({}),
+        mobileFriendliness: Promise.resolve({}),
+        safeBrowsing: Promise.resolve({}),
+      },
+      checkPromises
+    );
+    recommendationsPromise = recommendationsPromise || Promise.resolve({});
 
     try {
       // remember the current instance to ensure the promises will not modify a future instance
       const statusView = this.statusIntroView;
       const statusBannerIdPromise = getStatusId(
-        checkPromises, recommendationsPromise
+        checkPromises,
+        recommendationsPromise
       );
 
       checkPromises.linter.then(() => {

--- a/pixi/src/ui/PageExperience.js
+++ b/pixi/src/ui/PageExperience.js
@@ -73,6 +73,20 @@ export default class PageExperience {
     this.running = true;
 
     const linterPromise = this.runLintCheck(pageUrl);
+
+    // Early exit if the linter returned hard fails that make the other
+    // checks superfluous
+    const linter = await linterPromise;
+    if (!linter.isLoaded || !linter.isAmp || !linter.isOriginUrl) {
+      this.runStatusBannerResult(
+        pageUrl,
+        {linter: linterPromise}
+      );
+
+      this.running = false;
+      return;
+    }
+
     this.pageExperienceCheck.setLocale(i18n.getLanguage());
     const pageExperiencePromise = this.runPageExperienceCheck(
       pageUrl,
@@ -90,10 +104,12 @@ export default class PageExperience {
 
     this.runStatusBannerResult(
       pageUrl,
-      pageExperiencePromise,
-      linterPromise,
-      mobileFriendlinessPromise,
-      safeBrowsingPromise,
+      {
+        linter: linterPromise,
+        pageExperience: pageExperiencePromise,
+        safeBrowsing: safeBrowsingPromise,
+        mobileFriendliness: mobileFriendlinessPromise,
+      },
       recommendationsPromise
     );
 
@@ -111,45 +127,48 @@ export default class PageExperience {
 
   async runStatusBannerResult(
     pageUrl,
-    pageExperiencePromise,
-    linterPromise,
-    mobileFriendlinessPromise,
-    safeBrowsingPromise,
+    checkPromises,
     recommendationsPromise
   ) {
+    checkPromises = Object.assign({}, {
+      pageExperience: Promise.resolve({}),
+      linter: Promise.resolve({}),
+      mobileFriendliness: Promise.resolve({}),
+      safeBrowsing: Promise.resolve({}),
+    }, checkPromises);
+    recommendationsPromise = recommendationsPromise || Promise.resolve({});
+
     try {
       // remember the current instance to ensure the promises will not modify a future instance
       const statusView = this.statusIntroView;
       const statusBannerIdPromise = getStatusId(
-        recommendationsPromise,
-        pageExperiencePromise,
-        safeBrowsingPromise,
-        linterPromise,
-        mobileFriendlinessPromise
+        checkPromises, recommendationsPromise
       );
-      linterPromise.then(() => {
+
+      checkPromises.linter.then(() => {
         statusView.increaseFinishedChecks(AmpLinterCheck.getCheckCount());
       });
-      pageExperiencePromise.then(() => {
+      checkPromises.pageExperience.then(() => {
         statusView.increaseFinishedChecks(PageExperienceCheck.getCheckCount());
       });
-      mobileFriendlinessPromise.then(() => {
+      checkPromises.mobileFriendliness.then(() => {
         statusView.increaseFinishedChecks(
           MobileFriendlinessCheck.getCheckCount()
         );
       });
-      safeBrowsingPromise.then(() => {
+      checkPromises.safeBrowsing.then(() => {
         statusView.increaseFinishedChecks(SafeBrowsingCheck.getCheckCount());
       });
+
       statusView.render(statusBannerIdPromise, recommendationsPromise, pageUrl);
       await statusBannerIdPromise;
     } catch (error) {
-      console.error('unable to get page status', error);
+      console.error('Unable to get page status', error);
     }
     this.toggleLoading(false);
   }
 
-  async runPageExperienceCheck(pageUrl, linterDataPromise) {
+  async runPageExperienceCheck(pageUrl, linterPromise) {
     // Initialize views before running the check to be able
     // to toggle the loading state
     this.reportViews.pageExperience =
@@ -159,7 +178,7 @@ export default class PageExperience {
 
     const reportPromise = this.pageExperienceCheck.run(pageUrl);
 
-    const linter = await linterDataPromise;
+    const linter = await linterPromise;
     let cacheReport = null;
     if (!linter.isAmp || !linter.isValid || !linter.isOriginUrl) {
       cacheReport = Promise.resolve({data: {}});

--- a/pixi/src/ui/StatusIntroView.js
+++ b/pixi/src/ui/StatusIntroView.js
@@ -21,7 +21,7 @@ const UNFIXABLE_ERROR_IDS = [
   'invalid-url',
   'no-amp',
   'amp-cache-url',
-  'generic-error'
+  'generic-error',
 ];
 
 const CLASS_NAME_MAP = {

--- a/pixi/src/ui/StatusIntroView.js
+++ b/pixi/src/ui/StatusIntroView.js
@@ -104,7 +104,7 @@ export default class StatusIntroView {
       investigateButton.setAttribute('href', statusBanner.investigate);
       investigateButton.classList.remove('pristine');
     }
-    if (hideFixButton === true) {
+    if (hideFixButton) {
       const fixItButton = banner.querySelector('#fix-it-button');
       fixItButton.classList.add('pristine');
       // make second button primary

--- a/pixi/src/utils/checkAggregation/statusBanner.js
+++ b/pixi/src/utils/checkAggregation/statusBanner.js
@@ -14,10 +14,7 @@
 
 import {fixedRecommendations} from './recommendations';
 
-async function getStatusId (
-  checkPromises,
-  recommendationsPromise
-) {
+async function getStatusId(checkPromises, recommendationsPromise) {
   try {
     const linter = await checkPromises.linter;
     if (!linter.isLoaded) {

--- a/pixi/src/utils/checkAggregation/statusBanner.js
+++ b/pixi/src/utils/checkAggregation/statusBanner.js
@@ -14,15 +14,12 @@
 
 import {fixedRecommendations} from './recommendations';
 
-const getStatusId = async (
-  recommendationsPromise,
-  pageExperiencePromise,
-  safeBrowsingPromise,
-  linterPromise,
-  mobileFriendlinessPromise
-) => {
+async function getStatusId (
+  checkPromises,
+  recommendationsPromise
+) {
   try {
-    const linter = await linterPromise;
+    const linter = await checkPromises.linter;
     if (!linter.isLoaded) {
       return 'invalid-url';
     }
@@ -42,9 +39,9 @@ const getStatusId = async (
       mobileFriendliness,
     ] = await Promise.all([
       recommendationsPromise,
-      pageExperiencePromise,
-      safeBrowsingPromise,
-      mobileFriendlinessPromise,
+      checkPromises.pageExperience,
+      checkPromises.safeBrowsing,
+      checkPromises.mobileFriendliness,
     ]);
 
     if (!linter.isValid) {
@@ -105,6 +102,6 @@ const getStatusId = async (
   } catch (err) {
     return 'generic-error';
   }
-};
+}
 
 export default getStatusId;

--- a/pixi/src/utils/checkAggregation/statusBanner.test.js
+++ b/pixi/src/utils/checkAggregation/statusBanner.test.js
@@ -21,39 +21,33 @@ const passedSafeBrowsingPromise = Promise.resolve({
 
 describe('getStatusId', () => {
   it('returns invalid-url', async () => {
-    const statusId = await getStatusId(
-      {
-        linter: Promise.resolve({
-          isLoaded: false,
-        }),
-      }
-    );
+    const statusId = await getStatusId({
+      linter: Promise.resolve({
+        isLoaded: false,
+      }),
+    });
     expect(statusId).toBe('invalid-url');
   });
 
   it('returns no-amp', async () => {
-    const statusId = await getStatusId(
-      {
-        linter: Promise.resolve({
-          isLoaded: true,
-          isAmp: false,
-          isOriginUrl: true,
-        }),
-      }
-    );
+    const statusId = await getStatusId({
+      linter: Promise.resolve({
+        isLoaded: true,
+        isAmp: false,
+        isOriginUrl: true,
+      }),
+    });
     expect(statusId).toBe('no-amp');
   });
 
   it('returns amp-cache-url', async () => {
-    const statusId = await getStatusId(
-      {
-        linter: Promise.resolve({
-          isLoaded: true,
-          isAmp: true,
-          isOriginUrl: false,
-        }),
-      }
-    );
+    const statusId = await getStatusId({
+      linter: Promise.resolve({
+        isLoaded: true,
+        isAmp: true,
+        isOriginUrl: false,
+      }),
+    });
     expect(statusId).toBe('amp-cache-url');
   });
 
@@ -367,7 +361,7 @@ describe('getStatusId', () => {
               isAllFast: true,
             },
             source: 'fieldData',
-          }
+          },
         }),
       },
       Promise.resolve(fixedRecommendations)
@@ -390,7 +384,7 @@ describe('getStatusId', () => {
               isAllFast: true,
             },
             source: 'fieldData',
-          }
+          },
         }),
       },
       Promise.resolve(fixedRecommendations)

--- a/pixi/src/utils/checkAggregation/statusBanner.test.js
+++ b/pixi/src/utils/checkAggregation/statusBanner.test.js
@@ -22,457 +22,485 @@ const passedSafeBrowsingPromise = Promise.resolve({
 describe('getStatusId', () => {
   it('returns invalid-url', async () => {
     const statusId = await getStatusId(
-      pendingPromise,
-      pendingPromise,
-      pendingPromise,
-      Promise.resolve({
-        isLoaded: false,
-      }),
-      pendingPromise
+      {
+        linter: Promise.resolve({
+          isLoaded: false,
+        }),
+      }
     );
     expect(statusId).toBe('invalid-url');
   });
 
   it('returns no-amp', async () => {
     const statusId = await getStatusId(
-      pendingPromise,
-      pendingPromise,
-      pendingPromise,
-      Promise.resolve({
-        isLoaded: true,
-        isAmp: false,
-        isOriginUrl: true,
-      }),
-      pendingPromise
+      {
+        linter: Promise.resolve({
+          isLoaded: true,
+          isAmp: false,
+          isOriginUrl: true,
+        }),
+      }
     );
     expect(statusId).toBe('no-amp');
   });
 
   it('returns amp-cache-url', async () => {
     const statusId = await getStatusId(
-      pendingPromise,
-      pendingPromise,
-      pendingPromise,
-      Promise.resolve({
-        isLoaded: true,
-        isAmp: true,
-        isOriginUrl: false,
-      }),
-      pendingPromise
+      {
+        linter: Promise.resolve({
+          isLoaded: true,
+          isAmp: true,
+          isOriginUrl: false,
+        }),
+      }
     );
     expect(statusId).toBe('amp-cache-url');
   });
 
   it('returns invalid-amp', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: true,
+      {
+        linter: Promise.resolve({
+          isLoaded: true,
+          isAmp: true,
+          isOriginUrl: true,
+          isValid: false,
+        }),
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: true,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      Promise.resolve({
-        isLoaded: true,
-        isAmp: true,
-        isOriginUrl: true,
-        isValid: false,
-      }),
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('invalid-amp');
   });
 
   it('returns cache-failed-no-info based on field data', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: true,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: true,
+          pageExperienceCached: {
+            fieldData: {
+              isAllFast: false,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          source: 'fieldData',
-        },
-        pageExperienceCached: {
-          fieldData: {
-            isAllFast: false,
-          },
-          labData: {
-            isAllFast: true,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('cache-failed-no-info');
   });
 
   it('returns cache-failed-no-info based on lab data', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {
-          labData: {
-            isAllFast: true,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            labData: {
+              isAllFast: true,
+            },
+            source: 'labData',
           },
-          source: 'labData',
-        },
-        pageExperienceCached: {
-          fieldData: {
-            isAllFast: true,
+          pageExperienceCached: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: false,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: false,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('cache-failed-no-info');
   });
 
   it('returns cache-failed-with-info based on field data', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(['one-more', ...fixedRecommendations]),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: true,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: true,
+          pageExperienceCached: {
+            fieldData: {
+              isAllFast: false,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          source: 'fieldData',
-        },
-        pageExperienceCached: {
-          fieldData: {
-            isAllFast: false,
-          },
-          labData: {
-            isAllFast: true,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(['one-more', ...fixedRecommendations])
     );
     expect(statusId).toBe('cache-failed-with-info');
   });
 
   it('returns cache-failed-with-info based on lab data', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(['one-more', ...fixedRecommendations]),
-      Promise.resolve({
-        pageExperience: {
-          labData: {
-            isAllFast: true,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            labData: {
+              isAllFast: true,
+            },
+            source: 'labData',
           },
-          source: 'labData',
-        },
-        pageExperienceCached: {
-          fieldData: {
-            isAllFast: true,
+          pageExperienceCached: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: false,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: false,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(['one-more', ...fixedRecommendations])
     );
     expect(statusId).toBe('cache-failed-with-info');
   });
 
   it('returns origin-failed-no-info for field data', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: false,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: false,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: true,
+          pageExperienceCached: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: false,
+            },
+            source: 'fieldData',
           },
-          source: 'fieldData',
-        },
-        pageExperienceCached: {
-          fieldData: {
-            isAllFast: true,
-          },
-          labData: {
-            isAllFast: false,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('origin-failed-no-info');
   });
 
   it('returns origin-failed-no-info for lab data', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {
-          labData: {
-            isAllFast: false,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            labData: {
+              isAllFast: false,
+            },
+            source: 'labData',
           },
-          source: 'labData',
-        },
-        pageExperienceCached: {
-          fieldData: {
-            isAllFast: false,
+          pageExperienceCached: {
+            fieldData: {
+              isAllFast: false,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: true,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('origin-failed-no-info');
   });
 
   it('returns origin-failed-with-info for field data', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(['one-more', ...fixedRecommendations]),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: false,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: false,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: true,
+          pageExperienceCached: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: false,
+            },
+            source: 'fieldData',
           },
-          source: 'fieldData',
-        },
-        pageExperienceCached: {
-          fieldData: {
-            isAllFast: true,
-          },
-          labData: {
-            isAllFast: false,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(['one-more', ...fixedRecommendations])
     );
     expect(statusId).toBe('origin-failed-with-info');
   });
 
   it('returns origin-failed-with-info for lab data', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(['one-more', ...fixedRecommendations]),
-      Promise.resolve({
-        pageExperience: {
-          labData: {
-            isAllFast: false,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            labData: {
+              isAllFast: false,
+            },
+            source: 'labData',
           },
-          source: 'labData',
-        },
-        pageExperienceCached: {
-          fieldData: {
-            isAllFast: false,
+          pageExperienceCached: {
+            fieldData: {
+              isAllFast: false,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: true,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(['one-more', ...fixedRecommendations])
     );
     expect(statusId).toBe('origin-failed-with-info');
   });
 
   it('returns failed-no-info due to CWV', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: false,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: false,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: true,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('failed-no-info');
   });
 
   it('returns failed-no-info due to safe browsing', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: true,
-          },
-          labData: {
-            isAllFast: true,
-          },
-          source: 'fieldData',
-        },
-      }),
-      Promise.resolve({}),
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: Promise.resolve({}),
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
+          }
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('failed-no-info');
   });
 
   it('returns failed-no-info due to mobile friendly', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: true,
-          },
-          labData: {
-            isAllFast: true,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      Promise.resolve({})
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: Promise.resolve({}),
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
+          }
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('failed-no-info');
   });
 
   it('returns failed-no-info due to linter', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {
-          labData: {
-            isAllFast: true,
+      {
+        linter: Promise.resolve({
+          isLoaded: true,
+          isAmp: true,
+          isOriginUrl: true,
+          isValid: true,
+          usesHttps: false,
+        }),
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            labData: {
+              isAllFast: true,
+            },
+            source: 'labData',
           },
-          source: 'labData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      Promise.resolve({
-        isLoaded: true,
-        isAmp: true,
-        isOriginUrl: true,
-        isValid: true,
-        usesHttps: false,
-      }),
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('failed-no-info');
   });
 
   it('returns failed-with-info', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(['one-more', ...fixedRecommendations]),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: false,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: false,
+            },
+            labData: {
+              isAllFast: true,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: true,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(['one-more', ...fixedRecommendations])
     );
     expect(statusId).toBe('failed-with-info');
   });
 
   it('returns all-passed', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: true,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: false,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: false,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('all-passed');
   });
 
   it('returns passed-with-info', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(['one-more', ...fixedRecommendations]),
-      Promise.resolve({
-        pageExperience: {
-          fieldData: {
-            isAllFast: true,
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {
+            fieldData: {
+              isAllFast: true,
+            },
+            labData: {
+              isAllFast: false,
+            },
+            source: 'fieldData',
           },
-          labData: {
-            isAllFast: false,
-          },
-          source: 'fieldData',
-        },
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+        }),
+      },
+      Promise.resolve(['one-more', ...fixedRecommendations])
     );
     expect(statusId).toBe('passed-with-info');
   });
 
   it('returns generic-error for linter error', async () => {
     const statusId = await getStatusId(
-      pendingPromise,
-      pendingPromise,
-      pendingPromise,
-      Promise.reject(new Error('error')),
+      {
+        linter: Promise.reject(new Error('error')),
+        mobileFriendliness: pendingPromise,
+        safeBrowsing: pendingPromise,
+        pageExperience: pendingPromise,
+      },
       pendingPromise
     );
     expect(statusId).toBe('generic-error');
@@ -480,37 +508,43 @@ describe('getStatusId', () => {
 
   it('returns cwv-error for page experience error', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({error: new Error('error')}),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({error: new Error('error')}),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('cwv-error');
   });
 
   it('returns api-error for safe browsing error', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {},
-      }),
-      Promise.resolve({error: new Error('error')}),
-      passedLinterPromise,
-      passedMobileFriendlinessPromise
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: passedMobileFriendlinessPromise,
+        safeBrowsing: Promise.resolve({error: new Error('error')}),
+        pageExperience: Promise.resolve({
+          pageExperience: {},
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('api-error');
   });
 
   it('returns api-error for mobile friendliness error', async () => {
     const statusId = await getStatusId(
-      Promise.resolve(fixedRecommendations),
-      Promise.resolve({
-        pageExperience: {},
-      }),
-      passedSafeBrowsingPromise,
-      passedLinterPromise,
-      Promise.resolve({error: new Error('error')})
+      {
+        linter: passedLinterPromise,
+        mobileFriendliness: Promise.resolve({error: new Error('error')}),
+        safeBrowsing: passedSafeBrowsingPromise,
+        pageExperience: Promise.resolve({
+          pageExperience: {},
+        }),
+      },
+      Promise.resolve(fixedRecommendations)
     );
     expect(statusId).toBe('api-error');
   });


### PR DESCRIPTION
This PR makes the linter check blocking and prevents other checks from running if it fails. This fixes #4669 and fixes that the "Fix it now" button is visible even if no further results are shown.