### PR TITLE
bring back templates

### DIFF
--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -290,7 +290,8 @@ function buildPrepare(done) {
       buildBoilerplate,
       buildPixi,
       buildSamples,
-      importAll
+      importAll,
+      zipTemplates
     ),
     // eslint-disable-next-line prefer-arrow-callback
     async function packArtifacts() {


### PR DESCRIPTION
fixes #5661

[Looks like they were removed](https://github.com/ampproject/amp.dev/commit/f2d63dce6498e34ac97ea51fdb4b3c4ee894abcb#diff-f6030ecaa81fe01c520f48d9593ec049587bbca33af2ab8c7e5fb006ffdd5d95L291) when we switched to github actions, not sure if that was intentional or not - @matthiasrohmer ?