### PR TITLE
Add web player short link

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -63,6 +63,7 @@
 /validate: /documentation/guides-and-tutorials/learn/validation-workflow/validate_amp/
 /verizonmedia: https://developer.verizonmedia.com/mail/amp-for-email/
 /vision-mission: /about/mission-and-vision/
+/web-player: /documentation/guides-and-tutorials/integrate/embed-stories-nonamp/?format=stories
 /websites: /about/websites/
 /wg: https://github.com/ampproject/meta/tree/master/working-groups
 /wg-updates: https://github.com/search?o=desc&q=org%3Aampproject+label%3A%22Type%3A+Status+Update%22&s=created&


### PR DESCRIPTION
Adding a short link for the web player with the existing guide as a placeholder, will update the actual URL later.