### PR TITLE
Fix linter API to handle the response without Content-Type header field

### DIFF
--- a/platform/lib/utils/rateLimitedFetch.js
+++ b/platform/lib/utils/rateLimitedFetch.js
@@ -117,7 +117,7 @@ class RateLimitedFetch {
     }
 
     const contentType = response.headers.get('content-type');
-    if (!contentType.includes('text/html')) {
+    if (!contentType || !contentType.includes('text/html')) {
       throw new FetchError(
         FetchError.UNSUPPORTED_CONTENT_TYPE,
         `${urlString} is no HTML document.`

--- a/platform/lib/utils/rateLimitedFetch.test.js
+++ b/platform/lib/utils/rateLimitedFetch.test.js
@@ -62,6 +62,25 @@ test('Fetch error unsupported content type', () => {
   });
 });
 
+test('Fetch error no content type header', () => {
+  fetch.mockReturnValue(
+    Promise.resolve(
+      new Response('{}', {
+        status: 200,
+        headers: {
+          'content-type': null,
+        },
+      })
+    )
+  );
+  const result = remoteFetch.fetchHtmlDocument('http://www.test');
+  expect.assertions(2);
+  return result.catch((e) => {
+    expect(e.errorId).toEqual(RemoteFetchError.UNSUPPORTED_CONTENT_TYPE);
+    expect(e.message).toEqual('http://www.test is no HTML document.');
+  });
+});
+
 test('Fetch error empty url', () => {
   const result = remoteFetch.fetchHtmlDocument('');
   expect.assertions(2);


### PR DESCRIPTION
Related to https://github.com/ampproject/amp.dev/issues/4887

Currently the linter API makes error when passed AMP page URL doesn't have `Content-Type` header. This change handle the error case.