### PR TITLE
Revert updating dependency p-queue to v7 due to ESM migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
 		"node-fetch": "2.6.1",
 		"node-zopfli-es": "1.0.7",
 		"nunjucks": "3.2.3",
-		"p-queue": "7.1.0",
+		"p-queue": "6.6.2",
 		"postcss": "8.2.9",
 		"postcss-css-variables": "0.17.0",
 		"process": "0.11.10",


### PR DESCRIPTION
Reverts ampproject/amp.dev#5613.