### PR TITLE
Pixi: Support RTL direction on full page

### DIFF
--- a/frontend/scss/components/molecules/pixi-basic-metric.scss
+++ b/frontend/scss/components/molecules/pixi-basic-metric.scss
@@ -22,10 +22,18 @@
     border-radius: 4px;
     border-bottom: 0;
     box-shadow: 0 10px 25px 0 transparentize(color('black'), 0.87);
+
+    &[dir='rtl'] {
+      padding: 25px 25px 25px 15px;
+    }
   }
 
   @media (min-width: 1024px) {
     padding: 25px 25px 25px 35px;
+
+    &[dir='rtl'] {
+      padding: 25px 35px 25px 25px;
+    }
   }
 
   &-title {

--- a/frontend/scss/components/molecules/pixi-recommendations-item.scss
+++ b/frontend/scss/components/molecules/pixi-recommendations-item.scss
@@ -6,7 +6,8 @@
 .#{molecule('pixi-recommendations-item')} {
   $recommendationsItem: &;
   margin-top: 30px;
-  transition: transform 0.25s ease-in, background 0.25s ease-in, box-shadow 0.3s ease-in, border-color 0.3s ease-in;
+  transition: transform 0.25s ease-in, background 0.25s ease-in,
+    box-shadow 0.3s ease-in, border-color 0.3s ease-in;
 
   &-box {
     padding: 30px 18px;
@@ -53,6 +54,11 @@
       background-repeat: no-repeat;
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath d='M56.293 16.003c1.761-1.645 4.553-1.645 6.314 0a4.323 4.323 0 010 6.357l-27.45 25.638c-1.761 1.645-4.553 1.645-6.314 0L1.393 22.36C.494 21.521 0 20.397 0 19.182s.494-2.339 1.393-3.178c1.761-1.645 4.553-1.645 6.314 0L32 38.693l24.293-22.689z'/%3E%3C/svg%3E");
       transition: transform 0.25s cubic-bezier(0, 0, 0.3, 1);
+
+      &[dir='rtl'] {
+        left: 20px;
+        right: initial;
+      }
 
       @media (min-width: 768px) {
         width: 21px;
@@ -115,11 +121,13 @@
       border-collapse: collapse;
     }
 
-    tr + tr, thead + tr {
+    tr + tr,
+    thead + tr {
       border-top: 1px solid color('mercury');
     }
 
-    td, th {
+    td,
+    th {
       padding: 15px;
     }
 
@@ -140,6 +148,36 @@
       overflow: hidden;
       direction: rtl;
       text-overflow: ellipsis;
+    }
+  }
+
+  &-next-advice {
+    &[dir='rtl'] {
+      margin-left: initial;
+
+      &:hover {
+        transform: translateX(-10px);
+      }
+    }
+
+    &-icon {
+      [dir='rtl'] > & {
+        transform: scaleX(-1);
+      }
+
+      [dir='rtl']:hover > & {
+        transform: scaleX(-1) translate(10px) !important;
+      }
+    }
+
+    &-text {
+      [dir='rtl'] > & {
+        padding-left: initial;
+        padding-right: 10px;
+      }
+      [dir='rtl']:hover > & {
+        transform: translateX(-10px);
+      }
     }
   }
 
@@ -165,12 +203,12 @@
 
   &.expanded {
     @media (min-width: 768px) {
-      transform: translateY(-.125em);
+      transform: translateY(-0.125em);
 
       #{$recommendationsItem}-box {
         border-color: transparent;
         background: safeColor('white');
-        box-shadow: 0 15px 30px 0 fade-out(color('black'), .85);
+        box-shadow: 0 15px 30px 0 fade-out(color('black'), 0.85);
       }
     }
 
@@ -186,10 +224,9 @@
   }
 
   &.highlight {
-
     #{$recommendationsItem}-header-title {
       &:before {
-        content: "";
+        content: '';
         display: inline-block;
         height: 25px;
         width: 25px;

--- a/frontend/scss/components/molecules/pixi-status-intro.scss
+++ b/frontend/scss/components/molecules/pixi-status-intro.scss
@@ -19,12 +19,12 @@
 
     @media (min-width: 768px) {
       margin-top: 50px;
-      padding: 0 0 0 25px;
+      padding: 0 25px 0 25px;
     }
 
     @media (min-width: 1024px) {
       margin-top: 30px;
-      padding: 0 0 0 35px;
+      padding: 0 35px 0 35px;
     }
 
     a,
@@ -70,10 +70,20 @@
       background-repeat: no-repeat;
       background-position-x: center;
 
+      &[dir='rtl'] {
+        margin-left: 14px;
+        margin-right: initial;
+      }
+
       @media (min-width: 1024px) {
         width: 70px;
         max-width: 70px;
         margin-right: 28px;
+
+        &[dir='rtl'] {
+          margin-left: 28px;
+          margin-right: initial;
+        }
       }
     }
 

--- a/frontend/scss/components/organisms/pixi-primary-checks.scss
+++ b/frontend/scss/components/organisms/pixi-primary-checks.scss
@@ -19,6 +19,10 @@
 
     @media (min-width: 768px) {
       width: 66.6%;
+
+      &[dir='rtl'] {
+        margin-left: 33.4%;
+      }
     }
 
     &-tab {
@@ -27,7 +31,6 @@
       padding: 14px 20px;
       @include txt-font-accent;
       font-size: 18px;
-      text-align: left;
       background-color: color('alto');
       transition: color 0.2s ease, background-color 0.2s ease;
       cursor: pointer;
@@ -40,11 +43,17 @@
         padding: 16px 35px;
       }
 
-      &:first-child {
+      [dir='rtl'] > & {
+        text-align: right;
+      }
+
+      &:first-child,
+      [dir='rtl'] > &:last-child {
         border-top-left-radius: 4px;
       }
 
-      &:last-child {
+      &:last-child,
+      [dir='rtl'] > &:first-child {
         border-top-right-radius: 4px;
       }
 

--- a/frontend/scss/components/templates/pixi.scss
+++ b/frontend/scss/components/templates/pixi.scss
@@ -41,12 +41,14 @@
 
     h1 {
       max-width: 600px;
-      margin: 0 360px -40px 0;
+      margin: 0;
+      margin-bottom: -40px;
       font-size: 42px;
       line-height: 1.14;
 
       @media (min-width: 768px) {
         font-size: 64px;
+        margin-right: 360px;
       }
     }
 

--- a/frontend/scss/components/templates/pixi.scss
+++ b/frontend/scss/components/templates/pixi.scss
@@ -41,8 +41,7 @@
 
     h1 {
       max-width: 600px;
-      margin: 0;
-      margin-bottom: -40px;
+      margin: 0 360px -40px 0;
       font-size: 42px;
       line-height: 1.14;
 
@@ -136,15 +135,18 @@
         @media (min-width: 768px) {
           top: 90px;
           margin-left: -15px;
+          margin-right: -15px;
         }
 
         @media (min-width: 1024px) {
           top: 125px;
           margin-left: -35px;
+          margin-right: -35px;
         }
 
         @media (min-width: 1280px) {
           margin-left: 0;
+          margin-right: 0;
         }
       }
 
@@ -178,6 +180,10 @@
 
         h2 {
           margin: 0 20px 0 0;
+
+          &[dir='rtl'] {
+            margin: 0 0 0 20px;
+          }
         }
       }
     }

--- a/frontend/templates/views/partials/pixi/basic-metric.j2
+++ b/frontend/templates/views/partials/pixi/basic-metric.j2
@@ -1,6 +1,6 @@
 {% do doc.styles.addCssFile('css/components/molecules/pixi-basic-metric.css') %}
 
-<div id="{{ basic_metric.id }}" class="ap-m-pixi-basic-metric">
+<div id="{{ basic_metric.id }}" class="ap-m-pixi-basic-metric" dir="{{ doc.locale.text_direction }}">
   <h3 class="ap-m-pixi-basic-metric-title">
     {{ basic_metric.title }}
     <br>

--- a/frontend/templates/views/partials/pixi/primary-checks.j2
+++ b/frontend/templates/views/partials/pixi/primary-checks.j2
@@ -1,7 +1,7 @@
 {% do doc.styles.addCssFile('css/components/organisms/pixi-primary-checks.css') %}
 
 <div class="ap-o-pixi-primary-checks" id="core-web-vitals">
-  <div class="ap-o-pixi-primary-checks-tabs" aria-label="{{ pixi.staticText.coreWebVitals.tabsAriaLabel }}">
+  <div class="ap-o-pixi-primary-checks-tabs" dir="{{ doc.locale.text_direction }}" aria-label="{{ pixi.staticText.coreWebVitals.tabsAriaLabel }}">
     <button role="tab" aria-selected="true" aria-controls="primary-checks-field-data"
             id="field-data-tab" class="ap-o-pixi-primary-checks-tabs-tab active">
       {{ pixi.staticText.coreWebVitals.fieldData }}

--- a/frontend/templates/views/partials/pixi/recommendations-item.j2
+++ b/frontend/templates/views/partials/pixi/recommendations-item.j2
@@ -1,10 +1,10 @@
 {% do doc.styles.addCssFile('css/components/molecules/pixi-recommendations-item.css') %}
 
 <div class="ap-m-pixi-recommendations-item" style="display: none;">
-  <div class="ap-m-pixi-recommendations-item-box">
+  <div dir="{{ doc.locale.text_direction }}" class="ap-m-pixi-recommendations-item-box">
     <button class="ap-m-pixi-recommendations-item-header" aria-expanded="false">
       <div class="ap-m-pixi-recommendations-item-header-title"></div>
-      <div class="ap-m-pixi-recommendations-item-header-toggle">
+      <div dir="{{ doc.locale.text_direction }}" class="ap-m-pixi-recommendations-item-header-toggle">
       </div>
     </button>
 
@@ -17,9 +17,9 @@
         </table>
       </div>
 
-      <a class="ap-m-lnk ap-m-lnk-square">
-        <div class="ap-a-ico ap-m-lnk-icon"></div>
-        <span class="ap-m-lnk-text">{{ pixi.staticText.recommendations.nextAdvice }}</span>
+      <a class="ap-m-pixi-recommendations-item-next-advice ap-m-lnk ap-m-lnk-square" dir="{{ doc.locale.text_direction }}">
+        <div class="ap-m-pixi-recommendations-item-next-advice-icon ap-a-ico ap-m-lnk-icon"></div>
+        <span class="ap-m-pixi-recommendations-item-next-advice-text ap-m-lnk-text">{{ pixi.staticText.recommendations.nextAdvice }}</span>
       </a>
     </div>
 

--- a/frontend/templates/views/partials/pixi/status-intro.j2
+++ b/frontend/templates/views/partials/pixi/status-intro.j2
@@ -5,7 +5,7 @@
    {{ pixi.html|render|safe }}
   </div>
   <div id="status-intro-banner-loading" class="ap-m-pixi-status-intro-banner">
-    <div class="ap-m-pixi-status-intro-banner-icon"></div>
+    <div class="ap-m-pixi-status-intro-banner-icon" dir="{{ doc.locale.text_direction }}"></div>
     <div class="ap-m-pixi-status-intro-banner-content">
       <h3>
         {{ pixi.staticText.statusIntro.headline }}

--- a/pages/content/amp-dev/page-experience.html
+++ b/pages/content/amp-dev/page-experience.html
@@ -87,7 +87,7 @@ description: Coming soon - analyze and learn how to optimize your AMP pages for 
   }
 } %}
 
-<main class="ap--main ap-t-pixi">
+<main class="ap--main ap-t-pixi" dir="{{ doc.locale.text_direction }}">
   <section class="ap-t-pixi-stage">
     <h1>{{ pixi.title }}</h1>
     {% do doc.icons.useIcon('icons/page-experience.svg') %}
@@ -184,7 +184,7 @@ description: Coming soon - analyze and learn how to optimize your AMP pages for 
         
         <section class="ap-t-pixi-checks-reports">
           <div class="ap-t-pixi-checks-reports-title">
-            <h2 id="core-web-vitals-checks">{{ pixi.staticText.coreWebVitals.headline }}</h2>
+            <h2 id="core-web-vitals-checks" dir="{{ doc.locale.text_direction }}">{{ pixi.staticText.coreWebVitals.headline }}</h2>
             {% with tooltip = {
               'id': 'core-web-vitals',
               'invert': false


### PR DESCRIPTION
Partial for #4379, which will be fixed once both this and #4702 are merged.

Desktop:
![image](https://user-images.githubusercontent.com/10456171/94708914-1c5c3900-0313-11eb-96f7-7f0fe7a73005.png)
![image](https://user-images.githubusercontent.com/10456171/94708925-1f572980-0313-11eb-84e8-fee5222af51f.png)
![image](https://user-images.githubusercontent.com/10456171/94708936-22521a00-0313-11eb-9191-560d388cc758.png)

Mobile: 
![image](https://user-images.githubusercontent.com/10456171/94709537-ca67e300-0313-11eb-9bef-eb0f43d9b895.png)
![image](https://user-images.githubusercontent.com/10456171/94709574-d489e180-0313-11eb-9435-20bb20e0b8ef.png)
![image](https://user-images.githubusercontent.com/10456171/94709589-d8b5ff00-0313-11eb-910a-8f3a8da813c4.png)
![image](https://user-images.githubusercontent.com/10456171/94709597-da7fc280-0313-11eb-9eb4-9543c9324bfa.png)
![image](https://user-images.githubusercontent.com/10456171/94709603-dbb0ef80-0313-11eb-82f9-22cf98e0dc4a.png)
