### PR TITLE
🐛 Fix amp-validation error caused by inline custom properties

### DIFF
--- a/frontend/scss/_variables.scss
+++ b/frontend/scss/_variables.scss
@@ -59,6 +59,7 @@ $colors: (
   'slack':           #45184B,
   'lav-magenta':     #EB49E1,
   'electric-violet': #5500D7,
+  'chestnut-rose':   #D45A5A,
 );
 
 $safeColors: (

--- a/frontend/scss/components/atoms/pill.scss
+++ b/frontend/scss/components/atoms/pill.scss
@@ -56,4 +56,9 @@
     color: safeColor('white');
     pointer-events: none;
   }
+
+  &-bento {
+    background-color: color('chestnut-rose');
+    color: safeColor('white');
+  }
 }

--- a/frontend/templates/views/partials/component-headline.j2
+++ b/frontend/templates/views/partials/component-headline.j2
@@ -29,8 +29,7 @@
 {% endif %}
 {% if doc.bento %}
   {% do doc.styles.addCssFile('css/components/atoms/pill.css') %}
-  <div class="ap-a-pill ap-a-pill-small" style="--background-color:
-  #D45A5A; --color: #FFF;">
+  <div class="ap-a-pill ap-a-pill-small ap-a-pill-bento">
     {{ _('Bento') }}
   </div>
 {% endif %}


### PR DESCRIPTION
* Remove inline custom properties
* Create modifier class in CSS
* Fixes #5256 