### PR TITLE
🚸 Show passing recommendations if there are details

### DIFF
--- a/pixi/src/checks/PageExperienceCheck.js
+++ b/pixi/src/checks/PageExperienceCheck.js
@@ -97,7 +97,6 @@ export default class PageExperienceCheck {
         result.data[resultName] = !details.items.length;
         result.details[resultName] = details;
       }
-
     }
   }
 

--- a/pixi/src/checks/PageExperienceCheck.js
+++ b/pixi/src/checks/PageExperienceCheck.js
@@ -89,12 +89,15 @@ export default class PageExperienceCheck {
   addScoreCheck(result, resultName, audits, testName) {
     if (audits && audits[testName] && !Number.isNaN(audits[testName].score)) {
       result.data[resultName] = audits[testName].score === 1;
-
       result.descriptions[resultName] = audits[testName].description;
       const details = audits[testName].details;
       if (details) {
+        // If a check has additional details although it identifies as passing
+        // show the recommendation anyway
+        result.data[resultName] = !details.items.length;
         result.details[resultName] = details;
       }
+
     }
   }
 

--- a/pixi/src/ui/recommendations/RecommendationItem.js
+++ b/pixi/src/ui/recommendations/RecommendationItem.js
@@ -17,6 +17,7 @@ import {addTargetBlankToLinks, cleanCodeForInnerHtml} from '../../utils/texts';
 
 const VALUE_TYPE_BYTES = 'bytes';
 const VALUE_TYPE_MS = 'ms';
+const VALUE_TYPE_TIMESPAN_MS = 'timespanMs';
 const VALUE_TYPE_THUMBNAIL = 'thumbnail';
 const VALUE_TYPE_URL = 'url';
 
@@ -135,7 +136,7 @@ export default class RecommendationItem {
           }" layout="fill"></amp-img>`;
         } else if (column.type == VALUE_TYPE_BYTES) {
           value = `${(item[column.key] / 1000).toFixed(2)}KB`;
-        } else if (column.type == VALUE_TYPE_MS) {
+        } else if (column.type == VALUE_TYPE_MS || column.type == VALUE_TYPE_TIMESPAN_MS) {
           value = `${item[column.key].toFixed(2)}ms`;
         } else if (column.type == VALUE_TYPE_URL) {
           value = `<a href="${

--- a/pixi/src/ui/recommendations/RecommendationItem.js
+++ b/pixi/src/ui/recommendations/RecommendationItem.js
@@ -136,7 +136,10 @@ export default class RecommendationItem {
           }" layout="fill"></amp-img>`;
         } else if (column.type == VALUE_TYPE_BYTES) {
           value = `${(item[column.key] / 1000).toFixed(2)}KB`;
-        } else if (column.type == VALUE_TYPE_MS || column.type == VALUE_TYPE_TIMESPAN_MS) {
+        } else if (
+          column.type == VALUE_TYPE_MS ||
+          column.type == VALUE_TYPE_TIMESPAN_MS
+        ) {
           value = `${item[column.key].toFixed(2)}ms`;
         } else if (column.type == VALUE_TYPE_URL) {
           value = `<a href="${


### PR DESCRIPTION
Fixes #4955.

This force-renders recommendations for Pixi even if the underlying PSI check finishes with a score of 1 as long as it provides further details like response times, resource sizes, etc. 