### PR TITLE
Banner for AMP Fest

### DIFF
--- a/frontend/scss/components/organisms/burger-menu.scss
+++ b/frontend/scss/components/organisms/burger-menu.scss
@@ -26,10 +26,10 @@
   background-color: color('white');
 
   @media (max-width: $minDeviceWidth) {
-    padding: 74px 20px 0;
+    padding: 37px 20px 0;
 
     .has-banner ~ & {
-      padding: calc(74px + #{$bannerHeight}) 0 0 20px;
+      padding: calc(37px + #{$bannerHeight}) 0 0 20px;
     }
   }
 
@@ -37,7 +37,7 @@
   &-label {
     position: fixed;
     z-index: 1001;
-    top: 50px;
+    top: 12px;
     right: 20px;
     cursor: pointer;
 
@@ -46,12 +46,12 @@
     }
 
     .has-banner + & {
-      top: calc(49px + #{$bannerHeight});
+      top: calc(12px + #{$bannerHeight});
     }
 
     amp-user-notification[hidden] + .has-banner + &,
     .amp-hidden + .has-banner + & {
-      top: 50px;
+      top: 12px;
     }
 
     @media (min-width: 768px) {

--- a/frontend/templates/views/partials/banner.j2
+++ b/frontend/templates/views/partials/banner.j2
@@ -1,7 +1,23 @@
 {% do doc.styles.addCssFile('/css/components/molecules/banner.css') %}
-
+<!--
 <a id="blm-banner"
    target="_blank"
    href="https://blacklivesmatter.com">
   #BlackLivesMatter
 </a>
+-->
+<div class="ap-m-banner">
+  <a id="top-banner"
+     class="ap-m-banner-link"
+     target="_blank"
+     href="https://amp.dev/events/amp-fest-2020/">
+    <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
+    {{ _('Join us for AMP Fest on October 13!') }}
+  </a>
+{% if banner_closeable %}
+  <button class="ap-m-banner-dismiss" on="tap:{{ banner_notification_id }}.dismiss">
+    {% do doc.icons.useIcon('/icons/close.svg') %}
+    <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close"></use></svg>
+  </button>
+{% endif %}
+</div>

--- a/frontend/templates/views/partials/banner.j2
+++ b/frontend/templates/views/partials/banner.j2
@@ -1,11 +1,4 @@
 {% do doc.styles.addCssFile('/css/components/molecules/banner.css') %}
-<!--
-<a id="blm-banner"
-   target="_blank"
-   href="https://blacklivesmatter.com">
-  #BlackLivesMatter
-</a>
--->
 <div class="ap-m-banner">
   <a id="top-banner"
      class="ap-m-banner-link"

--- a/frontend/templates/views/partials/header.j2
+++ b/frontend/templates/views/partials/header.j2
@@ -73,7 +73,7 @@ to provide its state to other components #}
 </nav>
 {% endmacro %}
 
-<header class="ap--header" [class]="'ap--header ' + (mainmenuopen ? 'mainmenuopen' : '')">
+<header class="ap--header {{'has-banner' if show_banner}}" [class]="'ap--header {{'has-banner' if show_banner}} ' + (mainmenuopen ? 'mainmenuopen' : '')">
   {% if show_banner %}
     {% include '/views/partials/banner.j2' %}
   {% endif %}


### PR DESCRIPTION
This puts up the banner for AMP Fest.

Note that, to avoid layout problems, I had to undo the work that was done to put up the BLM banner in https://github.com/ampproject/amp.dev/pull/4235 - as that PR wasn't compatible with other banner sizes. Going forward, we need to make the header more flexible so that it can accommodate banners of different sizes!