### PR TITLE
Prevent keyboard popup in iOS

### DIFF
--- a/examples/static/samples/files/copier.html
+++ b/examples/static/samples/files/copier.html
@@ -37,7 +37,7 @@ button#copy:focus {
 </head>
 <body>
 <button id="copy">Copy</button>
-<input type="text" id="_i" hidden />
+<input type="text" id="_i" hidden readonly />
 <script>
 /*
   When the copy button is pressed, we:


### PR DESCRIPTION
## Bug Description
In iOS safari / chrome, keyboard was popped up after clicking the copy button.

## Changes
Enable `readonly` mode on input tag