### PR TITLE
Pixi: Surface generic error before other linter information

### DIFF
--- a/pages/content/pixi/status-banners/generic-error.md
+++ b/pages/content/pixi/status-banners/generic-error.md
@@ -2,5 +2,5 @@
 $title: Oops! Looks like something went wrong.
 type: error
 ---
-We weren't able to get reliable results for all required criteria.
-Please rerun the test.
+
+We weren't able to get reliable results for the page you requested. Please wait momentarily before trying to rerun the test.

--- a/pages/content/pixi/status-banners/generic-error.md
+++ b/pages/content/pixi/status-banners/generic-error.md
@@ -1,6 +1,7 @@
 ---
 $title: Oops! Looks like something went wrong.
 type: error
+hide_share: true
 ---
 
 We weren't able to get reliable results for the page you requested. Please wait momentarily before trying to rerun the test.

--- a/pixi/src/utils/checkAggregation/statusBanner.js
+++ b/pixi/src/utils/checkAggregation/statusBanner.js
@@ -17,6 +17,9 @@ import {fixedRecommendations} from './recommendations';
 async function getStatusId(checkPromises, recommendationsPromise) {
   try {
     const linter = await checkPromises.linter;
+    if (linter.error) {
+      return 'generic-error';
+    }
     if (!linter.isLoaded) {
       return 'invalid-url';
     }
@@ -36,9 +39,6 @@ async function getStatusId(checkPromises, recommendationsPromise) {
 
     if (!linter.isValid) {
       return 'invalid-amp';
-    }
-    if (linter.error) {
-      return 'generic-error';
     }
     if (pageExperienceChecks.error) {
       return 'cwv-error';


### PR DESCRIPTION
Otherwise, in the case that the linter response fails, we were originally surfacing "This page is invalid AMP". Tagging #4765 as this is a change in copy.

Now we surface:

![image](https://user-images.githubusercontent.com/10456171/94842395-57c93700-03e9-11eb-9480-0a2ca3249725.png)
