### PR TITLE
🐛 Specify ref for nightly production builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,3 +20,4 @@ jobs:
         with:
           workflow: 'Release: Production'
           token: ${{ secrets.NIGHTLY_WORKFLOW_GITHUB_PAT }}
+          ref: refs/heads/production-amp-dev


### PR DESCRIPTION
Nightly production builds currently [fail (scroll down to annotations)](https://github.com/ampproject/amp.dev/actions/runs/697111433) as they are build from `future` but should rather be build from `production-amp-dev`