### PR TITLE
📱 Mobile usability viewport fixes

### DIFF
--- a/examples/static/samples/files/copier.html
+++ b/examples/static/samples/files/copier.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta name="viewport" content="width=device-width">
   <style> 
 /* so button can go to edge */
 body {

--- a/examples/static/samples/internationalization/alternate/fr/index.amp.html
+++ b/examples/static/samples/internationalization/alternate/fr/index.amp.html
@@ -69,6 +69,12 @@
       </style></noscript
     >
 
+    <style amp-custom>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
+
     <link
       rel="canonical"
       href="https://amp.dev/static/samples/internationalization/alternate/fr/"

--- a/examples/static/samples/internationalization/alternate/fr/index.html
+++ b/examples/static/samples/internationalization/alternate/fr/index.html
@@ -13,6 +13,12 @@
     <link rel="alternate" hreflang="en" href="https://amp.dev/static/samples/internationalization/alternate/" />
     <link rel="alternate" hreflang="fr" href="https://amp.dev/static/samples/internationalization/alternate/fr/" />
     <link rel="alternate" hreflang="ja" href="https://amp.dev/static/samples/internationalization/alternate/ja/" />
+
+    <style>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
   </head>
   <body>
     <h1>French Desktop Document</h1>

--- a/examples/static/samples/internationalization/alternate/fr/index.mobile.html
+++ b/examples/static/samples/internationalization/alternate/fr/index.mobile.html
@@ -13,6 +13,12 @@
     <link rel="alternate" hreflang="en" href="https://amp.dev/static/samples/internationalization/alternate/index.mobile.html" />
     <link rel="alternate" hreflang="fr" href="https://amp.dev/static/samples/internationalization/alternate/fr/index.mobile.html" />
     <link rel="alternate" hreflang="ja" href="https://amp.dev/static/samples/internationalization/alternate/ja/index.mobile.html" />
+
+    <style>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
   </head>
   <body>
     <h1>French Mobile Document</h1>

--- a/examples/static/samples/internationalization/alternate/index.amp.html
+++ b/examples/static/samples/internationalization/alternate/index.amp.html
@@ -69,6 +69,12 @@
       </style></noscript
     >
 
+    <style amp-custom>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
+
     <link
       rel="canonical"
       href="https://amp.dev/static/samples/internationalization/alternate/"

--- a/examples/static/samples/internationalization/alternate/index.html
+++ b/examples/static/samples/internationalization/alternate/index.html
@@ -13,6 +13,12 @@
     <link rel="alternate" hreflang="en" href="https://amp.dev/static/samples/internationalization/alternate/" />
     <link rel="alternate" hreflang="fr" href="https://amp.dev/static/samples/internationalization/alternate/fr/" />
     <link rel="alternate" hreflang="ja" href="https://amp.dev/static/samples/internationalization/alternate/ja/" />
+
+    <style>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
   </head>
   <body>
     <h1>English Desktop Document</h1>

--- a/examples/static/samples/internationalization/alternate/index.mobile.html
+++ b/examples/static/samples/internationalization/alternate/index.mobile.html
@@ -13,6 +13,12 @@
     <link rel="alternate" hreflang="en" href="https://amp.dev/static/samples/internationalization/alternate/index.mobile.html" />
     <link rel="alternate" hreflang="fr" href="https://amp.dev/static/samples/internationalization/alternate/fr/index.mobile.html" />
     <link rel="alternate" hreflang="ja" href="https://amp.dev/static/samples/internationalization/alternate/ja/index.mobile.html" />
+
+    <style>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
   </head>
   <body>
     <h1>English Mobile Document</h1>

--- a/examples/static/samples/internationalization/alternate/ja/index.amp.html
+++ b/examples/static/samples/internationalization/alternate/ja/index.amp.html
@@ -14,6 +14,12 @@
     <link rel="alternate" hreflang="en" href="https://amp.dev/static/samples/internationalization/alternate/index.amp.html" />
     <link rel="alternate" hreflang="fr" href="https://amp.dev/static/samples/internationalization/alternate/fr/index.amp.html" />
     <link rel="alternate" hreflang="ja" href="https://amp.dev/static/samples/internationalization/alternate/ja/index.amp.html" />
+
+    <style>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
   </head>
   <body>
     <h1>日本語のAMPページ</h1>

--- a/examples/static/samples/internationalization/alternate/ja/index.html
+++ b/examples/static/samples/internationalization/alternate/ja/index.html
@@ -13,6 +13,12 @@
     <link rel="alternate" hreflang="en" href="https://amp.dev/static/samples/internationalization/alternate/" />
     <link rel="alternate" hreflang="fr" href="https://amp.dev/static/samples/internationalization/alternate/fr/" />
     <link rel="alternate" hreflang="ja" href="https://amp.dev/static/samples/internationalization/alternate/ja/" />
+
+    <style>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
   </head>
   <body>
     <h1>日本語のPC用ページ</h1>

--- a/examples/static/samples/internationalization/alternate/ja/index.mobile.html
+++ b/examples/static/samples/internationalization/alternate/ja/index.mobile.html
@@ -13,6 +13,12 @@
     <link rel="alternate" hreflang="en" href="https://amp.dev/static/samples/internationalization/alternate/index.mobile.html" />
     <link rel="alternate" hreflang="fr" href="https://amp.dev/static/samples/internationalization/alternate/fr/index.mobile.html" />
     <link rel="alternate" hreflang="ja" href="https://amp.dev/static/samples/internationalization/alternate/ja/index.mobile.html" />
+
+    <style>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
   </head>
   <body>
     <h1>日本語のモバイルページ</h1>

--- a/examples/static/samples/internationalization/basic/fr/index.amp.html
+++ b/examples/static/samples/internationalization/basic/fr/index.amp.html
@@ -69,6 +69,12 @@
       </style></noscript
     >
 
+    <style amp-custom>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
+
     <link
       rel="canonical"
       href="https://amp.dev/static/samples/internationalization/basic/fr/"

--- a/examples/static/samples/internationalization/basic/fr/index.html
+++ b/examples/static/samples/internationalization/basic/fr/index.html
@@ -12,6 +12,12 @@
     <link rel="alternate" hreflang="en" href="https://amp.dev/static/samples/internationalization/basic/" />
     <link rel="alternate" hreflang="fr" href="https://amp.dev/static/samples/internationalization/basic/fr/" />
     <link rel="alternate" hreflang="ja" href="https://amp.dev/static/samples/internationalization/basic/ja/" />
+
+    <style>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
   </head>
   <body>
     <h1>French Desktop Document</h1>

--- a/examples/static/samples/internationalization/basic/index.amp.html
+++ b/examples/static/samples/internationalization/basic/index.amp.html
@@ -69,6 +69,12 @@
       </style></noscript
     >
 
+    <style amp-custom>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
+
     <link
       rel="canonical"
       href="https://amp.dev/static/samples/internationalization/basic/"

--- a/examples/static/samples/internationalization/basic/index.html
+++ b/examples/static/samples/internationalization/basic/index.html
@@ -12,6 +12,12 @@
     <link rel="alternate" hreflang="en" href="https://amp.dev/static/samples/internationalization/basic/" />
     <link rel="alternate" hreflang="fr" href="https://amp.dev/static/samples/internationalization/basic/fr/" />
     <link rel="alternate" hreflang="ja" href="https://amp.dev/static/samples/internationalization/basic/ja/" />
+
+    <style>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
   </head>
   <body>
     <h1>English Desktop Document</h1>

--- a/examples/static/samples/internationalization/basic/ja/index.amp.html
+++ b/examples/static/samples/internationalization/basic/ja/index.amp.html
@@ -69,6 +69,12 @@
       </style></noscript
     >
 
+    <style amp-custom>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
+
     <link
       rel="canonical"
       href="https://amp.dev/static/samples/internationalization/basic/ja/"

--- a/examples/static/samples/internationalization/basic/ja/index.html
+++ b/examples/static/samples/internationalization/basic/ja/index.html
@@ -12,6 +12,12 @@
     <link rel="alternate" hreflang="en" href="https://amp.dev/static/samples/internationalization/basic/" />
     <link rel="alternate" hreflang="fr" href="https://amp.dev/static/samples/internationalization/basic/fr/" />
     <link rel="alternate" hreflang="ja" href="https://amp.dev/static/samples/internationalization/basic/ja/" />
+
+    <style>
+      pre {
+        overflow-x: scroll;
+      }
+    </style>
   </head>
   <body>
     <h1>日本語のPC用ページ</h1>


### PR DESCRIPTION
Add viewport tag:
- https://amp.dev/static/samples/files/copier.html

Handle overflow of ```pre```-Element:
- https://amp.dev/static/samples/internationalization/basic/index.html
- https://amp.dev/static/samples/internationalization/basic/index.amp.html
- https://amp.dev/static/samples/internationalization/basic/fr/index.html
- https://amp.dev/static/samples/internationalization/basic/fr/index.amp.html
- https://amp.dev/static/samples/internationalization/basic/ja/index.html
- https://amp.dev/static/samples/internationalization/basic/ja/index.amp.html
- https://amp.dev/static/samples/internationalization/alternate/index.html
- https://amp.dev/static/samples/internationalization/alternate/index.amp.html
- https://amp.dev/static/samples/internationalization/alternate/index.mobile.html
- https://amp.dev/static/samples/internationalization/alternate/fr/index.html
- https://amp.dev/static/samples/internationalization/alternate/fr/index.amp.html
- https://amp.dev/static/samples/internationalization/alternate/fr/index.mobile.html
- https://amp.dev/static/samples/internationalization/alternate/ja/index.html
- https://amp.dev/static/samples/internationalization/alternate/ja/index.amp.html
- https://amp.dev/static/samples/internationalization/alternate/ja/index.mobile.html