### PR TITLE
include event category in google analytics events for pixi

### DIFF
--- a/pixi/backend/api.js
+++ b/pixi/backend/api.js
@@ -100,6 +100,8 @@ const logAnalytics = async (url) => {
       aip: 1,
       // Application Name - for easier searching in GA
       an: 'pixi',
+      // Event Category - required value
+      ec: 'pixi',
       // Event Action - required value
       ea: 'lint',
       // Event Label - where the URL is stored


### PR DESCRIPTION
currently its more difficult than it needs to be to get pixi search events, because they won't show up outside of realtime data without a category attached