### PR TITLE
make sure nodes exist before we access them

### DIFF
--- a/platform/lib/format-transform/formats/amp4email.js
+++ b/platform/lib/format-transform/formats/amp4email.js
@@ -45,7 +45,9 @@ module.exports = {
     'style[amp-custom]': (el) => {
       const node = el[0].children[0];
 
-      node.data = postcssCssVariables.process(node.data).css;
+      if (node) {
+        node.data = postcssCssVariables.process(node.data).css;
+      }
     },
     'head > style[amp-boilerplate]':
       '<style amp4email-boilerplate>body{visibility:hidden}</style>',


### PR DESCRIPTION
fixes #5522 - the example has 
```js
<style amp-custom></style>
```

so the selector matches, but I hadn't done existence checks on the code because "...why would this exist?"

mea culpa