### PR TITLE
Migrate to official packager docker image

### DIFF
--- a/packager/Dockerfile
+++ b/packager/Dockerfile
@@ -22,10 +22,6 @@ ENV GO111MODULE=on
 # RUN go get -v github.com/ampproject/amppackager/cmd/amppkg@master
 RUN go get -v github.com/ampproject/amppackager/cmd/amppkg
 
-# Install git
-RUN apt-get update \
-    && apt-get install -y git
-
 # Clone amppackager files so we can use b3 directory
 WORKDIR /data
 # Run this if you clone from master branch.

--- a/packager/Dockerfile
+++ b/packager/Dockerfile
@@ -1,23 +1,56 @@
-# Maybe switch to one of the Google-provided images? But seems to be go 1.8, not 1.10:
-# https://cloud.google.com/appengine/docs/flexible/custom-runtimes/build#base
-FROM golang:1.15
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 /usr/local/bin/dumb-init
-RUN chmod +x /usr/local/bin/dumb-init
-ENTRYPOINT ["dumb-init", "--"]
+# Use an official Go runtime as a parent image
+FROM golang:1.13
 
-RUN groupadd -r amppkg && useradd --no-log-init -r -g amppkg amppkg
-WORKDIR /amppkg
+ENV GO111MODULE=on
 
-COPY amppkg.toml /amppkg
-# Copy whatever certs are available in the certs/ directory  into the container. 
+# Install AMP Packager
+# Run this if you want to go off master branch.
+# RUN go get -v github.com/ampproject/amppackager/cmd/amppkg@master
+RUN go get -v github.com/ampproject/amppackager/cmd/amppkg
+
+# Install git
+RUN apt-get update \
+    && apt-get install -y git
+
+# Clone amppackager files so we can use b3 directory
+WORKDIR /data
+# Run this if you clone from master branch.
+# RUN git clone -b master https://github.com/ampproject/amppackager.git /data/amppackager
+RUN git clone https://github.com/ampproject/amppackager.git /data/amppackager
+
+# Seed the ocsp cache
+WORKDIR /data/amppackager/testdata/b3
+RUN ./seedcache.sh
+
+WORKDIR /go/src/app
+
+# Copy the AMP packager binary into our app dir inside the container.
+RUN cp /go/bin/amppkg .
+
+# Copy whatever certs are available in the certs/ directory  into the container.
 COPY certs/*pem* /amppkg/
+# Copy config file into container.
+COPY amppkg.toml .
 
-RUN chown -R amppkg:amppkg /amppkg
-
-# Install the AMP packager
-RUN go get github.com/ampproject/amppackager/cmd/amppkg
-
-USER amppkg
+# Make port 8080 available to the world outside this container. This
+# port must match the AMP Packager port configured in the toml file.
 EXPOSE 8080
-CMD [ "bash", "-c", "exec amppkg -config /amppkg/amppkg.toml" ]
+
+# Start the AMP Packager
+ENTRYPOINT ["amppkg"]
+
+CMD ["-config=amppkg.toml"]


### PR DESCRIPTION
If using both AMP Packager and a 2.8.0 canary release of AMP Optimizer, there is a conflict that will lead to invalid AMP pages.