### PR TITLE
🚸  Fix errors around Pixi webpack dev config

### DIFF
--- a/frontend21/webpack.config.js
+++ b/frontend21/webpack.config.js
@@ -108,8 +108,8 @@ module.exports = (env, argv) => {
       }),
       isDevelopment
         ? new WebpackBuildNotifierPlugin({
-            title: 'amp.dev Frontend',
-            logo: path.join(process.cwd(), '/static/img/favicon-128x128.png'),
+            title: 'amp.dev: Frontend',
+            logo: path.join(process.cwd(), '../pages/static/img/favicon.png'),
           })
         : () => {},
     ],

--- a/pixi/webpack.config.js
+++ b/pixi/webpack.config.js
@@ -15,8 +15,6 @@ module.exports = (env, argv) => {
   return {
     entry: path.join(__dirname, 'src/ui/PageExperience.js'),
     output: {
-      filename: 'pixi.[name].[contenthash].js',
-      chunkFilename: 'pixi.[name].[chunkhash].bundle.js',
       filename: isDevelopment
         ? 'pixi.[name].js'
         : 'pixi.[name].[contenthash].js',

--- a/pixi/webpack.config.js
+++ b/pixi/webpack.config.js
@@ -3,18 +3,26 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const FileManagerPlugin = require('filemanager-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const WebpackBuildNotifierPlugin = require('webpack-build-notifier');
 
 const config = require('./config.js');
 const {calculateHash} = require('@ampproject/toolbox-script-csp');
 
 module.exports = (env, argv) => {
   const mode = argv.mode || 'production';
+  const isDevelopment = mode == 'development';
 
   return {
     entry: path.join(__dirname, 'src/ui/PageExperience.js'),
     output: {
       filename: 'pixi.[name].[contenthash].js',
       chunkFilename: 'pixi.[name].[chunkhash].bundle.js',
+      filename: isDevelopment
+        ? 'pixi.[name].js'
+        : 'pixi.[name].[contenthash].js',
+      chunkFilename: isDevelopment
+        ? 'pixi.[name].js'
+        : 'pixi.[name].[chunkhash].bundle.js',
       sourceMapFilename: 'pixi.[name].map',
       publicPath: '/static/page-experience/',
     },
@@ -32,7 +40,7 @@ module.exports = (env, argv) => {
       ],
       concatenateModules: false,
     },
-    devtool: mode == 'development' ? 'cheap-module-source-map' : false,
+    devtool: isDevelopment ? 'cheap-module-source-map' : false,
     plugins: [
       new HtmlWebpackPlugin({
         template: path.join(__dirname, 'src/ui/page-experience.hbs'),
@@ -53,7 +61,7 @@ module.exports = (env, argv) => {
         },
       }),
       new webpack.DefinePlugin({
-        IS_DEVELOPMENT: mode == 'development',
+        IS_DEVELOPMENT: isDevelopment,
         API_ENDPOINT_LINTER: JSON.stringify(config[mode].API_ENDPOINT_LINTER),
         API_ENDPOINT_SAFE_BROWSING: JSON.stringify(
           config[mode].API_ENDPOINT_SAFE_BROWSING
@@ -99,6 +107,12 @@ module.exports = (env, argv) => {
           },
         },
       }),
+      isDevelopment
+        ? new WebpackBuildNotifierPlugin({
+            title: 'amp.dev: Pixi',
+            logo: path.join(process.cwd(), '../pages/static/img/favicon.png'),
+          })
+        : () => {},
     ],
     module: {
       rules: [
@@ -116,6 +130,10 @@ module.exports = (env, argv) => {
           ],
         },
       ],
+    },
+
+    devServer: {
+      writeToDisk: true,
     },
   };
 };


### PR DESCRIPTION
/cc @lluerich

This enables the same notifications as for the frontend to know when a build succeeded.
![image](https://user-images.githubusercontent.com/12857772/111332290-f1239700-8671-11eb-8780-dd87d8cb4f3b.png)

But in the first place this fixes not building the bundle incrementally for `npm run start:pixi`.