### PR TITLE
Pixi: Normalize scores of 0 to no decimal places

### DIFF
--- a/pixi/src/ui/report/CoreWebVitalsReportView.js
+++ b/pixi/src/ui/report/CoreWebVitalsReportView.js
@@ -35,9 +35,10 @@ class WeightedScale {
       (data.numericValue / data.proportion.slow) * 100
     );
     this.indicator.style.left = `${Math.round(score)}%`;
-    this.indicator.textContent = `${(
-      data.numericValue / unit.conversion
-    ).toFixed(unit.digits)} ${unit.name}`;
+    const value = data.numericValue / unit.conversion;
+    this.indicator.textContent = `${
+      value === 0 ? value.toFixed(0) : value.toFixed(unit.digits)
+    } ${unit.name}`;
 
     this.resetStyles();
     this.indicator.classList.add(data.category.toLowerCase());
@@ -130,7 +131,8 @@ class CoreWebVitalView {
     this.container.classList.add(this.performanceCategory);
     this.category.textContent = displayCategory;
 
-    const score = (data.numericValue / unit.conversion).toFixed(unit.digits);
+    const value = data.numericValue / unit.conversion;
+    const score = value === 0 ? value.toFixed(0) : value.toFixed(unit.digits);
     this.score.textContent = `${score} ${unit.name}`;
 
     if (this.scale.percentile !== undefined) {


### PR DESCRIPTION
Fixes #4694 

Field data:
![image](https://user-images.githubusercontent.com/10456171/94280177-1a613700-ff1b-11ea-9953-2f582ade5ea7.png)

Lab data:
(Note indicator value also has no decimal places)
![image](https://user-images.githubusercontent.com/10456171/94280195-20571800-ff1b-11ea-99d0-15445c3a31a8.png)
