### PR TITLE
use CSP reporting endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12013,6 +12013,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "helmet-csp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-3.2.0.tgz",
+      "integrity": "sha512-kF9bqY39/d4btEetQR6DiUBmHuzJqAPqxU+nF5vd3vEj6Lo2W4UMFqHuj5tS6MOcQ2vnEyDaKsE5ooVohEM6Gw=="
+    },
     "hex-color-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		"express": "4.17.1",
 		"express-formidable": "1.2.0",
 		"gcp-metadata": "4.2.1",
+    "helmet-csp": "3.2.0",
 		"http-proxy": "1.18.1",
 		"iltorb": "2.4.5",
 		"ioredis": "4.19.4",

--- a/platform/lib/middleware/csp.js
+++ b/platform/lib/middleware/csp.js
@@ -50,7 +50,7 @@ module.exports = (req, res, next) => {
       'https://cdn.ampproject.org/rtv/',
       ...getDynamicHosts(),
     ],
-    reportUri: ['https://csp-collector.appspot.com/csp/amp'],
+    reportUri: ['/csp-report'],
   };
 
   // Allow unsafe-inline for examples

--- a/platform/lib/middleware/csp.js
+++ b/platform/lib/middleware/csp.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const contentSecurityPolicy = require('helmet-csp');
+const config = require('@lib/config');
+
+const getDynamicHosts = () =>
+  ['playground', 'preview', 'go', 'log']
+    .map((key) => {
+      const {[key]: hostConfig} = config.hosts || {};
+      if (hostConfig) {
+        return `${config.getHost(hostConfig)}/`;
+      }
+    })
+    .filter((v) => v);
+
+module.exports = (req, res, next) => {
+  const directives = {
+    defaultSrc: ['*', 'data:', 'blob:'],
+    workerSrc: [`'self'`, 'blob:'],
+    scriptSrc: [
+      'blob:',
+      `'unsafe-inline'`,
+      'https://cdn.ampproject.org/v0.js',
+      'https://cdn.ampproject.org/v0/',
+      'https://cdn.ampproject.org/sw/',
+      'https://cdn.ampproject.org/viewer/',
+      'https://cdn.ampproject.org/rtv/',
+      'https://www.googletagmanager.com/gtag/js',
+      ...getDynamicHosts(),
+    ],
+    objectSrc: [`'none'`],
+    styleSrc: [
+      `'unsafe-inline'`,
+      'https://cdn.ampproject.org/rtv/',
+      ...getDynamicHosts(),
+    ],
+    reportUri: ['https://csp-collector.appspot.com/csp/amp'],
+  };
+
+  // Allow unsafe-inline for examples
+  if (/\/documentation\/examples\//.test(req.path)) {
+    directives.scriptSrc = [...directives.scriptSrc, `'unsafe-inline'`];
+  }
+
+  // Add security headers.
+  contentSecurityPolicy({
+    directives,
+    reportOnly: true,
+  })(req, res, next);
+};

--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -28,6 +28,7 @@ const webSocketServer = require('@examples/socket-server/socket-server');
 
 const routers = {
   boilerplate: require('../../boilerplate/backend/'),
+  cspReport: require('@lib/routers/cspReport.js'),
   example: {
     api: require('@examples'),
     embeds: require('@lib/routers/example/embeds.js'),
@@ -36,16 +37,16 @@ const routers = {
     experiments: require('@lib/routers/example/experiments.js'),
     inline: require('@lib/routers/inlineExamples.js'),
   },
-  log: require('@lib/routers/runtimeLog.js'),
   go: require('@lib/routers/go.js'),
+  growPages: require('@lib/routers/growPages.js').growPages,
   growSharedPages: require('@lib/routers/growSharedPages.js'),
   growXmls: require('@lib/routers/growXmls.js'),
-  growPages: require('@lib/routers/growPages.js').growPages,
   healthCheck: require('@lib/routers/healthCheck.js').router,
+  log: require('@lib/routers/runtimeLog.js'),
   notFound: require('@lib/routers/notFound.js'),
   packager: require('@lib/routers/packager.js'),
-  playground: require('../../playground/backend/'),
   pixi: require('../../pixi/backend/'),
+  playground: require('../../playground/backend/'),
   search: require('@lib/routers/search.js'),
   static: require('@lib/routers/static.js'),
   templates: require('@lib/routers/templates.js'),
@@ -103,6 +104,7 @@ class Platform {
 
   _configureMiddlewares() {
     this.server.use(shrinkRay());
+    this.server.use(require('./middleware/csp.js'));
     this.server.use(require('./middleware/security.js'));
     this.server.use(require('./middleware/redirects.js'));
     this.server.use(require('./middleware/caching.js'));
@@ -117,6 +119,7 @@ class Platform {
         email: true,
       })
     );
+
     // debug computing times
     this.server.use((req, res, next) => {
       const timeStart = process.hrtime();
@@ -165,6 +168,7 @@ class Platform {
   }
 
   _configureRouters() {
+    this.server.use(routers.cspReport);
     this.server.use(routers.packager);
     this.server.use(routers.thumbor);
     this.server.use(routers.whoAmI);

--- a/platform/lib/routers/cspReport.js
+++ b/platform/lib/routers/cspReport.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const express = require('express');
+const log = require('@lib/utils/log')('CSP Violation Report')
+
+// eslint-disable-next-line new-cap
+const cspReportRouter = express.Router();
+
+cspReportRouter.use('/csp-report', express.json({ type: 'application/csp-report' }));
+
+cspReportRouter.post('/csp-report', (req, res) => {
+  log.error(req.body)
+});
+
+module.exports = cspReportRouter;

--- a/platform/lib/routers/cspReport.js
+++ b/platform/lib/routers/cspReport.js
@@ -17,15 +17,19 @@
 'use strict';
 
 const express = require('express');
-const log = require('@lib/utils/log')('CSP Violation Report')
+const log = require('@lib/utils/log')('CSP Violation Report');
 
 // eslint-disable-next-line new-cap
 const cspReportRouter = express.Router();
 
-cspReportRouter.use('/csp-report', express.json({ type: 'application/csp-report' }));
+cspReportRouter.use(
+  '/csp-report',
+  express.json({type: 'application/csp-report'})
+);
 
 cspReportRouter.post('/csp-report', (req, res) => {
-  log.error(req.body)
+  log.error(req.body);
+  res.sendStatus(200);
 });
 
 module.exports = cspReportRouter;


### PR DESCRIPTION
Turn on the [reporting](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only), rather than blocking, in CSP, so we can audit potential issues

https://csp-collector.appspot.com/csp/amp is listed as a the endpoint, which is the csp report collector for @ampproject, probably should use a different endpoint?