### PR TITLE
Pixi: Tooltip aria-expanded value should default to "false"

### DIFF
--- a/frontend/templates/views/partials/pixi/tooltip.j2
+++ b/frontend/templates/views/partials/pixi/tooltip.j2
@@ -3,7 +3,7 @@
 <div id="tooltip-{{ tooltip.id|replace(".", "-")  + tooltip.type|default('') }}"
     class="ap-m-tooltip {% if tooltip.invert %}invert{% endif %}">
 
-  <button class="ap-m-tooltip-toggle" aria-expanded="false" [aria-expanded]="tooltipExpanded"
+  <button class="ap-m-tooltip-toggle" aria-expanded="false" [aria-expanded]="tooltipExpanded || 'false'"
       id="tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}-open"
       on="tap:tooltip-{{ tooltip.id|replace(".", "-") + tooltip.type|default('') }}.toggleClass(class=active),AMP.setState({tooltipExpanded: tooltipExpanded == 'true' ? 'false' : 'true'})"
       aria-label="{{ pixi.staticText.infoDialog.open }} {{ info_texts[tooltip.id].title }}">


### PR DESCRIPTION
Prior to this change it has been defaulting to "null"