### PR TITLE
remove unused package

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "randomstring": "1.1.5",
     "rcs-core": "3.5.1",
     "rss-to-json": "1.1.1",
-    "safe-eval": "0.4.1",
     "shrink-ray-current": "4.1.2",
     "signale": "1.4.0",
     "uuid": "8.3.1",


### PR DESCRIPTION
package was added in a4fc6ce2d4046581005385ba9f4e855c8d030401, but was never actually used.