### PR TITLE
🎨  Further enhance GitHub workflows

### DIFF
--- a/.github/workflows/check-grow-link-integrity.yaml
+++ b/.github/workflows/check-grow-link-integrity.yaml
@@ -5,9 +5,6 @@ on:
   push:
     paths:
       - 'pages/content/**'
-  pull_request:
-    paths:
-      - 'pages/content/**'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-js.yaml
+++ b/.github/workflows/lint-js.yaml
@@ -5,9 +5,6 @@ on:
   push:
     paths:
       - '**/*.js'
-  pull_request:
-    paths:
-      - '**/*.js'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -7,11 +7,6 @@ on:
       - '**/*.yml'
       - '**/*.yaml'
       - '!.github/**/*.yaml'
-  pull_request:
-    paths:
-      - '**/*.yml'
-      - '**/*.yaml'
-      - '!.github/**/*.yaml'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -2,11 +2,25 @@
 name: 'Release: Production'
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - production-amp-dev
 
 jobs:
+  queue:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'outdated_runs'
+          cancel_others: true
+          skip_after_successful_duplicate: true
+          paths_ignore: '["**/README.md", "**/docs/**"]'
+          do_not_skip: '["workflow_dispatch", "schedule"]'
   verify:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -2,11 +2,26 @@
 name: 'Release: Staging'
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - future
 
 jobs:
+  queue:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'outdated_runs'
+          cancel_others: true
+          skip_after_successful_duplicate: true
+          paths_ignore: '["**/README.md", "**/docs/**"]'
+          do_not_skip: '["workflow_dispatch", "schedule"]'
+
   verify:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-grow-extensions.yaml
+++ b/.github/workflows/test-grow-extensions.yaml
@@ -5,9 +5,7 @@ on:
   push:
     paths:
       - 'pages/extensions/**'
-  pull_request:
-    paths:
-      - 'pages/extensions/**'
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-pixi.yaml
+++ b/.github/workflows/test-pixi.yaml
@@ -6,10 +6,7 @@ on:
     paths:
       - 'package.json'
       - 'pixi/**'
-  pull_request:
-    paths:
-      - 'package.json'
-      - 'pixi/**'
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-platform.yaml
+++ b/.github/workflows/test-platform.yaml
@@ -6,10 +6,7 @@ on:
     paths:
       - 'package.json'
       - 'platform/lib/**'
-  pull_request:
-    paths:
-      - 'package.json'
-      - 'platform/lib/**'
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-playground.yaml
+++ b/.github/workflows/test-playground.yaml
@@ -6,10 +6,7 @@ on:
     paths:
       - 'package.json'
       - 'playground/**'
-  pull_request:
-    paths:
-      - 'package.json'
-      - 'playground/**'
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This tries to enhance workflows: actually running the tests on `push` should be enough; we need to investigate if that works for PRs created after everything has been pushed.

Also this fixes the nightly workflow - the required triggers weren't allowed for the release workflows.

Additionally this tries to implement skipping for concurrent release jobs on `future`. As this is not a core feature we need to rely on a 3p action which has [confusing documentation](https://github.com/fkirc/skip-duplicate-actions/).

All in all: fingers crossed 😅