### PR TITLE
♻️ Do not rely on AMP.getState to get Pixi sharing URL

### DIFF
--- a/frontend/templates/views/partials/pixi/share-dialog.j2
+++ b/frontend/templates/views/partials/pixi/share-dialog.j2
@@ -18,8 +18,8 @@
       <h2 id="share-dialog-title">{{ pixi.staticText.shareDialog.headline }}</h2>
       <input class="ap-m-share-dialog-container-textarea"
           type="text"
-          value=""
-          [value]="pixi.shareUrl"
+          value="{{ doc.url }}"
+          [value]="'{{ doc.url }}?url=' + pixi.shareUrlQuery"
           readonly>
       <amp-iframe class="ap-m-share-dialog-container-copy-button"
           title="{{ pixi.staticText.shareDialog.copyToClipboard }}"
@@ -28,7 +28,7 @@
           layout="fixed"
           sandbox="allow-scripts"
           src="{{ base_url }}/shared/copy-pixi-url/"
-          [src]="'{{ base_url }}/shared/copy-pixi-url/#' + pixi.shareUrl">
+          [src]="'{{ base_url }}/shared/copy-pixi-url/#' + pixi.shareUrlQuery">
         <div placeholder></div>
       </amp-iframe>
     </div>

--- a/pages/content/shared/copy-pixi-url.html
+++ b/pages/content/shared/copy-pixi-url.html
@@ -59,7 +59,7 @@ $sitemap:
       scriptTag.setSelectionRange(0, 99999);
       document.execCommand('copy');
 
-      button.textContent = "{{ pixi.staticText.shareDialog.buttonSuccess }}";
+      button.textContent = "{{ pixi.staticText.shareDialog.success }}";
       setTimeout(function() {
         button.textContent = "{{ pixi.staticText.shareDialog.copyToClipboard }}";
       }, animationDuration);

--- a/pixi/src/ui/StatusIntroView.js
+++ b/pixi/src/ui/StatusIntroView.js
@@ -76,13 +76,7 @@ export default class StatusIntroView {
     }
 
     const statusBanner = i18n.getStatusBanner(statusBannerId);
-    try {
-      const shareUrl = new URL(await AMP.getState('pixi.baseUrl'));
-      shareUrl.searchParams.set('url', pageUrl);
-      AMP.setState({pixi: {shareUrl: shareUrl.toString()}});
-    } catch (e) {
-      console.error('Failed to set share Url from StatusIntroView', e);
-    }
+    AMP.setState({pixi: {shareUrlQuery: encodeURIComponent(pageUrl)}});
 
     this.finishedChecks = null;
     this.container.classList.remove('loading');


### PR DESCRIPTION
Fixes #4458. Even if `AMP.setState` fails the sharing URL would now never be empty.