### PR TITLE
✅  Add Pixi to smoke tested pages

### DIFF
--- a/smoke-tests/platform/Routes.test.js
+++ b/smoke-tests/platform/Routes.test.js
@@ -71,6 +71,12 @@ describe('Routes', () => {
       });
     });
   });
+  it('serves Pixi', async () => {
+    const response = await fetch('/page-experience/');
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(await validate(body)).toBe(true);
+  });
   function fetch(path) {
     return nodeFetch(new URL(path, config.hosts.platform.base));
   }


### PR DESCRIPTION
This would have prevented https://github.com/ampproject/amp.dev/pull/4792. Before a build goes live on amp-dev-staging.appspot.com or amp.dev itself it now needs to be able to serve a AMP-valid version of Pixi, otherwise it blocks build. 