### PR TITLE
🐛 Explicitly use platform URL for sitemap generation

### DIFF
--- a/frontend/templates/layouts/sitemap.xml
+++ b/frontend/templates/layouts/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% for doc in docs|sort(attribute='url') if not doc.sitemap.enabled is sameas false %}
   <url>
-    <loc>{{ doc.url }}</loc>
+    <loc>{{ doc.pod.podspec.base_urls.platform }}{{ doc.url.path }}</loc>
     {% if doc.modified %}
     <lastmod>{{ doc.modified|date("%Y-%M-%D") }}</lastmod>
     {% endif %}


### PR DESCRIPTION
Currently https://amp.dev/sitemap_grow.xml points to URLs with amp-dev-staging.appspot.com as we did not add a monkey-patch for hostnames in Grow. That's not a problem anywhere else as the sitemap is the only place where we've used `doc.url`