### PR TITLE
Pixi: Fix code snippet in tap deplay recommendation

### DIFF
--- a/frontend/scss/components/molecules/pixi-recommendations-item.scss
+++ b/frontend/scss/components/molecules/pixi-recommendations-item.scss
@@ -10,6 +10,10 @@
   transition: transform 0.25s ease-in, background 0.25s ease-in,
     box-shadow 0.3s ease-in, border-color 0.3s ease-in;
 
+  code {
+    @include txt-mono-inline 
+  }
+
   &-box {
     padding: 30px 18px;
     border-radius: 8px;
@@ -151,9 +155,6 @@
       text-overflow: ellipsis;
     }
 
-    code {
-      @include txt-mono-inline 
-    }
   }
 
   &-next-advice {

--- a/pages/content/pixi/recommendations/viewport-disables-tap-delay.md
+++ b/pages/content/pixi/recommendations/viewport-disables-tap-delay.md
@@ -6,12 +6,8 @@ tags:
 ---
 Set viewport width to match the device width to disable touch delay, which 
 can increase FID. To remove this 300-350ms tap delay, change the viewport 
-declaration in the `<head>` of your page to:
-
-```
-<meta name="viewport" content="width=device-width">
-```
-
+declaration in the `<head>` of your page to: `<meta name="viewport" content="width=device-width">`.
+<br><br>
 This sets the viewport width to the same as the device, and is generally a 
 best-practice for mobile-optimized sites. You can
 [read more about disabling the tap delay on web.dev](https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away).

--- a/pixi/src/ui/I18n.js
+++ b/pixi/src/ui/I18n.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import marked from 'marked';
+import snarkdown from 'snarkdown';
 
 const DEFAULT_LANGUAGE = 'en';
 
@@ -66,7 +66,7 @@ class I18n {
       if (recommendation) {
         result.push(
           Object.assign({}, item, recommendation, {
-            body: recommendation.body || marked(item.description),
+            body: recommendation.body || snarkdown(item.description),
           })
         );
       } else {


### PR DESCRIPTION
* Use `<code>` instead of `<pre>`
* Style `<code>` in recommendations
* Also use snarkdown instead of marked (saves 42kb)

Fixes #5417