### PR TITLE
Remove JavaScript from Tink-supported languages

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/monetization/content_encryption.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/monetization/content_encryption.md
@@ -129,7 +129,7 @@ You must use Tink to decrypt document keys in your authorizer. To decrypt with T
 
 Your HybridDecrypt/Authorizer deployment should roughly match your key rotation schedule. This creates availability of all generated keys to the HybridDecrypt client.
 
-Tink has extensive [documentation](https://github.com/google/tink/tree/master/docs) and [examples](https://github.com/google/tink/tree/master/examples) in C++, Java, Go, and Javascript to help you get started on your server-side implementation.
+Tink has extensive [documentation](https://github.com/google/tink/tree/master/docs) and [examples](https://github.com/google/tink/tree/master/examples) in C++, Java, Go, and Python to help you get started on your server-side implementation.
 
 ### Request management
 


### PR DESCRIPTION
Tink for JavaScript only works in a browser environment, not in Node.js. Furthermore, it is in an extremely alpha-quality state, largely undocumented, and people shouldn't be directed to it at this point in its development unless they want to brave a lot of sharp edges.

I added Python to the list instead, since support for that is more mature.

If the AMP Project considers Tink Node.js support important for the AMP ecosystem, let me know and I'll see what we can do. There might not be much movement until March, though.