### PR TITLE
use the LTS version of node in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:lts-alpine
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
the survey isn't working in prod because the backend is calling `flat()`, which wasn't caught because out testing uses node lts. I assume this is an over sight? 