### PR TITLE
commit the package-lock file to update the hash used in actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
 				"clean-webpack-plugin": "3.0.0",
 				"codemirror": "5.60.0",
 				"copy-webpack-plugin": "8.1.1",
-				"css-loader": "5.2.1",
+				"css-loader": "5.2.4",
 				"del": "6.0.0",
 				"eslint": "7.24.0",
 				"eslint-config-google": "0.14.0",
@@ -8368,23 +8368,22 @@
 			}
 		},
 		"node_modules/css-loader": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.1.tgz",
-			"integrity": "sha512-YCyRzlt/jgG1xanXZDG/DHqAueOtXFHeusP9TS478oP1J++JSKOyEgGW1GHVoCj/rkS+GWOlBwqQJBr9yajQ9w==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.4.tgz",
+			"integrity": "sha512-OFYGyINCKkdQsTrSYxzGSFnGS4gNjcXkKkQgWxK138jgnPt+lepxdjSZNc8sHAl5vP3DhsJUxufWIjOwI8PMMw==",
 			"dev": true,
 			"dependencies": {
 				"camelcase": "^6.2.0",
-				"cssesc": "^3.0.0",
 				"icss-utils": "^5.1.0",
 				"loader-utils": "^2.0.0",
-				"postcss": "^8.2.8",
+				"postcss": "^8.2.10",
 				"postcss-modules-extract-imports": "^3.0.0",
 				"postcss-modules-local-by-default": "^4.0.0",
 				"postcss-modules-scope": "^3.0.0",
 				"postcss-modules-values": "^4.0.0",
 				"postcss-value-parser": "^4.1.0",
 				"schema-utils": "^3.0.0",
-				"semver": "^7.3.4"
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": ">= 10.13.0"
@@ -36472,23 +36471,22 @@
 			}
 		},
 		"css-loader": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.1.tgz",
-			"integrity": "sha512-YCyRzlt/jgG1xanXZDG/DHqAueOtXFHeusP9TS478oP1J++JSKOyEgGW1GHVoCj/rkS+GWOlBwqQJBr9yajQ9w==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.4.tgz",
+			"integrity": "sha512-OFYGyINCKkdQsTrSYxzGSFnGS4gNjcXkKkQgWxK138jgnPt+lepxdjSZNc8sHAl5vP3DhsJUxufWIjOwI8PMMw==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^6.2.0",
-				"cssesc": "^3.0.0",
 				"icss-utils": "^5.1.0",
 				"loader-utils": "^2.0.0",
-				"postcss": "^8.2.8",
+				"postcss": "^8.2.10",
 				"postcss-modules-extract-imports": "^3.0.0",
 				"postcss-modules-local-by-default": "^4.0.0",
 				"postcss-modules-scope": "^3.0.0",
 				"postcss-modules-values": "^4.0.0",
 				"postcss-value-parser": "^4.1.0",
 				"schema-utils": "^3.0.0",
-				"semver": "^7.3.4"
+				"semver": "^7.3.5"
 			},
 			"dependencies": {
 				"ajv-keywords": {


### PR DESCRIPTION
the staging build is currently failing because the cache hash is [based on a hash of `package-lock.json`](https://github.com/ampproject/amp.dev/blob/9f8b45577397f80b7b48c4c2e7fd5f5177c3506e/.github/workflows/release-staging.yaml#L39). I updated that file to unblock the build, and will follow up with a workflow change shortly to prevent it from happening again