### PR TITLE
🚸 Mobile usability fixes

### DIFF
--- a/frontend/scss/components/molecules/code-snippet.scss
+++ b/frontend/scss/components/molecules/code-snippet.scss
@@ -48,7 +48,7 @@ Styles taken and combined from: https://raw.githubusercontent.com/richleland/pyg
 
   pre, code {
     @include txt-mono;
-    white-space: pre-wrap;
+    white-space: pre;
     font-size: 0.9rem;
 	  padding: unset;
 	  word-break: initial;

--- a/frontend/scss/components/molecules/tip.scss
+++ b/frontend/scss/components/molecules/tip.scss
@@ -47,6 +47,8 @@ The tip molecule shows text alongside a contextual icon
 
   &-content {
     @include txt-2;
+    min-width: 0;
+
     h4 {
       @include txt-1;
       margin: 0 0 0.75em;

--- a/frontend/scss/components/organisms/teaser-grid.scss
+++ b/frontend/scss/components/organisms/teaser-grid.scss
@@ -50,7 +50,7 @@
     display: flex;
     flex-wrap: nowrap;
     padding: 20px 0;
-    margin: 0 -20px;
+    margin: 0 -15px;
 
     @media (min-width: 575px) {
       overflow: visible;

--- a/frontend/scss/components/templates/_default.scss
+++ b/frontend/scss/components/templates/_default.scss
@@ -15,6 +15,10 @@
 
   @media (max-width: 767px) {
     padding: 0 15px;
+
+    & > div, section {
+      min-width: 0;
+    }
   }
 
   @media (min-width: 768px) {
@@ -43,6 +47,12 @@
   margin-left: auto;
   margin-right: auto;
   max-width: 1920px;
+
+  @media (max-width: 767px) {
+    & > div, section {
+      min-width: 0;
+    }
+  }
 
   @media (min-width: 768px) {
     display: grid;

--- a/frontend/scss/components/templates/use-cases.scss
+++ b/frontend/scss/components/templates/use-cases.scss
@@ -51,6 +51,7 @@
   .#{organism('fragment-slider')} {
     grid-column: 1 / -1;
     margin-top: -76%;
+    overflow: hidden;
     @media (min-width: 768px) {
       margin-top: -56%;
     }

--- a/frontend/scss/components/templates/what-is-amp.scss
+++ b/frontend/scss/components/templates/what-is-amp.scss
@@ -36,10 +36,6 @@
 
   .#{utility('container-fluid')} {
     @include container-fluid;
-    
-    > div, section {
-      min-width: 0;
-    }
   }
 
 

--- a/playground/src/fly-in/fly-in.scss
+++ b/playground/src/fly-in/fly-in.scss
@@ -4,7 +4,7 @@
 .fly-in {
   $headerHeight: 64px;
 
-  position: absolute;
+  position: fixed;
   z-index: 10000;
   top: 0;
   display: flex;
@@ -18,6 +18,7 @@
   transition: transform .3s ease, box-shadow .2s ease-in;
 
   @media (min-width: 768px) {
+    position: absolute;
     top: #{$headerHeight};
     width: 42%;
     max-width: 480px;


### PR DESCRIPTION
Here is a list of pages, that Google Search Console marked as mobile unfriendly:
* https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-managing-user-state/
* https://amp.dev/about/how-amp-works/
* https://amp.dev/zh_cn/documentation/guides-and-tutorials/develop/style_and_layout/responsive_design/
* https://amp.dev/about/use-cases/
* https://playground.amp.dev/?runtime=amp4ads
* https://amp.dev/es/documentation/guides-and-tutorials/optimize-and-measure/amp-managing-user-state/
* https://playground.amp.dev/
* https://playground.amp.dev/embed
* https://amp.dev/id/documentation/guides-and-tutorials/learn/a4a_spec/
* https://amp.dev/es/documentation/guides-and-tutorials/learn/a4a_spec/