### PR TITLE
use specific HTTP verbs instead of all for survey router config

### DIFF
--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -176,6 +176,7 @@ class Platform {
     this.server.use(routers.healthCheck);
     this.server.use(routers.example.api);
     this.server.use(routers.pixi);
+    this.server.use(routers.survey);
     this.server.use(routers.search);
     this.server.use(routers.boilerplate);
     this.server.use(routers.static);

--- a/platform/lib/routers/surveyComponent.js
+++ b/platform/lib/routers/surveyComponent.js
@@ -156,6 +156,7 @@ const surveyResponseRouter = express.Router();
 
 surveyResponseRouter.use(surveyEndpoint, express.json());
 
-surveyResponseRouter.all(surveyEndpoint, validateRequest, uploadAnswer);
+surveyResponseRouter.get(surveyEndpoint, validateRequest, uploadAnswer);
+surveyResponseRouter.post(surveyEndpoint, validateRequest, uploadAnswer);
 
 module.exports = surveyResponseRouter;


### PR DESCRIPTION
I pulled down the prod docker image, and for some reason when I use `.all` it adds the route to the router, but doesn't register it to any methods. As a result, production requests 404 for `fez-survey-requests`, but worked locally. 

