### PR TITLE
📌  Update to js-yaml 4 and replace safe prefix from yaml methods

### DIFF
--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -540,7 +540,7 @@ function persistBuildInfo(done) {
     },
   };
 
-  fs.writeFile(project.paths.BUILD_INFO, yaml.safeDump(buildInfo), done);
+  fs.writeFile(project.paths.BUILD_INFO, yaml.dump(buildInfo), done);
 }
 
 exports.clean = clean;

--- a/gulpfile.js/import/importRoadmap.js
+++ b/gulpfile.js/import/importRoadmap.js
@@ -133,7 +133,7 @@ async function getMetaForWorkigGroup(workingGroup) {
     log.warn(`.. ${workingGroup.name} - METADATA.yaml not found`);
   }
   try {
-    meta = yaml.safeLoad(meta);
+    meta = yaml.load(meta);
   } catch (e) {
     log.error(
       `.. ${workingGroup.name} - Failed loading ${DEFAULT_ORGANISATION}` +

--- a/gulpfile.js/import/importWorkingGroups.js
+++ b/gulpfile.js/import/importWorkingGroups.js
@@ -56,7 +56,7 @@ async function _importWorkingGroup(client, wg) {
     return Promise.resolve();
   }
   try {
-    meta = yaml.safeLoad(meta);
+    meta = yaml.load(meta);
   } catch (e) {
     log.error(
       `Failed loading ${DEFAULT_ORGANISATION}/${wg.name}/METADATA.yaml`,

--- a/gulpfile.js/lint.js
+++ b/gulpfile.js/lint.js
@@ -38,7 +38,7 @@ function lintYaml() {
             `Can not validate ${file.relative} as it contains custom constructors`
           );
         } else {
-          yaml.safeLoad(file.contents);
+          yaml.load(file.contents);
         }
 
         callback();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2001,6 +2001,15 @@
             "uri-js": "^4.2.2"
           }
         },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -2047,6 +2056,16 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "ms": {
           "version": "2.1.2",
@@ -2396,6 +2415,15 @@
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2404,6 +2432,16 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "locate-path": {
@@ -4224,12 +4262,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -6936,6 +6971,15 @@
         "parse-json": "^4.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "import-fresh": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -6944,6 +6988,16 @@
           "requires": {
             "caller-path": "^2.0.0",
             "resolve-from": "^3.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "resolve-from": {
@@ -8562,6 +8616,15 @@
             "color-convert": "^2.0.1"
           }
         },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "chalk": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -8672,6 +8735,16 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "ms": {
           "version": "2.1.2",
@@ -15169,12 +15242,11 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsbn": {
@@ -21021,7 +21093,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -21907,6 +21980,15 @@
         "util.promisify": "~1.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "css-select": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
@@ -21933,6 +22015,16 @@
           "requires": {
             "dom-serializer": "0",
             "domelementtype": "1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"http-proxy": "1.18.1",
 		"iltorb": "2.4.5",
 		"ioredis": "4.19.4",
-		"js-yaml": "3.14.1",
+		"js-yaml": "4.0.0",
 		"json-tree-view": "0.4.12",
 		"linkifyjs": "2.1.9",
 		"lru-cache": "6.0.0",

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -282,7 +282,7 @@ class SamplesBuilder {
 
     const platformHost = config.getHost(config.hosts.platform);
     const websocketHost = config.getHost(config.hosts.websocket);
-    
+
     const parsedSample = await abe.parseSample(samplePath, {
       'base_path': `${platformHost}${this._getBaseRoute(sample)}`,
       'canonical': `${platformHost}${this._getDocumentationRoute(sample)}`,
@@ -572,7 +572,7 @@ class SamplesBuilder {
     // Build actual file needed for Grow to render the documentation
     manual.contents = Buffer.from([
       '---',
-      yaml.safeDump(header, {'lineWidth': 500}),
+      yaml.dump(header, {'lineWidth': 500}),
       // Add example manually as constructors may not be quoted
       `example: !g.json /${DOCUMENTATION_POD_PATH}/${manual.stem}.json`,
       // ... and some additional information that is used by the example teaser
@@ -611,7 +611,7 @@ class SamplesBuilder {
       }};
     }
 
-    return yaml.safeDump(teaserData, {'lineWidth': 500});
+    return yaml.dump(teaserData, {'lineWidth': 500});
   }
 
   /**
@@ -774,7 +774,7 @@ class SamplesBuilder {
     preview.isPreview = true;
     preview.contents = Buffer.from([
       '---',
-      yaml.safeDump({
+      yaml.dump({
         '$title': parsedSample.document.title,
         '$view': PREVIEW_TEMPLATE,
         '$category': this._getCategory(sample),

--- a/platform/lib/config.js
+++ b/platform/lib/config.js
@@ -203,7 +203,7 @@ class Config {
     Object.assign(options, this.options);
 
     let podspec = fs.readFileSync(GROW_CONFIG_TEMPLATE_PATH, 'utf-8');
-    podspec = yaml.safeLoad(podspec);
+    podspec = yaml.load(podspec);
 
     // disable sitemap (useful for test builds)
     if (options.noSitemap) {

--- a/platform/lib/middleware/redirects.js
+++ b/platform/lib/middleware/redirects.js
@@ -31,7 +31,7 @@ const REDIRECT_LINKS_DEFINITION = join(
   __dirname,
   '../../config/amp-dev-redirects.yaml'
 );
-const redirectLinks = yaml.safeLoad(readFileSync(REDIRECT_LINKS_DEFINITION));
+const redirectLinks = yaml.load(readFileSync(REDIRECT_LINKS_DEFINITION));
 
 const AVAILABLE_LOCALES = config.getAvailableLocales();
 const LANGUAGE_PATH_PATTERN = /^\/([a-z]{2}(_[a-z]{2})?)\//;

--- a/platform/lib/middleware/redirects.test.js
+++ b/platform/lib/middleware/redirects.test.js
@@ -14,9 +14,9 @@ const UNIT_TEST_REDIRECTS = `
 
 jest.mock('js-yaml');
 const yaml = require('js-yaml');
-const {safeLoad} = jest.requireActual('js-yaml');
-const unitTestRedirects = safeLoad(UNIT_TEST_REDIRECTS);
-yaml.safeLoad.mockReturnValue(unitTestRedirects);
+const {load} = jest.requireActual('js-yaml');
+const unitTestRedirects = load(UNIT_TEST_REDIRECTS);
+yaml.load.mockReturnValue(unitTestRedirects);
 
 const app = express();
 const router = require('./redirects.js');

--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -253,7 +253,7 @@ class MarkdownDocument {
         // Strip out limiters from frontmatter string to be able to parse it
         // and then use it as initial fill for the actual properties
         frontmatter = frontmatter.replace(/---/g, '');
-        return yaml.safeLoad(frontmatter);
+        return yaml.load(frontmatter);
       }
     } else {
       throw Error('contents does not contain a frontmatter block.');
@@ -418,7 +418,7 @@ class MarkdownDocument {
    */
   save(path) {
     let content = '';
-    const frontmatter = `---\n${yaml.safeDump(this._frontmatter, {
+    const frontmatter = `---\n${yaml.dump(this._frontmatter, {
       'skipInvalid': true,
     })}---\n\n`;
     content += frontmatter;

--- a/platform/lib/pipeline/recentGuides.js
+++ b/platform/lib/pipeline/recentGuides.js
@@ -75,7 +75,7 @@ class RecentGuides {
       guides.sort((a, b) => (a.date > b.date ? -1 : 1));
       fs.writeFileSync(
         DEST_FILE,
-        yaml.safeDump(guides, {
+        yaml.dump(guides, {
           lineWidth: 'none',
         })
       );

--- a/platform/lib/routers/go.js
+++ b/platform/lib/routers/go.js
@@ -29,7 +29,7 @@ const GO_LINKS_DEFINITION = join(__dirname, '../../config/go-links.yaml');
 // eslint-disable-next-line new-cap
 const go = express.Router();
 
-const goLinks = initGoLinks(yaml.safeLoad(readFileSync(GO_LINKS_DEFINITION)));
+const goLinks = initGoLinks(yaml.load(readFileSync(GO_LINKS_DEFINITION)));
 
 go.use((request, response, next) => {
   const requestPath = request.path.replace(/\/?$/, '');

--- a/platform/lib/routers/go.test.js
+++ b/platform/lib/routers/go.test.js
@@ -11,9 +11,9 @@ const GO_LINKS_YAML = `
 
 jest.mock('js-yaml');
 const yaml = require('js-yaml');
-const {safeLoad} = jest.requireActual('js-yaml');
-const goLinks = safeLoad(GO_LINKS_YAML);
-yaml.safeLoad.mockReturnValue(goLinks);
+const {load} = jest.requireActual('js-yaml');
+const goLinks = load(GO_LINKS_YAML);
+yaml.load.mockReturnValue(goLinks);
 
 const app = express();
 const router = require('./go.js');

--- a/platform/lib/routers/whoAmI.js
+++ b/platform/lib/routers/whoAmI.js
@@ -27,7 +27,7 @@ const whoAmI = express.Router();
 const info = {
   'environment': config.environment,
   'instance': process.env.GAE_INSTANCE,
-  'build': yaml.safeLoad(
+  'build': yaml.load(
     fs.readFileSync(utils.project.paths.BUILD_INFO_PATH, 'utf8')
   ),
 };

--- a/platform/lib/samples/DocumentParser.js
+++ b/platform/lib/samples/DocumentParser.js
@@ -142,7 +142,7 @@ class DocumentParser {
         if (trimmedLine.endsWith('--->')) {
           this.inMetadata = false;
           try {
-            this.document.metadata = yaml.safeLoad(this.metadata);
+            this.document.metadata = yaml.load(this.metadata);
           } catch (err) {
             throw new Error(
               'There is an error in the YAML frontmatter in ' +

--- a/platform/lib/utils/pageCache.js
+++ b/platform/lib/utils/pageCache.js
@@ -28,7 +28,7 @@ const fs = require('fs');
 const LRU = require('lru-cache');
 const gcpMetadata = require('gcp-metadata');
 
-const buildInfo = yaml.safeLoad(
+const buildInfo = yaml.load(
   fs.readFileSync(utils.project.paths.BUILD_INFO_PATH, 'utf8')
 );
 


### PR DESCRIPTION
Replaces #5155 following the [migration guide](https://github.com/nodeca/js-yaml/blob/master/migrate_v3_to_v4.md).