### PR TITLE
AMP Social Share Docs

### DIFF
--- a/examples/source/1.components/amp-social-share.html
+++ b/examples/source/1.components/amp-social-share.html
@@ -125,10 +125,10 @@ author: paul-matthews
   <!-- Use `data-param-media` to share media via Pinterest. -->
   <amp-social-share type="pinterest" aria-label="Share on Pinterest" data-param-media="https://amp.dev/static/samples/img/amp.jpg"></amp-social-share>
 
-  <!-- ## Native share dialog (Chrome on Android) -->
+  <!-- ## Native share dialog -->
   <!--
 
-  The `system` type will display a native share UI if the user is viewing the AMP document using Chrome on Android. (The only supported browser as of February 2018.)
+  The `system` type will display a native share UI if the user is viewing the AMP document using a browser that supports the Web Share API.
 
   Here's what it looks like in Chrome on Android:
 


### PR DESCRIPTION
The Web Share API is now supported on iOS (Safari + Chrome), Desktop Safari, and many other browsers (acc. to https://caniuse.com/web-share roughly 90% of mobile traffic).

Updating the docs to make that clearer. As so many browsers support, not sure we need to list them individually.