### PR TITLE
🐛 Explicitly export AMP_DEV_PIXI_APIS_KEY in GitHub workflows

### DIFF
--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -74,6 +74,7 @@ jobs:
         env:
           APP_ENV: production
           AMP_DOC_TOKEN: ${{ secrets.AMP_DOC_TOKEN }}
+          AMP_DEV_PIXI_APIS_KEY: ${{ secrets.AMP_DEV_PIXI_APIS_KEY }}
         run: |
           gulp buildPrepare
 

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -75,6 +75,7 @@ jobs:
         env:
           APP_ENV: staging
           AMP_DOC_TOKEN: ${{ secrets.AMP_DOC_TOKEN }}
+          AMP_DEV_PIXI_APIS_KEY: ${{ secrets.AMP_DEV_PIXI_APIS_KEY }}
         run: |
           gulp buildPrepare
 


### PR DESCRIPTION
Fixes #5604.