### PR TITLE
better click behavior

### DIFF
--- a/frontend/scss/components/atoms/sidebar-toggle.scss
+++ b/frontend/scss/components/atoms/sidebar-toggle.scss
@@ -88,7 +88,6 @@ $originalEasing: cubic-bezier(0,0,.21,1);
     }
 
     .label-title {
-      position: absolute;
       left: 32px;
       display: flex;
       align-items: center;


### PR DESCRIPTION
The sidebar toggle on click/focus outlines only the label-icon:

![14](https://user-images.githubusercontent.com/40922889/99145389-7bdc9100-2694-11eb-9bd5-337116d94a63.gif)

I improved the click behavior to encompass the whole label:

![24](https://user-images.githubusercontent.com/40922889/99145399-93b41500-2694-11eb-8fd2-e056e905c864.gif)

GIFs from Chrome