### PR TITLE
Add `sizes` for hero images in home stage

### DIFF
--- a/frontend/templates/views/partials/case-band.j2
+++ b/frontend/templates/views/partials/case-band.j2
@@ -3,7 +3,7 @@
 <div class="ap-o-case-band">
   {% for image in case_band_images %}
   <div class="ap-o-case-band-image">
-    <amp-img src="{{ image.src }}" alt="{{ _('A screenshot of a website using AMP.') }}" layout="responsive" width="{{ image.width }}" height="{{ image.height }}" data-hero></amp-img>
+    <amp-img src="{{ image.src }}" alt="{{ _('A screenshot of a website using AMP.') }}" layout="responsive" width="{{ image.width }}" height="{{ image.height }}" sizes="{{ image.sizes }}" data-hero></amp-img>
   </div>
   {% endfor %}
 </div>

--- a/pages/content/amp-dev/index.html
+++ b/pages/content/amp-dev/index.html
@@ -65,11 +65,11 @@ success_stories:
 
     {% with %}
     {% set case_band_images = [
-      {"src": "/static/img/case-band-image-2.jpg", "width": "106", "height": "190"},
-      {"src": "/static/img/case-band-image-1.png", "width": "131", "height": "152"},
-      {"src": "/static/img/case-band-image-5.jpg", "width": "180", "height": "115"},
-      {"src": "/static/img/case-band-image-4.jpg", "width": "144", "height": "214"},
-      {"src": "/static/img/case-band-image-3.jpg", "width": "162", "height": "104"}
+      {"src": "/static/img/case-band-image-2.jpg", "width": "106", "height": "190", "sizes": "(max-width: 450px) 150w, (max-width: 1280px) 330w, 470w"},
+      {"src": "/static/img/case-band-image-1.png", "width": "131", "height": "152", "sizes": "(max-width: 450px) 150w, (max-width: 1280px) 330w, 470w"},
+      {"src": "/static/img/case-band-image-5.jpg", "width": "180", "height": "115", "sizes": "(max-width: 450px) 180w, (max-width: 1280px) 390w, 560w"},
+      {"src": "/static/img/case-band-image-4.jpg", "width": "144", "height": "214", "sizes": "(max-width: 450px) 150w, (max-width: 1280px) 330w, 470w"},
+      {"src": "/static/img/case-band-image-3.jpg", "width": "162", "height": "104", "sizes": "(max-width: 450px) 180w, (max-width: 1280px) 390w, 560w"}
       ]
     %}
     {% include 'views/partials/case-band.j2' %}

--- a/platform/lib/routers/growPages.js
+++ b/platform/lib/routers/growPages.js
@@ -184,7 +184,11 @@ growPages.get(/^(.*\/)?([^\/\.]+|.+\.html|.*\/|$)$/, async (req, res, next) => {
     return;
   }
   // Preload critical font(s)
-  res.header('Link' , `<${config.hosts.platform.base}/static/fonts/poppins-v5-latin-700.woff2>; rel=preload; as=font; type=font/woff2; crossorigin`);
+  res.header(
+    'Link',
+    `<${config.hosts.platform.base}/static/fonts/poppins-v5-latin-700.woff2>` +
+      ';rel=preload;as=font;type=font/woff2;crossorigin'
+  );
 
   // Check if the page has been cached
   const cachedPage = await pageCache.get(req.originalUrl);

--- a/platform/lib/routers/growPages.js
+++ b/platform/lib/routers/growPages.js
@@ -183,6 +183,8 @@ growPages.get(/^(.*\/)?([^\/\.]+|.+\.html|.*\/|$)$/, async (req, res, next) => {
     res.redirect(301, url.toString());
     return;
   }
+  // Preload critical font(s)
+  res.header('Link' , `<${config.hosts.platform.base}/static/fonts/poppins-v5-latin-700.woff2>; rel=preload; as=font; type=font/woff2; crossorigin`);
 
   // Check if the page has been cached
   const cachedPage = await pageCache.get(req.originalUrl);


### PR DESCRIPTION
@kristoferbaxter noticed that browsers would always download the largest version of the image, which is way bigger than needed.

The matching `srcset` will be generated by AMP Optimizer.