### PR TITLE
🐛 Pixi: Check for falsy value instead of undefined specifically

### DIFF
--- a/pixi/src/utils/checkAggregation/statusBanner.js
+++ b/pixi/src/utils/checkAggregation/statusBanner.js
@@ -63,7 +63,7 @@ async function getStatusId(checkPromises, recommendationsPromise) {
     const pagePassedAll =
       pageExperience[dataType].isAllFast && passedOtherCriteria;
 
-    if (cacheExperience && cacheExperience[dataType] !== undefined) {
+    if (cacheExperience && cacheExperience[dataType]) {
       const cachePassedAll =
         cacheExperience[dataType].isAllFast && passedOtherCriteria;
       if (cachePassedAll && !pagePassedAll) {

--- a/pixi/src/utils/checkAggregation/statusBanner.js
+++ b/pixi/src/utils/checkAggregation/statusBanner.js
@@ -93,6 +93,7 @@ async function getStatusId(checkPromises, recommendationsPromise) {
     }
     return 'all-passed';
   } catch (err) {
+    console.error('Failed to determine final status', err);
     return 'generic-error';
   }
 }

--- a/pixi/webpack.config.js
+++ b/pixi/webpack.config.js
@@ -25,6 +25,13 @@ module.exports = (env, argv) => {
     },
     devtool: mode == 'development' ? 'cheap-module-source-map' : false,
     plugins: [
+      new CleanWebpackPlugin({
+        dry: false,
+        dangerouslyAllowCleanPatternsOutsideProject: true,
+        cleanOnceBeforeBuildPatterns: [
+          path.join(process.cwd(), '../dist/static/page-experience'),
+        ],
+      }),
       new HtmlWebpackPlugin({
         template: path.join(__dirname, 'src/ui/page-experience.hbs'),
         filename: './pixi.html',
@@ -61,6 +68,13 @@ module.exports = (env, argv) => {
       }),
       new FileManagerPlugin({
         events: {
+          // Blocked by https://github.com/gregnb/filemanager-webpack-plugin/issues/89
+          // Would allow removeal of clean-webpack-plugin
+          // onStart: {
+          //   delete: [
+          //     '../dist/static/page-experience/',
+          //   ]
+          // },
           onEnd: {
             copy: [
               {
@@ -79,13 +93,6 @@ module.exports = (env, argv) => {
             ],
           },
         },
-      }),
-      new CleanWebpackPlugin({
-        dry: false,
-        dangerouslyAllowCleanPatternsOutsideProject: true,
-        cleanAfterEveryBuildPatterns: [
-          path.join(process.cwd(), '../dist/static/page-experience'),
-        ],
       }),
     ],
     module: {


### PR DESCRIPTION
Fixes #5205. `cacheExperience[dataType]` is either an object or `null` but never undefined.

The webpack config changes are not closely related to this bug but any of the latest updates to either the `CleanWebpackPlugin` or `FileManagerPlugin` caused a race condition that delete the created bundles before they can get copied to where express can find them.