### PR TITLE
fix build

### DIFF
--- a/frontend21/webpack.config.js
+++ b/frontend21/webpack.config.js
@@ -84,7 +84,7 @@ module.exports = (env, argv) => {
             copy: [
               {
                 source: './dist/base.html',
-                destination: '../pages/views/2021',
+                destination: '../pages/views/2021/',
               },
               {
                 source: './dist/static/**/*',


### PR DESCRIPTION
the build has been failing recently
![image](https://user-images.githubusercontent.com/465414/104241639-fd9a3200-542b-11eb-90dc-fa10f985d720.png)

The failure happens because some of the files aren't being copied over properly in the webpack phase (sidenote - there was an [error logged](https://travis-ci.com/github/ampproject/amp.dev/jobs/470622479#L688), but it doesn't change the exit code of the webpack build so it was getting lost in the wall of text in travis)

[filemanager-webpack-plugin](https://github.com/gregnb/filemanager-webpack-plugin) [switched to using fs-extra](https://github.com/gregnb/filemanager-webpack-plugin/commit/07726e09612378a9a5200602c327415df09c5b09#diff-c9ba150069a18b5ecb200e2eaca3dd1a3391d2f558547a98c1f5142d2c3e1c1eR6) for the actual copying in v3, which [we recently updated to](https://github.com/ampproject/amp.dev/commit/cd5cc1e13f827dc5a95e4c6c2b7ff9694e169d9b#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R132).

This matters because fs-extra follows unix rules, in that with our [current syntax](https://github.com/ampproject/amp.dev/commit/be0b880b4030ce647035f19bfbf8997f23965dde#diff-cb805dec65c8f4dd31b918c81dca4230ee7a00f158307d67b8d5b15e62662ac7L87) we are trying to overwrite the folder `../pages/views/2021` with the file rather than placing the file within that path. Adding a trailing slash fixes that, and unblocks the build