### PR TITLE
Pixi: Put metric title and summary in one line

### DIFF
--- a/frontend/scss/components/molecules/pixi-primary-metric.scss
+++ b/frontend/scss/components/molecules/pixi-primary-metric.scss
@@ -42,7 +42,6 @@
       line-height: 1.4;
 
       @media (min-width: 768px) {
-        width: 40%;
         font-size: 28px;
       }
 
@@ -65,7 +64,7 @@
       }
 
       &-status {
-        display: block;
+        display: inline-block;
         color: safeColor('light-gray');
 
         .fast & {

--- a/frontend/templates/views/partials/pixi/primary-metric.j2
+++ b/frontend/templates/views/partials/pixi/primary-metric.j2
@@ -7,7 +7,7 @@
         {{ primary_metric.title.full }}
       </div>
       <div class="ap-m-pixi-primary-metric-header-title-id">
-        {{ primary_metric.title.id }}
+        {{ primary_metric.title.id }}:
       </div>
       <label class="ap-m-pixi-primary-metric-header-title-status">
         <span class="ap-m-pixi-primary-metric-category">{{ pixi.scriptText.status.analyzing }}</span>


### PR DESCRIPTION
Fixes #4545

Desktop view with 1607 x 813 inner window size:
![image](https://user-images.githubusercontent.com/10456171/94829042-1f6d2d00-03d8-11eb-8b63-d3ede5349682.png)
![image](https://user-images.githubusercontent.com/10456171/94829073-26943b00-03d8-11eb-937d-0aa5e6d8f9a8.png)

Desktop view with 790 x 813 inner window size:
![image](https://user-images.githubusercontent.com/10456171/94829354-6c510380-03d8-11eb-8975-0d3e561b5760.png)
![image](https://user-images.githubusercontent.com/10456171/94829365-6eb35d80-03d8-11eb-9de9-d46bd56ceae6.png)

Mobile view with 360 x 640:
![image](https://user-images.githubusercontent.com/10456171/94829483-8ee31c80-03d8-11eb-8316-1352d192fb72.png)
