### PR TITLE
🚧  Update format switcher hint

### DIFF
--- a/frontend/scss/components/molecules/format-filter-hint.scss
+++ b/frontend/scss/components/molecules/format-filter-hint.scss
@@ -5,7 +5,7 @@
 
 @import '../atoms/_text.scss';
 
-$height: 60px;
+$height: 42px;
 
 .#{molecule('format-filter-hint')} {
   $root: &;
@@ -22,6 +22,10 @@ $height: 60px;
     background-color: color('charade');
     @include txt-2;
     z-index: 100;
+    position: absolute;
+    width: 100%;
+    left: 0;
+    right: 0;
 
     @media (min-width: 768px) {
       display: block;
@@ -35,19 +39,23 @@ $height: 60px;
         width: 100%;
         height: 100%;
         max-width: 1440px;
-        padding: 12px 15px;
+        padding: 0 30px;
         margin: 0 auto;
+
+        @media (min-width: 1024px) {
+          padding: 0 15px;
+        }
 
         &:after {
           position: absolute;
           content: "";
-          top: 60px;
+          top: 42px;
           left: 50px;
           width: 0;
           height: 0;
           border-style: solid;
-          border-width: 16px 12px 0;
-          border-color: #29323c transparent transparent;
+          border-width: 8px 10px 0;
+          border-color: color('charade') transparent transparent;
         }
       }
 
@@ -56,37 +64,18 @@ $height: 60px;
         padding-right: 10px;
       }
 
-      &-formats {
-        display: none;
-        flex: 1 0 auto;
-        @media (min-width: 768px) {
-          display: flex;
-        }
-      }
-
-      &-format {
-        cursor: pointer;
-        max-width: 150px;
-        margin-right: 10px;
-        margin-bottom: 0;
-
-        &:after {
-          display: none;
-        }
-      }
-
       &-dismiss {
-        border-radius: 50%;
         height: 20px;
         width: 20px;
-        background-color: color('white');
+        background-color: transparent;
         border: 0;
         cursor: pointer;
+        padding: 3px;
 
         svg {
-          fill: color('blue-ribbon');
-          width: 110%;
-          height: 110%;
+          fill: color('white');
+          width: 100%;
+          height: 100%;
         }
       }
     }

--- a/frontend/scss/components/templates/_default.scss
+++ b/frontend/scss/components/templates/_default.scss
@@ -1,5 +1,5 @@
 .#{utility('main')}>.#{utility('container')}:first-child {
-  padding-top: 26px;
+  padding-top: 54px;
   padding-bottom: 3rem;
 }
 

--- a/frontend/templates/views/partials/format-filter-hint.j2
+++ b/frontend/templates/views/partials/format-filter-hint.j2
@@ -12,23 +12,11 @@
 <div class="ap-m-format-filter-hint-banner" aria-hidden="true">
   <div class="ap-m-format-filter-hint-banner-content">
     <div class="ap-m-format-filter-hint-banner-note">{{ _('Select your format for a more streamlined experience') }}</div>
-    <div class="ap-m-format-filter-hint-banner-formats">
-      {% set formats = ['websites', 'stories', 'ads', 'email'] %}
-      {% for format in formats %}
-      {% do doc.icons.useIcon('icons/amp-' + format + '.svg') %}
-      <button on="tap:format-filter-hint.dismiss,AMP.navigateTo(url='{{ doc.url.path }}?format={{ format }}')" class="ap-m-format-filter-hint-banner-format ap-m-format-toggle-link ap-m-format-toggle-link-{{ format }} ap-m-format-toggle-selected">
-        <span class="ap-a-ico">
-          <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#amp-{{ format }}"></use></svg>
-        </span>
-        <span>{{ _(format) }}</span>
-      </button>
-      {% endfor %}
-    </div>
-
     <button class="ap-m-format-filter-hint-banner-dismiss" on="tap:format-filter-hint.dismiss">
       {% do doc.icons.useIcon('/icons/close.svg') %}
       <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close"></use></svg>
     </button>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
- removed the format switcher inside the hint
- increase the space at the top of container to fit the hint
- set hint to ```position: absolute``` so that it does not cause CLS when closed

TODO:
- update copy

Fixes #5476 