### PR TITLE
🔧  Enable AGGRESSIVE_BUNDLE for Pixi build

### DIFF
--- a/pixi/src/checks/constants.js
+++ b/pixi/src/checks/constants.js
@@ -17,9 +17,4 @@ const UNIT_DEC = {name: '', conversion: 100, digits: 2};
 const UNIT_SEC = {name: 's', conversion: 1000, digits: 1};
 const UNIT_MS = {name: 'ms', conversion: 1, digits: 0};
 
-export {
-  UNIT_DEFAULT,
-  UNIT_DEC,
-  UNIT_SEC,
-  UNIT_MS,
-};
+export {UNIT_DEFAULT, UNIT_DEC, UNIT_SEC, UNIT_MS};

--- a/pixi/src/checks/constants.js
+++ b/pixi/src/checks/constants.js
@@ -17,7 +17,7 @@ const UNIT_DEC = {name: '', conversion: 100, digits: 2};
 const UNIT_SEC = {name: 's', conversion: 1000, digits: 1};
 const UNIT_MS = {name: 'ms', conversion: 1, digits: 0};
 
-module.exports = {
+export {
   UNIT_DEFAULT,
   UNIT_DEC,
   UNIT_SEC,

--- a/pixi/src/utils/checkAggregation/recommendations.js
+++ b/pixi/src/utils/checkAggregation/recommendations.js
@@ -86,17 +86,10 @@ export default async function getRecommendations(
   linterPromise,
   mobileFriendlinessPromise
 ) {
-  const [
-    pageExperience,
-    safeBrowsing,
-    linter,
-    mobileFriendliness,
-  ] = await Promise.all([
-    pageExperiencePromise,
-    safeBrowsingPromise,
-    linterPromise,
-    mobileFriendlinessPromise,
-  ]);
+  const pageExperience = await pageExperiencePromise;
+  const safeBrowsing = await safeBrowsingPromise;
+  const linter = await linterPromise;
+  const mobileFriendliness = await mobileFriendlinessPromise;
 
   const result = fixedRecommendations.map((id) => ({id}));
 

--- a/pixi/src/utils/checkAggregation/statusBanner.js
+++ b/pixi/src/utils/checkAggregation/statusBanner.js
@@ -29,17 +29,10 @@ async function getStatusId(checkPromises, recommendationsPromise) {
 
     // We need to check all promises for general error
     // (promise can be rejected or error is set in result)
-    const [
-      recommendations,
-      pageExperienceChecks,
-      safeBrowsing,
-      mobileFriendliness,
-    ] = await Promise.all([
-      recommendationsPromise,
-      checkPromises.pageExperience,
-      checkPromises.safeBrowsing,
-      checkPromises.mobileFriendliness,
-    ]);
+    const recommendations = await recommendationsPromise;
+    const pageExperienceChecks = await checkPromises.pageExperience;
+    const safeBrowsing = await checkPromises.safeBrowsing;
+    const mobileFriendliness = await checkPromises.mobileFriendliness;
 
     if (!linter.isValid) {
       return 'invalid-amp';

--- a/pixi/webpack.config.js
+++ b/pixi/webpack.config.js
@@ -19,7 +19,8 @@ module.exports = (env, argv) => {
       publicPath: '/static/page-experience/',
     },
     optimization: {
-      minimizer: [new ClosurePlugin({mode: 'STANDARD'}, {})],
+      minimizer: [new ClosurePlugin({mode: 'AGGRESSIVE_BUNDLE'}, {})],
+      concatenateModules: false,
     },
     devtool: mode == 'development' ? 'cheap-module-source-map' : false,
     plugins: [
@@ -73,13 +74,6 @@ module.exports = (env, argv) => {
     ],
     module: {
       rules: [
-        {
-          test: /\.js$/,
-          exclude: /node_modules/,
-          use: {
-            loader: 'babel-loader',
-          },
-        },
         {
           test: /\.hbs$/,
           loader: 'handlebars-loader',


### PR DESCRIPTION
This disables babel transpilations for Pixi as all JS features we are using (`async`/`await` mainly) are gracefully handled by Closure Compiler already. This brought down bundle size from 110 KiB to 98.7 KiB.

Additionally this PR enables CCs' `AGGRESSIVE_BUNDLE` mode which surprisingly didn't require much work. Savings aren't that big though, it brought down bundle size to 98.2 KiB with slight DX degredations.

We could even further bring it down to by only supporting ES2015 capable browsers (82.4KB) but this would exclude IE11.

Biggest optimization would be to get rid of `marked` though, without it and ES2015+ browser support we would land at 48.6 KiB. Creating a follow-up issue to discuss this.