### PR TITLE
🚀  Configure GitHub Actions workflows for production deployment and nightly releases

### DIFF
--- a/.github/workflows/check-grow-link-integrity.yaml
+++ b/.github/workflows/check-grow-link-integrity.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/check-grow-link-integrity.yaml
+++ b/.github/workflows/check-grow-link-integrity.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/lint-js.yaml
+++ b/.github/workflows/lint-js.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/lint-js.yaml
+++ b/.github/workflows/lint-js.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,22 @@
+---
+name: 'Nightly'
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploying to staging
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: 'Release: Staging'
+          token: ${{ secrets.GITHUB_NIGHTLY_TOKEN }}
+
+      - name: Deploying to production
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: 'Release: Production'
+          token: ${{ secrets.GITHUB_NIGHTLY_TOKEN }}

--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -1,0 +1,197 @@
+---
+name: 'Release: Production'
+
+on:
+  push:
+    branches:
+      - production-amp-dev
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cloning repository
+        uses: actions/checkout@v2
+
+      - name: Setting up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Installing Node.js packages
+        run: npm install
+
+      - name: Running tests
+        run: |
+          gulp updateTestResources
+          gulp buildComponentVersions
+          gulp buildPixiFunctions
+          gulp lintNode
+          gulp lintYaml
+          npm run test:platform
+          npm run test:playground
+          npm run test:pixi
+  prepare:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cloning repository
+        uses: actions/checkout@v2
+
+      - name: Setting up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Installing Node.js packages
+        run: npm install
+
+      - name: Preparing build
+        env:
+          AMP_DOC_TOKEN: ${{ secrets.AMP_DOC_TOKEN }}
+        run: |
+          gulp buildPrepare
+
+      - name: Storing build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-setup
+          path: artifacts/setup.tar.gz
+
+  build:
+    env:
+      APP_ENV: production
+    needs: prepare
+    strategy:
+      matrix:
+        language:
+          [
+            'en',
+            'de',
+            'fr',
+            'ar',
+            'es',
+            'it',
+            'id',
+            'ja',
+            'ko',
+            'pt_BR',
+            'ru',
+            'tr',
+            'zh_CN',
+            'pl',
+            'vi',
+          ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cloning repository
+        uses: actions/checkout@v2
+
+      - name: Setting up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Installing Node.js packages
+        run: npm install
+
+      - name: Setting up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}
+
+      - name: Installing Grow
+        run: |
+          sudo apt-get install libyaml-dev
+          pip install grow --upgrade-strategy eager
+
+      - name: Fetching build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-setup
+          path: artifacts
+
+      - name: Unpacking artifacts
+        run: |
+          gulp unpackArtifacts
+
+      - name: Building pages
+        run: |
+          gulp buildPages --locales ${{ matrix.language }}
+
+      - name: Storing build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: pages-${{ github.run_id }}-${{ matrix.language }}
+          path: artifacts
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: Production
+    env:
+      APP_ENV: production
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+    steps:
+      - name: Cloning repository
+        uses: actions/checkout@v2
+
+      - name: Setting up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Installing Node.js packages
+        run: npm install
+
+      - name: Setting up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Fetching build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: Unpacking artifacts
+        run: |
+          gulp unpackArtifacts
+
+      - name: Finalizing build
+        run: |
+          gulp buildFinalize
+          npm run smoke-test -- --colors
+
+      - name: Deploying
+        run: |
+          gcloud components update --quiet
+          gcloud components install beta --quiet
+          npx gulp deploy

--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
@@ -157,7 +157,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:
@@ -46,7 +46,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:
@@ -100,7 +100,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:
@@ -156,7 +156,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
@@ -154,7 +154,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/test-grow-extensions.yaml
+++ b/.github/workflows/test-grow-extensions.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/test-grow-extensions.yaml
+++ b/.github/workflows/test-grow-extensions.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/test-pixi.yaml
+++ b/.github/workflows/test-pixi.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/test-pixi.yaml
+++ b/.github/workflows/test-pixi.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/test-platform.yaml
+++ b/.github/workflows/test-platform.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/test-platform.yaml
+++ b/.github/workflows/test-platform.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/test-playground.yaml
+++ b/.github/workflows/test-playground.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/test-playground.yaml
+++ b/.github/workflows/test-playground.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setting up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # amp.dev
 
-[![Build Status](https://travis-ci.com/ampproject/amp.dev.svg?branch=future)](https://travis-ci.com/ampproject/amp.dev)
+![Staging](https://github.com//ampproject/amp.dev/workflows/Release%3A%20Staging/badge.svg)
+![Production](https://github.com//ampproject/amp.dev/workflows/Release%3A%20Production/badge.svg)
 
 The official homepage of the AMP Project.
 


### PR DESCRIPTION
This adapts the staging workflow for production. Also it updates the Node.js action to v2 and uses Node.js 14 across all workflows as this is the current LTS and not 12 anymore.

Additionally this adds a nightly workflow which is a workaround for the fact that the `schedule` trigger is only respected for workflows on the default branch. It will trigger releases for staging and production every morning at 8 to keep imported docs fresh.