### PR TITLE
add default workflow to run tests

### DIFF
--- a/.github/workflows/test-default.yml
+++ b/.github/workflows/test-default.yml
@@ -1,5 +1,5 @@
 ---
-name: 'Default test job'
+name: 'Test: Default'
 
 on:
   push:
@@ -12,4 +12,3 @@ jobs:
       - name: 'Default'
         run: |
           echo 'we require a job named "test", but not all pull requests trigger an action. So we created this small silly job named "test" that will always pass, just to make sure nothing hangs as a result of not triggering an actual job.'
-

--- a/.github/workflows/test-default.yml
+++ b/.github/workflows/test-default.yml
@@ -1,0 +1,15 @@
+---
+name: 'Default test job'
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: 'Default'
+        run: |
+          echo 'we require a job named "test", but not all pull requests trigger an action. So we created this small silly job named "test" that will always pass, just to make sure nothing hangs as a result of not triggering an actual job.'
+


### PR DESCRIPTION
PRs like #5612 are currently hung because we require a `test` job to pass in checks

![image](https://user-images.githubusercontent.com/465414/113177530-9fefd780-921b-11eb-8834-94cc972f1d65.png)

but the existing workflows all filter on filename.

This PR adds a default workflow to run `npm test` on all PRs as the requisite `test` job. Since this should be run on [`pre-push`](https://github.com/ampproject/amp.dev/blob/future/.husky/pre-push#L4), this shouldn't ever really fail, but folks can force push a [`--no-verify`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-verify) to get around it locally, so 🤷‍♀️.

If it takes up too much time, we can change the `run` [bit](https://github.com/ampproject/amp.dev/commit/3aa34ffc8a5fa2b9d275c2aa3df9aa24174c2e12#diff-1b8368a50c1714fe9faf0dfd1bf766142f1f0bb1eedd48540fb4bdde0323f50dR29) to something like `exit 0` and it should work, just be...hacky.