### PR TITLE
⏪  Revert changes to component reference importer

### DIFF
--- a/platform/config/imports/componentReference.json
+++ b/platform/config/imports/componentReference.json
@@ -1,31 +1,4 @@
 {
 	"only": [],
-	"fetchFromMaster": [
-		"amp-access-laterpay",
-		"amp-accordion",
-		"amp-app-banner",
-		"amp-base-carousel",
-		"amp-bind",
-		"amp-carousel",
-		"amp-consent",
-		"amp-date-countdown",
-		"amp-date-display",
-		"amp-fit-text",
-		"amp-inline-gallery",
-		"amp-inline-gallery-pagination",
-		"amp-inline-gallery-thumbnails",
-		"amp-instagram",
-		"amp-lightbox",
-		"amp-list",
-		"amp-script",
-		"amp-selector",
-		"amp-social-share",
-		"amp-story",
-		"amp-stream-gallery",
-		"amp-subscriptions",
-		"amp-timeago",
-		"amp-video",
-		"amp-video-iframe",
-		"amp-youtube"
-	]
+	"fetchFromMaster": ["amp-youtube", "amp-access-laterpay", "amp-app-banner", "amp-script", "amp-carousel", "amp-consent", "amp-bind", "amp-story", "amp-subscriptions", "amp-list", "amp-script"]
 }

--- a/platform/lib/pipeline/componentReferenceDocument.js
+++ b/platform/lib/pipeline/componentReferenceDocument.js
@@ -31,7 +31,7 @@ class ComponentReferenceDocument extends MarkdownDocument {
     this.title = extension.name;
     this.version = extension.version;
     this.versions = extension.versions;
-    this.latestVersion = extension.latestVersion;
+    this.latestVersion = extension.versions[extension.versions.length - 1];
 
     // Force enable TOC for all component docs
     this.toc = true;


### PR DESCRIPTION
This reverts various changes done to the component reference importer and related stuff to get the state on `future` back in a healthy, deployable state.

PR reintroducing the changes done to have the bento docs live upcoming.