### PR TITLE
Fix amp-next-page example

### DIFF
--- a/examples/source/1.components/amp-next-page.html
+++ b/examples/source/1.components/amp-next-page.html
@@ -69,27 +69,27 @@
         {
           "title": "amp-img",
           "image": "<% hosts.preview %>/static/samples/img/amp.jpg",
-          "url": "<% hosts.preview %>/documentation/examples/components/amp-img/"
+          "url": "<% hosts.playground %>/documentation/examples/components/amp-img/"
         },
         {
           "title": "amp-bind",
           "image": "<% hosts.preview %>/static/samples/img/amp.jpg",
-          "url": "<% hosts.preview %>/documentation/examples/components/amp-bind/"
+          "url": "<% hosts.playground %>/documentation/examples/components/amp-bind/"
         },
         {
           "title": "amp-accordion",
           "image": "<% hosts.preview %>/static/samples/img/amp.jpg",
-          "url": "<% hosts.preview %>/documentation/examples/components/amp-accordion/"
+          "url": "<% hosts.playground %>/documentation/examples/components/amp-accordion/"
         },
         {
           "title": "amp-lightbox-gallery",
           "image": "<% hosts.preview %>/static/samples/img/amp.jpg",
-          "url": "<% hosts.preview %>/documentation/examples/components/amp-lightbox-gallery/"
+          "url": "<% hosts.playground %>/documentation/examples/components/amp-lightbox-gallery/"
         },
         {
           "title": "amp-list",
           "image": "<% hosts.preview %>/static/samples/img/amp.jpg",
-          "url": "<% hosts.preview %>/documentation/examples/components/amp-list/"
+          "url": "<% hosts.playground %>/documentation/examples/components/amp-list/"
         }
       ]
     </script>


### PR DESCRIPTION
amp-next-page JSON config requires the URL to be on the same origin.

Fixes #4319