### PR TITLE
Change shortlink for optimize-amp

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -44,7 +44,7 @@
 /nextjs: https://nextjs.org/docs/advanced-features/amp-support/introduction
 /optimize: /documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/
 /optimizer: /documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/
-/optimize-amp: /documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/
+/optimize-amp: /documentation/guides-and-tutorials/optimize-and-measure/optimize_amp
 /owners: https://ampproject-owners-bot.appspot.com/tree
 /publishing-checklist: /documentation/guides-and-tutorials/optimize-and-measure/publishing_checklist/
 /reftemplate: https://docs.google.com/document/d/1lRFcErFBnqsuv6W9mZsfYk2qnXO9nPzMkeog4Xtunl8/edit?usp=sharing

--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -44,7 +44,8 @@
 /nextjs: https://nextjs.org/docs/advanced-features/amp-support/introduction
 /optimize: /documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/
 /optimizer: /documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/
-/optimize-amp: /documentation/guides-and-tutorials/optimize-and-measure/optimize_amp
+/optimize-amp: /documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/
+/optimize-guide: /documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/
 /owners: https://ampproject-owners-bot.appspot.com/tree
 /publishing-checklist: /documentation/guides-and-tutorials/optimize-and-measure/publishing_checklist/
 /reftemplate: https://docs.google.com/document/d/1lRFcErFBnqsuv6W9mZsfYk2qnXO9nPzMkeog4Xtunl8/edit?usp=sharing


### PR DESCRIPTION
We have about 4 shortlinks for the optimizer guide, but none for the really useful [guide to speeding up AMP pages yourself](https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp). I need a shortlink for a talk... I hope it's ok to switch this one! It's named ideally for the optimize_amp page....