### PR TITLE
🐛 Set APP_ENV for prepare step in release workflows

### DIFF
--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Preparing build
         env:
+          APP_ENV: production
           AMP_DOC_TOKEN: ${{ secrets.AMP_DOC_TOKEN }}
         run: |
           gulp buildPrepare

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Preparing build
         env:
+          APP_ENV: staging
           AMP_DOC_TOKEN: ${{ secrets.AMP_DOC_TOKEN }}
         run: |
           gulp buildPrepare


### PR DESCRIPTION
Sebastian reported that samples are using `localhost` on prod. This was caused by `gulp buildPrepare` not having the correct `APP_ENV` set [as before on Travis](https://github.com/ampproject/amp.dev/commit/f2d63dce6498e34ac97ea51fdb4b3c4ee894abcb#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485L30).