### PR TITLE
start rolling-formats mid animation to reduce change

### DIFF
--- a/frontend/scss/components/molecules/rolling-formats.scss
+++ b/frontend/scss/components/molecules/rolling-formats.scss
@@ -25,6 +25,7 @@
     grid-row: 1 / -1;
     margin-right: auto;
     animation: roll 8s cubic-bezier(0.25, 0.1, 0.25, 1) 1s infinite backwards;
+    animation-delay: -1s;
 
     @media (min-width: 768px) {
       margin-left: auto;
@@ -34,9 +35,9 @@
       margin-left: 0;
     }
 
-    &:nth-child(2) { animation-delay: 3s; opacity: 0; }
-    &:nth-child(3) { animation-delay: 5s; opacity: 0; }
-    &:nth-child(4) { animation-delay: 7s; opacity: 0; }
+    &:nth-child(2) { animation-delay: 2s; opacity: 0; }
+    &:nth-child(3) { animation-delay: 4s; opacity: 0; }
+    &:nth-child(4) { animation-delay: 6s; opacity: 0; }
   }
 }
 

--- a/frontend/scss/components/molecules/rolling-formats.scss
+++ b/frontend/scss/components/molecules/rolling-formats.scss
@@ -24,8 +24,7 @@
     grid-column: 1 / -1;
     grid-row: 1 / -1;
     margin-right: auto;
-    animation: roll 8s cubic-bezier(0.25, 0.1, 0.25, 1) 1s infinite backwards;
-    animation-delay: -1s;
+    animation: roll 8s cubic-bezier(0.25, 0.1, 0.25, 1) -1s infinite backwards;
 
     @media (min-width: 768px) {
       margin-left: auto;
@@ -35,9 +34,9 @@
       margin-left: 0;
     }
 
-    &:nth-child(2) { animation-delay: 2s; opacity: 0; }
-    &:nth-child(3) { animation-delay: 4s; opacity: 0; }
-    &:nth-child(4) { animation-delay: 6s; opacity: 0; }
+    &:nth-child(2) { animation-delay: 1s; opacity: 0; }
+    &:nth-child(3) { animation-delay: 3s; opacity: 0; }
+    &:nth-child(4) { animation-delay: 5s; opacity: 0; }
   }
 }
 


### PR DESCRIPTION
As the LCP is being triggered around 3 seconds, and is localized to the header, I was thinking the rolling formats may be the culprit. If this is the case, having text show immediately, or elongating the time that the initial the word is shown could help?