### PR TITLE
move AJA from embed to ad

### DIFF
--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ar.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ar.md
@@ -265,6 +265,7 @@ draw3p(function(config, done) {
 * [AdvertServe](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -414,7 +415,6 @@ draw3p(function(config, done) {
 ## أنواع التضمينات المتوافقة <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@es.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@es.md
@@ -265,6 +265,7 @@ Consulta las [reglas de amp-ad](https://github.com/ampproject/amphtml/blob/maste
 * [AdvertServe](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -414,7 +415,6 @@ Consulta las [reglas de amp-ad](https://github.com/ampproject/amphtml/blob/maste
 ## Tipos de inserción admitidos <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@fr.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@fr.md
@@ -264,6 +264,7 @@ Consultez les [règles relatives à amp-ad](https://github.com/ampproject/amphtm
 * [AdvertServe](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -413,7 +414,6 @@ Consultez les [règles relatives à amp-ad](https://github.com/ampproject/amphtm
 ## Types d'éléments intégrés compatibles <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@id.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@id.md
@@ -264,6 +264,7 @@ Lihat [aturan amp-ad](https://github.com/ampproject/amphtml/blob/master/extensio
 * [AdvertServe](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -413,7 +414,6 @@ Lihat [aturan amp-ad](https://github.com/ampproject/amphtml/blob/master/extensio
 ## Jenis sematan yang didukung <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@it.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@it.md
@@ -267,6 +267,7 @@ Consulta le [regole amp-ad](https://github.com/ampproject/amphtml/blob/master/ex
 * [AdvertServe](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -416,7 +417,6 @@ Consulta le [regole amp-ad](https://github.com/ampproject/amphtml/blob/master/ex
 ## Tipi di incorporamenti supportati <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ja.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ja.md
@@ -261,6 +261,7 @@ AMP 検証ツールの仕様で [amp-ad のルール](https://github.com/ampproj
 * [AdvertServe](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -410,7 +411,6 @@ AMP 検証ツールの仕様で [amp-ad のルール](https://github.com/ampproj
 ## サポートされている埋め込みタイプ <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ko.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ko.md
@@ -265,6 +265,7 @@ AMP 유효성 검사기 사양의 [amp-ad 규칙](https://github.com/ampproject/
 * [AdvertServe](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -414,7 +415,6 @@ AMP 유효성 검사기 사양의 [amp-ad 규칙](https://github.com/ampproject/
 ## 지원되는 삽입 유형 <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@pt_BR.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@pt_BR.md
@@ -264,6 +264,7 @@ Consulte as [regras de amp-ad](https://github.com/ampproject/amphtml/blob/master
 * [AdvertServe](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -413,7 +414,6 @@ Consulte as [regras de amp-ad](https://github.com/ampproject/amphtml/blob/master
 ## Tipos de incorporação compatíveis <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ru.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@ru.md
@@ -263,6 +263,7 @@ draw3p(function(config, done) {
 * [AdvertServe](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -412,7 +413,6 @@ draw3p(function(config, done) {
 ## Поддерживаемые типы встраивания <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@tr.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@tr.md
@@ -262,6 +262,7 @@ AMP doğrulayıcı spesifikasyonundaki [amp-ad kurallarına](https://github.com/
 * [Advertserve](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -411,7 +412,6 @@ AMP doğrulayıcı spesifikasyonundaki [amp-ad kurallarına](https://github.com/
 ## Desteklenen yerleştirme türleri <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)

--- a/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@zh_CN.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-ad-v0.1@zh_CN.md
@@ -262,6 +262,7 @@ draw3p(function(config, done) {
 * [AdvertServe](https://github.com/ampproject/amphtml/blob/master/ads/advertserve.md)
 * [Adyoulike](https://github.com/ampproject/amphtml/blob/master/ads/adyoulike.md)
 * [Affiliate-B](https://github.com/ampproject/amphtml/blob/master/ads/affiliateb.md)
+* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [AMoAd](https://github.com/ampproject/amphtml/blob/master/ads/amoad.md)
 * [AppNexus](https://github.com/ampproject/amphtml/blob/master/ads/appnexus.md)
 * [AppVador](https://github.com/ampproject/amphtml/blob/master/ads/appvador.md)
@@ -411,7 +412,6 @@ draw3p(function(config, done) {
 ## 支持的嵌入类型 <a name="supported-embed-types"></a>
 
 * [24smi](https://github.com/ampproject/amphtml/blob/master/ads/24smi.md)
-* [AJA](https://github.com/ampproject/amphtml/blob/master/ads/aja.md)
 * [Bringhub](https://github.com/ampproject/amphtml/blob/master/ads/bringhub.md)
 * [Dable](https://github.com/ampproject/amphtml/blob/master/ads/dable.md)
 * [Engageya](https://github.com/ampproject/amphtml/blob/master/ads/engageya.md)


### PR DESCRIPTION
Currently AJA only supports &lt;amp-ad&gt;.
So move from embed-types to ad-types.
Ref: https://github.com/ampproject/amphtml/blob/master/ads/aja.md