### PR TITLE
Fixed captions

### DIFF
--- a/pages/content/amp-dev/documentation/courses/beginning-course/finding-the-right-component.md
+++ b/pages/content/amp-dev/documentation/courses/beginning-course/finding-the-right-component.md
@@ -27,7 +27,7 @@ When we look at the [documentation](../../../documentation/components/reference/
 
 - What layouts does this component support?
 
-{{ image('/static/img/courses/beginner/image25.png', 512, 386, caption='AMP documentation page for `<amp-carousel>`.') }}
+{{ image('/static/img/courses/beginner/image25.png', 512, 386, caption='AMP documentation page for <amp‑carousel>.') }}
 
 Look at the following items in the [documentation](../../../documentation/components/reference/amp-carousel.md) of `<amp-carousel>`:
 
@@ -136,7 +136,7 @@ Another way to find components is to use the [AMP Components Reference](../../..
 
 Finally, we might still have questions about how the component would act on our site, or we may be unclear about how to use the component in more complex ways. The [AMP By Example](../../../documentation/examples/index.html) section on amp.dev has pages showcasing many AMP components, showing a variety of ways to configure those components to meet common use cases in modern websites. Usually, you can get to the corresponding AMP By Example page for a component directly from its documentation.
 
-{{ image('/static/img/courses/beginner/image7.png', 512, 350, caption='AMP By Example page for the `<amp-carousel>` component.') }}
+{{ image('/static/img/courses/beginner/image7.png', 512, 350, caption='AMP By Example page for the <amp‑carousel> component.') }}
 
 ## Exercise 6: Adding Social Sharing Links
 
@@ -194,7 +194,7 @@ When we look at the [documentation]({{g.doc('/content/amp-dev/documentation/comp
 
 - What layouts does this component support?
 
-{{ image('/static/img/courses/beginner/image25.webp', 1024, 771, caption='AMP documentation page for `<amp-carousel>`.') }}
+{{ image('/static/img/courses/beginner/image25.webp', 1024, 771, caption='AMP documentation page for <amp‑carousel>.') }}
 
 Look at the following items in the [documentation]({{g.doc('/content/amp-dev/documentation/components/reference/amp-carousel.md', locale=doc.locale).url.path}}) of `<amp-carousel>`:
 

--- a/pages/content/amp-dev/documentation/courses/beginning-course/finding-the-right-component@pt_BR.md
+++ b/pages/content/amp-dev/documentation/courses/beginning-course/finding-the-right-component@pt_BR.md
@@ -27,7 +27,7 @@ Quando observamos para a [documentação]({{g.doc('/content/amp-dev/documentatio
 
 - Quais layouts este componente suporta?
 
-{{ image('/static/img/courses/beginner/image25.png', 512, 386, caption='Página de documentação de AMP para `<amp-carousel>`.') }}
+{{ image('/static/img/courses/beginner/image25.png', 512, 386, caption='Página de documentação de AMP para <amp‑carousel>.') }}
 
 Veja os seguintes itens na [documentação]({{g.doc('/content/amp-dev/documentation/components/reference/amp-carousel.md', locale=doc.locale).url.path}}) do `<amp-carousel>`:
 
@@ -196,7 +196,7 @@ Quando olhamos para a [documentação]({{g.doc('/content/amp-dev/documentation/c
 
 - Quais layouts este componente suporta?
 
-{{ image('/static/img/courses/beginner/image25.png', 512, 386, caption='Página de documentação de AMP para `<amp-carousel>`.') }}
+{{ image('/static/img/courses/beginner/image25.png', 512, 386, caption='Página de documentação de AMP para <amp‑carousel>.') }}
 
 Veja os seguintes itens na [documentação]({{g.doc('/content/amp-dev/documentation/components/reference/amp-carousel.md', locale=doc.locale).url.path}}) do `<amp-carousel>`:
 
@@ -302,7 +302,7 @@ Lembre-se de incluir o script `<amp-carousel>` no `<head>`:
 
 Podemos ainda ter dúvidas sobre como o componente atuaria em nosso site, ou podemos não estar certos sobre como usar o componente de maneiras mais complexas. A sessão [AMP por exemplo]({{g.doc('/content/amp-dev/documentation/examples/index.html', locale=doc.locale).url.path}}) em amp.dev tem páginas que mostram muitos componentes AMP, mostrando uma variedade de maneiras de configurar esses componentes para atender a casos de uso comuns em sites modernos. Ele também possui playgrounds de codificação, onde você pode executar seus próprios experimentos.
 
-{{ image('/static/img/courses/beginner/image7.webp', 1024, 699, caption='Página AMP por exemplo para o componente`<amp-carousel>`.') }}
+{{ image('/static/img/courses/beginner/image7.webp', 1024, 699, caption='Página AMP por exemplo para o componente <amp‑carousel>.') }}
 
 ## Exercício 6: Adicionando Links de Compartilhamento Social
 


### PR DESCRIPTION
The HTML output contained the word "code" and htmlentities. Removed markdown code markers, and replaced hyphen with something similar to avoid line break.

@matthiasrohmer , what I've done here is pretty hacky... "<amp-carousel>" was breaking at the hyphen in the Portuguese version, and when I tried an htmlentity for a nonbreaking hyphen, that was output literally. So I used a Unicode character that resembles a hyphen. This is not what we'd call a best practice :)

I wonder if we'd consider letting picture captions be wider than 300 px. That would solve this problem too.