### PR TITLE
✨ Render amp-script hash to Pixi template

### DIFF
--- a/frontend/templates/views/custom.j2
+++ b/frontend/templates/views/custom.j2
@@ -1,10 +1,5 @@
 {% extends '/layouts/default.j2' %}
 
-{% block head %}
-{{ super() }}
-
-{% endblock %}
-
 {% block styles %}
 {{ super() }}
 

--- a/frontend/templates/views/custom.j2
+++ b/frontend/templates/views/custom.j2
@@ -1,5 +1,10 @@
 {% extends '/layouts/default.j2' %}
 
+{% block head %}
+{{ super() }}
+
+{% endblock %}
+
 {% block styles %}
 {{ super() }}
 

--- a/frontend/templates/views/pixi.j2
+++ b/frontend/templates/views/pixi.j2
@@ -1,0 +1,17 @@
+{% extends '/layouts/default.j2' %}
+
+{% block head %}
+{{ super() }}
+
+{% import '/views/partials/pixi/webpack.j2' as webpack %}
+<meta name="amp-script-src" content="{{ webpack.cspHash }}">
+{% endblock %}
+
+{% block styles %}
+{{ super() }}
+
+{% endblock %}
+
+{% block main %}
+{{ doc.html|render|safe }}
+{% endblock %}

--- a/pages/content/amp-dev/page-experience.html
+++ b/pages/content/amp-dev/page-experience.html
@@ -1,14 +1,8 @@
 ---
 $title: AMP Page Experience Guide
-$view: /views/custom.j2
+$view: /views/pixi.j2
 description: Coming soon - analyze and learn how to optimize your AMP pages for Google's Page Experience ranking signal.
 ---
-{% import '/views/partials/pixi/webpack.j2' as webpack %}
-
-{% block head %}
-{{ super() }}
-<meta name="amp-script-src" content="{{ webpack.cspHash }}">
-{% endblock %}
 
 {% do doc.styles.addCssFile('css/components/templates/pixi.css') %}
 
@@ -137,6 +131,7 @@ description: Coming soon - analyze and learn how to optimize your AMP pages for 
     </script>
   </amp-state>
 
+  {% import '/views/partials/pixi/webpack.j2' as webpack %}
   <amp-script id="pixi-checks"
       class="ap-t-pixi-checks"
       src="{{ podspec.base_urls.platform }}{{ webpack.src }}"

--- a/pages/content/amp-dev/page-experience.html
+++ b/pages/content/amp-dev/page-experience.html
@@ -3,6 +3,12 @@ $title: AMP Page Experience Guide
 $view: /views/custom.j2
 description: Coming soon - analyze and learn how to optimize your AMP pages for Google's Page Experience ranking signal.
 ---
+{% import '/views/partials/pixi/webpack.j2' as webpack %}
+
+{% block head %}
+{{ super() }}
+<meta name="amp-script-src" content="{{ webpack.cspHash }}">
+{% endblock %}
 
 {% do doc.styles.addCssFile('css/components/templates/pixi.css') %}
 
@@ -131,7 +137,6 @@ description: Coming soon - analyze and learn how to optimize your AMP pages for 
     </script>
   </amp-state>
 
-  {% import '/views/partials/pixi/webpack.j2' as webpack %}
   <amp-script id="pixi-checks"
       class="ap-t-pixi-checks"
       src="{{ podspec.base_urls.platform }}{{ webpack.src }}"
@@ -156,7 +161,7 @@ description: Coming soon - analyze and learn how to optimize your AMP pages for 
           {{ analyticsConfig|tojson }}
         </script>
       </amp-analytics>
-      
+
       <section class="ap-t-pixi-checks-reports">
         <div class="ap-t-pixi-checks-reports-title">
           <h2 id="core-web-vitals-checks" dir="{{ doc.locale.text_direction }}">{{ pixi.staticText.coreWebVitals.headline }}</h2>

--- a/pixi/src/ui/page-experience.hbs
+++ b/pixi/src/ui/page-experience.hbs
@@ -2,3 +2,4 @@
 {{#htmlWebpackPlugin.files.js }}
 {% set src = '{{ . }}' %}
 {{/htmlWebpackPlugin.files.js }}
+{% set cspHash = '{{ cspHash }}' %}

--- a/pixi/webpack.config.js
+++ b/pixi/webpack.config.js
@@ -6,6 +6,8 @@ const {CleanWebpackPlugin} = require('clean-webpack-plugin');
 const FileManagerPlugin = require('filemanager-webpack-plugin');
 
 const config = require('./config.js');
+const {calculateHash} = require('@ampproject/toolbox-script-csp');
+
 
 module.exports = (env, argv) => {
   const mode = argv.mode || 'production';
@@ -28,6 +30,19 @@ module.exports = (env, argv) => {
         template: path.join(__dirname, 'src/ui/page-experience.hbs'),
         filename: './pixi.html',
         inject: false,
+        templateParameters: (compilation, assets, assetTags, options) => {
+          const js = Object.values(compilation.assets)[0].source();
+
+           return {
+             compilation,
+             webpackConfig: compilation.options,
+             htmlWebpackPlugin: {
+               files: assets,
+               options
+             },
+             cspHash: calculateHash(js)
+           };
+         }
       }),
       new webpack.DefinePlugin({
         IS_DEVELOPMENT: mode == 'development',

--- a/pixi/webpack.config.js
+++ b/pixi/webpack.config.js
@@ -8,7 +8,6 @@ const FileManagerPlugin = require('filemanager-webpack-plugin');
 const config = require('./config.js');
 const {calculateHash} = require('@ampproject/toolbox-script-csp');
 
-
 module.exports = (env, argv) => {
   const mode = argv.mode || 'production';
 
@@ -33,16 +32,16 @@ module.exports = (env, argv) => {
         templateParameters: (compilation, assets, assetTags, options) => {
           const js = Object.values(compilation.assets)[0].source();
 
-           return {
-             compilation,
-             webpackConfig: compilation.options,
-             htmlWebpackPlugin: {
-               files: assets,
-               options
-             },
-             cspHash: calculateHash(js)
-           };
-         }
+          return {
+            compilation,
+            webpackConfig: compilation.options,
+            htmlWebpackPlugin: {
+              files: assets,
+              options,
+            },
+            cspHash: calculateHash(js),
+          };
+        },
       }),
       new webpack.DefinePlugin({
         IS_DEVELOPMENT: mode == 'development',


### PR DESCRIPTION
Sorry, had a misconception that the AMP optimizer will add the hash, but it only does so for inline-scripts.

Fixes #4813, probably related to https://github.com/ampproject/amp.dev/issues/4818#issuecomment-705389563.