### PR TITLE
Disable amppackager

### DIFF
--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -170,7 +170,7 @@ class Platform {
 
   _configureRouters() {
     this.server.use(routers.cspReport);
-    this.server.use(routers.packager);
+    // this.server.use(routers.packager);
     this.server.use(routers.thumbor);
     this.server.use(routers.whoAmI);
     this.server.use(routers.healthCheck);

--- a/platform/lib/routers/packager.js
+++ b/platform/lib/routers/packager.js
@@ -75,11 +75,9 @@ const packager = (request, response, next) => {
     return;
   }
   // Hard-code amp.dev as it has to match the cert
-  const urlToSign = new URL(`https://amp.dev${request.url}`);
-  // Serve unoptimized pages to packager
-  urlToSign.searchParams.set('optimize', false);
+  const urlToSign = `https://amp.dev${request.url}`;
   const searchParams = new URLSearchParams({
-    sign: urlToSign.toString(),
+    sign: urlToSign,
   }).toString();
   const url = `/priv/doc?${searchParams}`;
   // Serve webpackage via packager


### PR DESCRIPTION
The current version of amppackager is curently not compatbile to
optimized AMP + mjs runtime.