### PR TITLE
Fix formatting issue

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/create/basic_markup.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/create/basic_markup.md
@@ -58,7 +58,7 @@ AMP HTML documents MUST:
 | Contain a `<meta charset="utf-8">` tag as the first child of their `<head>` tag. | Identifies the encoding for the page. |
 | Contain a `<script async src="https://cdn.ampproject.org/v0.js"></script>` tag inside their `<head>` tag. As a best practice, you should include the script as early as possible in the `<head>`.| Includes and loads the AMP JS library. |
 | Contain a `<link rel="canonical" href="$SOME_URL">` tag inside their `<head>`. | Points to the regular HTML version of the AMP HTML document or to itself if no such HTML version exists. Learn more in [Make Your Page Discoverable](../../../../documentation/guides-and-tutorials/optimize-measure/discovery.md).
-| Contain a `<meta name="viewport" content="width=device-width"> It's also recommended to include `initial-scale=1`. | Specifies a responsive viewport. Learn more in [Create Responsive AMP Pages](../../../../documentation/guides-and-tutorials/develop/style_and_layout/responsive_design.md). |
+| Contain a `<meta name="viewport" content="width=device-width">`. It's also recommended to include `initial-scale=1`. | Specifies a responsive viewport. Learn more in [Create Responsive AMP Pages](../../../../documentation/guides-and-tutorials/develop/style_and_layout/responsive_design.md). |
 | Contain the [AMP boilerplate code](../../../../documentation/guides-and-tutorials/learn/spec/amp-boilerplate.md) in their `<head>` tag.  | CSS boilerplate to initially hide the content until AMP JS is loaded. |
 
 ## Optional metadata


### PR DESCRIPTION
Add missing backtick in 'Create your AMP HTML page' tutorial.