### PR TITLE
filter out embed.html from examples in gulp glob

### DIFF
--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -154,11 +154,12 @@ class SamplesBuilder {
 
     return new Promise(async (resolve, reject) => {
       let stream = gulp.src([
-        `${SAMPLE_SRC}/*/*.html`, `${SAMPLE_SRC}/*/*/*.html`], {'read': true});
+        `${SAMPLE_SRC}/*/*.html`, `${SAMPLE_SRC}/*/*/*.html`, `!**/*embed.html`], {'read': true});
 
       stream = stream.pipe(once({file: false}));
 
       const sampleBuilds = [];
+
       stream = stream.pipe(through.obj((sample, encoding, callback) => {
         sampleBuilds.push(this._buildSample(sample, callback, stream));
       }));


### PR DESCRIPTION
fixes #4211

no idea if this is the "correct" way to go about this, or just a hack, but -  thoughts?