### PR TITLE
Added Salesforce to ESPs list

### DIFF
--- a/pages/shared/data/faq.yaml
+++ b/pages/shared/data/faq.yaml
@@ -819,6 +819,8 @@ email:
           url: https://www.moonmail.io
         - label: Pepipost
           url: https://pepipost.com/
+        - label: Salesforce
+          url: https://www.salesforce.com/
         - label: SendPulse
           url: https://sendpulse.com/
         - label: SocketLabs


### PR DESCRIPTION
Added Salesforce to list of Email Platforms and Service Providers
AMP for Email was added to Salesforce in the January 2021 release https://www.salesforce.com/blog/amp-email-interactive/