### PR TITLE
🚸 Use distinct name attribute for Pixi input bar

### DIFF
--- a/frontend/templates/views/partials/pixi/input-bar.j2
+++ b/frontend/templates/views/partials/pixi/input-bar.j2
@@ -7,7 +7,7 @@
       <input id="input-field"
         class="ap-m-input-bar-input-field"
         type="url"
-        name="url"
+        name="pixi-url"
         placeholder="{{ pixi.staticText.inputBar.fieldPlaceholder }}"
         value="[= query.url =]"
         aria-label="{{ pixi.staticText.inputBar.fieldPlaceholder }}">


### PR DESCRIPTION
Fixes #4641. Currently browsers would show input history for all fields named `url` - giving it distinct name should fix it while keeping the user-benefit of autocomplete.