### PR TITLE
🐛 Update AMP URL API sample iframe URL

### DIFF
--- a/examples/source/2.guides/Using_the_AMP_URL_API.html
+++ b/examples/source/2.guides/Using_the_AMP_URL_API.html
@@ -44,7 +44,7 @@ author: sebastianbenz
               sandbox="allow-scripts allow-same-origin allow-popups"
               allowfullscreen
               frameborder="0"
-              src="<% hosts.api %>/iframe/amp-url-api.html">
+              src="/static/samples/files/amp-url-api.html">
               <amp-img src="/static/samples/img/amp-url-api-placeholder.png"
                layout="fixed-height"
                height="645"

--- a/examples/static/samples/files/amp-url-api.html
+++ b/examples/static/samples/files/amp-url-api.html
@@ -69,7 +69,7 @@ function sendAmpUrlRequest() {
  */
 function sendApiRequest(urls, callback) {
   try {
-    var url = 'https://content-acceleratedmobilepageurl.googleapis.com/v1/ampUrls:batchGet?key=AIzaSyAM68IyT1bLVrlAU1172bspF-mZ93IdmsY';
+    var url = 'https://content-acceleratedmobilepageurl.googleapis.com/v1/ampUrls:batchGet?key=AIzaSyC1Bh5HwhrB6Ai2U4aXfsmhgy2zWOHS0Xk';
     var xhr = createRequest('POST', url);
     xhr.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
     xhr.onload = function () {


### PR DESCRIPTION
Fixes #4920

/cc @patrickkettner, @caroqliu: the API key is still scoped to ampbyexample.com and prevents the sample from working. I can't seem to find the matching API in the Cloud Console though. Can one of you advise?
