### PR TITLE
🔧 Increase timeouts for Pixi E2E tests

### DIFF
--- a/smoke-tests/pixi/Run.e2e-test.js
+++ b/smoke-tests/pixi/Run.e2e-test.js
@@ -42,6 +42,7 @@ describe('Pixi', () => {
     await expect(page).toClick('#input-submit');
     await expect(page).toMatchElement('#status-intro-banner-loading', {
       visible: true,
+      timeout: 60 * 1000,
     });
   });
 
@@ -51,7 +52,7 @@ describe('Pixi', () => {
         '.ap-m-pixi-primary-metric-header-title-full',
         {
           text: 'Loading speed',
-          timeout: 30 * 1000,
+          timeout: 60 * 1000,
         }
       ),
 
@@ -59,7 +60,7 @@ describe('Pixi', () => {
         '.ap-m-pixi-primary-metric-header-title-full',
         {
           text: 'Interactivity',
-          timeout: 30 * 1000,
+          timeout: 60 * 1000,
         }
       ),
 
@@ -67,7 +68,7 @@ describe('Pixi', () => {
         '.ap-m-pixi-primary-metric-header-title-full',
         {
           text: 'Visual stability',
-          timeout: 30 * 1000,
+          timeout: 60 * 1000,
         }
       ),
     ]);
@@ -78,7 +79,7 @@ describe('Pixi', () => {
       '#safe-browsing .ap-m-pixi-basic-metric-status',
       {
         text: new RegExp('Passed|Failed', 'gm'),
-        timeout: 30 * 1000,
+        timeout: 60 * 1000,
       }
     );
   });
@@ -86,7 +87,7 @@ describe('Pixi', () => {
   it('performs HTTPS check', async () => {
     await expect(page).toMatchElement('#https .ap-m-pixi-basic-metric-status', {
       text: new RegExp('Passed|Failed', 'gm'),
-      timeout: 30 * 1000,
+      timeout: 60 * 1000,
     });
   });
 
@@ -95,14 +96,14 @@ describe('Pixi', () => {
       '#mobile-friendliness .ap-m-pixi-basic-metric-status',
       {
         text: new RegExp('Passed|Failed|Analysis failed', 'gm'),
-        timeout: 30 * 1000,
+        timeout: 60 * 1000,
       }
     );
   });
 
   it('shows recommendations', async () => {
     await expect(page).toMatchElement('.ap-m-pixi-recommendations-item', {
-      timeout: 30 * 1000,
+      timeout: 60 * 1000,
     });
   });
 });

--- a/smoke-tests/pixi/Run.e2e-test.js
+++ b/smoke-tests/pixi/Run.e2e-test.js
@@ -19,9 +19,11 @@
 const Platform = require('../../platform/lib/platform.js');
 const platform = new Platform();
 
+const CHECK_TIMEOUT = 60 * 1000; // 60s
+
 describe('Pixi', () => {
   beforeAll(async () => {
-    jest.setTimeout(60 * 1000);
+    jest.setTimeout(CHECK_TIMEOUT);
     await platform.start();
     await page.goto(platformUrl('/page-experience/'));
   });
@@ -42,7 +44,7 @@ describe('Pixi', () => {
     await expect(page).toClick('#input-submit');
     await expect(page).toMatchElement('#status-intro-banner-loading', {
       visible: true,
-      timeout: 60 * 1000,
+      timeout: CHECK_TIMEOUT,
     });
   });
 
@@ -52,7 +54,7 @@ describe('Pixi', () => {
         '.ap-m-pixi-primary-metric-header-title-full',
         {
           text: 'Loading speed',
-          timeout: 60 * 1000,
+          timeout: CHECK_TIMEOUT,
         }
       ),
 
@@ -60,7 +62,7 @@ describe('Pixi', () => {
         '.ap-m-pixi-primary-metric-header-title-full',
         {
           text: 'Interactivity',
-          timeout: 60 * 1000,
+          timeout: CHECK_TIMEOUT,
         }
       ),
 
@@ -68,7 +70,7 @@ describe('Pixi', () => {
         '.ap-m-pixi-primary-metric-header-title-full',
         {
           text: 'Visual stability',
-          timeout: 60 * 1000,
+          timeout: CHECK_TIMEOUT,
         }
       ),
     ]);
@@ -79,7 +81,7 @@ describe('Pixi', () => {
       '#safe-browsing .ap-m-pixi-basic-metric-status',
       {
         text: new RegExp('Passed|Failed', 'gm'),
-        timeout: 60 * 1000,
+        timeout: CHECK_TIMEOUT,
       }
     );
   });
@@ -87,7 +89,7 @@ describe('Pixi', () => {
   it('performs HTTPS check', async () => {
     await expect(page).toMatchElement('#https .ap-m-pixi-basic-metric-status', {
       text: new RegExp('Passed|Failed', 'gm'),
-      timeout: 60 * 1000,
+      timeout: CHECK_TIMEOUT,
     });
   });
 
@@ -96,14 +98,14 @@ describe('Pixi', () => {
       '#mobile-friendliness .ap-m-pixi-basic-metric-status',
       {
         text: new RegExp('Passed|Failed|Analysis failed', 'gm'),
-        timeout: 60 * 1000,
+        timeout: CHECK_TIMEOUT,
       }
     );
   });
 
   it('shows recommendations', async () => {
     await expect(page).toMatchElement('.ap-m-pixi-recommendations-item', {
-      timeout: 60 * 1000,
+      timeout: CHECK_TIMEOUT,
     });
   });
 });


### PR DESCRIPTION
The newly introduced tests currently fail inside the CI: https://github.com/ampproject/amp.dev/runs/2331487733?check_suite_focus=true#step:9:181

Timeouts being too small is more than a wild guess than an exact idea what's wrong though.