### PR TITLE
hide surveys when they are inside of amp-next-page

### DIFF
--- a/frontend/scss/components/organisms/survey.scss
+++ b/frontend/scss/components/organisms/survey.scss
@@ -189,3 +189,7 @@ $delay: 0.25s;
   top: 250vh;
   height: 100%;
 }
+
+.i-amphtml-next-page-shadow-root #fez-container {
+  display: none;
+}


### PR DESCRIPTION
fixes #5717

@kristoferbaxter we have an amp-script component that shows the survey. It is loading multiple times as a result of `amp-next-page`. I created a PR to hide it via CSS if it is a descendant of of amp-next-page, but that feels fairly kludgey - is there a better way to detect/prevent this behavior?