### PR TITLE
add libyaml/pyYAML information to README, and make it a part of the default installation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ We welcome contributions to amp.dev.
 
   **Mac**
   ```sh
-    LDFLAGS="-L$(brew --prefix)/lib" CFLAGS="-I$(brew --prefix)/include" pipenv run pip3 install --global-option="--with-libyaml" --force pyyaml
-    pipenv run pip3 install --user grow
+    LDFLAGS="-L$(brew --prefix)/lib" CFLAGS="-I$(brew --prefix)/include" pip3 install --global-option="--with-libyaml" --force pyyaml
+    pip3 install --user grow
     ```
 
   **Linux**

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We welcome contributions to amp.dev.
       ```
    1. Run the following command to install Python. Version 3.7 is required at latest.
       ```sh
-      $ brew install python
+      $ brew install python libyaml
       ```
    1. Run the following command to add the _pip user base binary directory_ to `$PATH`.
       ```sh
@@ -65,14 +65,23 @@ We welcome contributions to amp.dev.
       ```
    1. Run the following command to use a faster YAML parser.
       ```sh
-      $ sudo apt install -y python-yaml
+      $ sudo apt install -y python-yaml libyaml-dev
       ```
 
 1. Install [Grow](http://grow.io), the static site generator used to build amp.dev. Do so by using `pip` instead of its installer. Using `pip` will enable importing from the `grow` package in Python later on.
 
    **Note**: Be sure to use the `pip` command associated with Python 3 as Grow 1 depends on Python 3.
 
+
+  **Mac**
+  ```sh
+    LDFLAGS="-L$(brew --prefix)/lib" CFLAGS="-I$(brew --prefix)/include" pipenv run pip3 install --global-option="--with-libyaml" --force pyyaml
+    pipenv run pip3 install --user grow
+    ```
+
+  **Linux**
    ```sh
+   $ pip3 install --global-option="--with-libyaml" --force pyyaml
    $ pip3 install --user grow
    ```
 


### PR DESCRIPTION
doing builds locally sped up ~500% when it was added, should not make it seem quite as unimportant in the README