### PR TITLE
Add bento js + CSS copy script

### DIFF
--- a/frontend/scss/components/atoms/copy-script.scss
+++ b/frontend/scss/components/atoms/copy-script.scss
@@ -7,12 +7,12 @@
   display: flex;
   align-items: center;
 
-  code {
+  pre {
     overflow-x: scroll;
     flex: 1 0;
     margin: 6px 8px 6px 0;
     padding: 4px 6px;
-    white-space: nowrap;
+    white-space: pre;
     background: color('iron');
     font-size: 12.6px;
 

--- a/frontend/scss/components/organisms/component-intro.scss
+++ b/frontend/scss/components/organisms/component-intro.scss
@@ -23,7 +23,6 @@
     }
 
     &-inline {
-
       @media (min-width: 768px) {
         display: flex;
         align-items: baseline;
@@ -31,45 +30,49 @@
     }
   }
 
-    &-headline {
-      font-size: 16px;
-      margin: 0 0 10px 0;
+  &-headline {
+    font-size: 16px;
+    margin: 0 0 10px 0;
 
-      #{$root}-row-inline & {
-        white-space: nowrap;
-        margin-right: 10px;
-      }
+    #{$root}-row-inline & {
+      white-space: nowrap;
+      margin-right: 10px;
     }
 
-    &-text {
-      margin: 5px 0;
+    .active {
+      color: blue;
+    }
+  }
+
+  &-text {
+    margin: 5px 0;
+  }
+
+  &-list {
+    max-height: 142px;
+    overflow: hidden;
+
+    @media (min-width: 768px) {
+      display: flex;
+      flex-wrap: wrap;
     }
 
-    &-list {
-      max-height: 142px;
+    &-item {
+      display: block;
+      margin-bottom: 6px;
+      @include txt-2;
+      white-space: nowrap;
       overflow: hidden;
+      text-overflow: ellipsis;
 
       @media (min-width: 768px) {
-        display: flex;
-        flex-wrap: wrap;
-      }
-
-      &-item {
-        display: block;
-        margin-bottom: 6px;
-        @include txt-2;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-
-        @media (min-width: 768px) {
-          width: 50%;
-          padding-right: 12px;
-        }
-      }
-
-      .expanded & {
-        max-height: none;
+        width: 50%;
+        padding-right: 12px;
       }
     }
+
+    .expanded & {
+      max-height: none;
+    }
+  }
 }

--- a/frontend/templates/views/partials/component-intro.j2
+++ b/frontend/templates/views/partials/component-intro.j2
@@ -19,18 +19,20 @@
     {% do doc.styles.addCssFile('css/components/atoms/copy-script.css') %}
     {% do doc.styles.addCssFile('css/components/molecules/code-snippet.css') %}
     {% for script in doc.scripts %}
-    {% set bentoScript =  script.js + '\n' + script.css %}
-    <div class="ap-a-copy-script" [hidden]="bento"><pre>{{ script|e }}</pre><amp-iframe
+    {% set bentoScript =  (script.js + '\n' + script.css) %}
+    <div class="ap-a-copy-script" [hidden]="bento">
+      <pre>{{ script.js|e }}</pre><amp-iframe
           width="24"
           height="24"
           layout="fixed"
           sandbox="allow-scripts"
-          src="{{ podspec.base_urls.platform }}/shared/copy-script/#{{ script|urlencode }}">
+          src="{{ podspec.base_urls.platform }}/shared/copy-script/#{{ script.js|urlencode }}">
         <div placeholder></div>
       </amp-iframe>
     </div>
     {% if doc.bento %}
-    <div class="ap-a-copy-script" hidden [hidden]="!bento"><pre>{{ bentoScript|e }}</pre><amp-iframe width="24"
+    <div class="ap-a-copy-script" hidden [hidden]="!bento">
+      <pre>{{ bentoScript|e }}</pre><amp-iframe width="24"
           height="24"
           layout="fixed"
           sandbox="allow-scripts"

--- a/frontend/templates/views/partials/component-intro.j2
+++ b/frontend/templates/views/partials/component-intro.j2
@@ -1,75 +1,89 @@
 {% do doc.styles.addCssFile('css/components/organisms/component-intro.css') %}
 <div class="ap-o-component-intro">
-  {% if doc.teaser %}
-  <div class="ap-o-component-intro-row">
-    <h4 class="ap-o-component-intro-headline">{{ _('Description') }}</h4>
-    <p class="ap-o-component-intro-text">{{ doc.teaser.text }}</p>
-  </div>
-  {% endif %}
+  {% if doc.teaser %}
+  <div class="ap-o-component-intro-row">
+    <h4 class="ap-o-component-intro-headline">{{ _('Description') }}</h4>
+    <p class="ap-o-component-intro-text">{{ doc.teaser.text }}</p>
+  </div>
+  {% endif %}
 
-  {% if doc.scripts %}
-  <div class="ap-o-component-intro-row">
-    <h4 class="ap-o-component-intro-headline">{{ _('Required Scripts') }}</h4>
+  {% if doc.scripts %}
+  <div class="ap-o-component-intro-row" id="component-scripts">
+    <h4 class="ap-o-component-intro-headline">{{ _('Required Scripts') }} 
+      {% if doc.bento %}
+      <span class="ap-a-pill ap-a-pill-flat ap-a-pill-small ap-a-pill-link filtered" [class]="bento ? 'ap-a-pill ap-a-pill-flat ap-a-pill-small ap-a-pill-link ' : 'ap-a-pill ap-a-pill-flat ap-a-pill-small ap-a-pill-link filtered'" on="tap:AMP.setState({ 'bento': false })">AMP</span>
+      <span class="ap-a-pill ap-a-pill-flat ap-a-pill-small ap-a-pill-link" [class]="bento ? 'ap-a-pill ap-a-pill-flat ap-a-pill-small ap-a-pill-link filtered' : 'ap-a-pill ap-a-pill-flat ap-a-pill-small ap-a-pill-link'" on="tap:AMP.setState({ 'bento': true })">Bento (Standalone)</span>
+      {% endif %}
+    </h4>
 
-    {% do doc.styles.addCssFile('css/components/atoms/copy-script.css') %}
-    {% do doc.styles.addCssFile('css/components/molecules/code-snippet.css') %}
-    {% for script in doc.scripts %}
-    <div class="ap-a-copy-script">
-      <code>{{ script }}</code>
-      <amp-iframe
-          width="24"
-          height="24"
-          layout="fixed"
-          sandbox="allow-scripts"
-          src="{{ podspec.base_urls.platform }}/shared/copy-script/#{{ script|urlencode }}">
-        <div placeholder></div>
-      </amp-iframe>
-    </div>
-    {% endfor %}
-  </div>
-  {% endif %}
+    {% do doc.styles.addCssFile('css/components/atoms/copy-script.css') %}
+    {% do doc.styles.addCssFile('css/components/molecules/code-snippet.css') %}
+    {% for script in doc.scripts %}
+    {% set bentoScript =  script.js + '\n' + script.css %}
+    <div class="ap-a-copy-script" [hidden]="bento"><pre>{{ script|e }}</pre><amp-iframe
+          width="24"
+          height="24"
+          layout="fixed"
+          sandbox="allow-scripts"
+          src="{{ podspec.base_urls.platform }}/shared/copy-script/#{{ script|urlencode }}">
+        <div placeholder></div>
+      </amp-iframe>
+    </div>
+    {% if doc.bento %}
+    <div class="ap-a-copy-script" hidden [hidden]="!bento"><pre>{{ bentoScript|e }}</pre><amp-iframe width="24"
+          height="24"
+          layout="fixed"
+          sandbox="allow-scripts"
+          src="{{ podspec.base_urls.platform }}/shared/copy-script/#{{ bentoScript|safe|urlencode }}">
+        <div placeholder></div>
+      </amp-iframe>
+    </div>
+    {% endif %}
+    {% endfor %}
+  </div>
+  {% endif %}
 
-  {% if doc.layouts %}
-  <div class="ap-o-component-intro-row ap-o-component-intro-row-inline">
-    <h4 class="ap-o-component-intro-headline">{{ _('Supported Layouts') }}</h4>
+  {% if doc.layouts %}
+  <div class="ap-o-component-intro-row ap-o-component-intro-row-inline">
+    <h4 class="ap-o-component-intro-headline">{{ _('Supported Layouts') }}</h4>
 
-    <div>
-      {% do doc.styles.addCssFile('css/components/atoms/pill.css') %}
-      {% for item in doc.layouts %}
-      <a class="ap-a-pill ap-a-pill-flat ap-a-pill-small ap-a-pill-link" href="/documentation/guides-and-tutorials/learn/amp-html-layout/layouts_demonstrated.html#{{ item }}">{{ item }}</a>
-      {% endfor %}
-    </div>
-  </div>
-  {% endif %}
+    <div>
+      {% do doc.styles.addCssFile('css/components/atoms/pill.css') %}
+      {% for item in doc.layouts %}
+      <a class="ap-a-pill ap-a-pill-flat ap-a-pill-small ap-a-pill-link" href="/documentation/guides-and-tutorials/learn/amp-html-layout/layouts_demonstrated.html#{{ item }}">{{ item }}</a>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
 
-  {% set examples = g.json('/shared/data/componentSamples.json') %}
-  {# Check if there are examples for the current component #}
-  {% if examples[doc.title] %}
-  [% if format in {{ examples[doc.title]|map(attribute='formats')|sum(start=[])|unique|list|tojson }} %]
-  <div class="ap-o-component-intro-row">
-    {% do doc.styles.addCssFile('css/components/molecules/clip.css') %}
-    <div id="examples" class="ap-m-clip">
-      <h4 class="ap-o-component-intro-headline">{{ _('Examples') }}</h4>
-      <div class="ap-o-component-intro-list">
-        [% set examples = {{ examples[doc.title]|tojson }} %]
-        [% set examplesCount = 0 %]
+  {% set examples = g.json('/shared/data/componentSamples.json') %}
+  {# Check if there are examples for the current component #}
+  {% if examples[doc.title] %}
+  [% if format in {{ examples[doc.title]|map(attribute='formats')|sum(start=[])|unique|list|tojson }} %]
+  <div class="ap-o-component-intro-row">
+    {% do doc.styles.addCssFile('css/components/molecules/clip.css') %}
+    <div id="examples" class="ap-m-clip">
+      <h4 class="ap-o-component-intro-headline">{{ _('Examples') }}</h4>
+      <div class="ap-o-component-intro-list">
+        [% set examples = {{ examples[doc.title]|tojson }} %]
+        [% set examplesCount = 0 %]
 
-        [% for example in examples %]
-        [% if example.formats.includes(format) %]
-        [% set examplesCount = examplesCount + 1 %]
-        <a class="ap-o-component-intro-list-item" href="[= example.url =]">[= example.title =]</a>
-        [% endif %]
-        [% endfor %]
-      </div>
+        [% for example in examples %]
+        [% if example.formats.includes(format) %]
+        [% set examplesCount = examplesCount + 1 %]
+        <a class="ap-o-component-intro-list-item" href="[= example.url =]">[= example.title =]</a>
+        [% endif %]
+        [% endfor %]
+      </div>
 
-      [% if examplesCount > 6 %]
-      <button id="examples-expand" class="ap-m-clip-expand" on="tap:examples.toggleClass(class='expanded', force=true),examples-expand.hide()">
-        {% do doc.icons.useIcon('icons/angle-down-solid.svg') %}
-        <svg class="ap-m-clip-expand-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
-      </button>
-      [% endif %]
-    </div>
-  </div>
-  [% endif %]
-  {% endif %}
+      [% if examplesCount > 6 %]
+      <button id="examples-expand" class="ap-m-clip-expand" on="tap:examples.toggleClass(class='expanded', force=true),examples-expand.hide()">
+        {% do doc.icons.useIcon('icons/angle-down-solid.svg') %}
+        <svg class="ap-m-clip-expand-icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
+      </button>
+      [% endif %]
+    </div>
+  </div>
+  [% endif %]
+  {% endif %}
 </div>

--- a/pages/content/shared/copy-script.html
+++ b/pages/content/shared/copy-script.html
@@ -14,7 +14,7 @@ $sitemap:
     html, body { background: none transparent; width: 24px; height: 24px; overflow: hidden; }
     body { margin: 0; cursor: pointer; transition: transform .3s; }
     svg { fill: #005af0; }
-    input { opacity: 0; pointer-events: none; }
+    textarea { opacity: 0; pointer-events: none; }
     .copy-script-icon--default, .copy-script-icon--success { position: absolute; top: 3px; transition: transform .3s; }
     .copy-script-icon--success { opacity: 0; }
     .success { transform: translate3d(0, 2px, 0); }
@@ -36,7 +36,7 @@ $sitemap:
     {% do doc.icons.useIcon('/icons/checkmark.svg') %}
     <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#checkmark"></use></svg>
   </div>
-  <input id="script-tag">
+  <textarea id="script-tag"></textarea>
   <script>
     const animationDuration = 1200;
     const scriptTag = document.getElementById('script-tag');

--- a/platform/lib/pipeline/componentReferenceDocument.js
+++ b/platform/lib/pipeline/componentReferenceDocument.js
@@ -68,13 +68,17 @@ class ComponentReferenceDocument extends MarkdownDocument {
 
     if (extension.script) {
       requiredExtensions.push(extension.script.extensionSpec.name);
-      scripts.push(
-        this._generateScript(
+      scripts.push({
+        js: this._generateScript(
           extension.script.extensionSpec.name,
           extension.version,
           extension.type
-        )
-      );
+        ),
+        css: this._generateCss(
+          extension.script.extensionSpec.name,
+          extension.version
+        ),
+      });
 
       if (extension.script.requiresExtension) {
         for (const requiredExtension of extension.script.requiresExtension) {
@@ -82,18 +86,26 @@ class ComponentReferenceDocument extends MarkdownDocument {
             continue;
           }
 
-          scripts.push(
-            this._generateScript(
-              requiredExtension,
+          scripts.push({
+            js: this._generateScript(
+              extension.script.extensionSpec.name,
               DEFAULT_VERSION,
               extension.type
-            )
-          );
+            ),
+            css: this._generateCss(
+              extension.script.extensionSpec.name,
+              DEFAULT_VERSION
+            ),
+          });
         }
       }
     }
 
     this.scripts = scripts;
+  }
+
+  _generateCss(extensionName, extensionVersion) {
+    return `<link rel="stylesheet" href="https://cdn.ampproject.org/v0/${extensionName}-${extensionVersion}.css">`;
   }
 
   _generateScript(


### PR DESCRIPTION
This adds a pill to the copy script for toggling between valid AMP and
Bento mode.

<img width="645" alt="Screen Shot 2021-01-26 at 11 44 44" src="https://user-images.githubusercontent.com/380472/105835507-31e52500-5fcc-11eb-87e4-bb484dcf69e4.png">

<img width="649" alt="Screen Shot 2021-01-26 at 11 44 48" src="https://user-images.githubusercontent.com/380472/105835516-34477f00-5fcc-11eb-92f7-af9a7a084106.png">
