### PR TITLE
🐛 Keep only latest component version

### DIFF
--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -181,6 +181,13 @@ async function buildComponentVersions() {
   const componentVersions = {};
   rules.extensions.forEach((e) => {
     const versions = e.version.filter((v) => v !== 'latest');
+    if (
+      componentVersions[e.name] &&
+      parseFloat(componentVersions[e.name]) >=
+        parseFloat(versions[versions.length - 1])
+    ) {
+      return;
+    }
     componentVersions[e.name] = versions[versions.length - 1];
   });
   const content = JSON.stringify(componentVersions, null, 2);


### PR DESCRIPTION
Since there are some duplicate components in the [validator.json](https://cdn.ampproject.org/v0/validator.json) the latest version was overwritten by a former version in at least one case (amp-carousel).
This should fix that and #5586.