### PR TITLE
Fix hide surveys when they are inside of amp-next-page

### DIFF
--- a/frontend/scss/components/organisms/survey.scss
+++ b/frontend/scss/components/organisms/survey.scss
@@ -190,6 +190,3 @@ $delay: 0.25s;
   height: 100%;
 }
 
-.i-amphtml-next-page-shadow-root #fez-container {
-  display: none;
-}

--- a/frontend/templates/views/partials/survey.j2
+++ b/frontend/templates/views/partials/survey.j2
@@ -12,7 +12,7 @@
     </script>
   </amp-state>
 
-  <amp-script src="{{ podspec.base_urls.platform }}/static/survey.js" width="450" height="1205"  id="fez-container" sandbox="allow-forms">
+  <amp-script src="{{ podspec.base_urls.platform }}/static/survey.js" width="450" height="1205"  id="fez-container" sandbox="allow-forms" next-page-hide>
     <form id="fez" action="#" target="_top">
       {% do doc.icons.useIcon('icons/close.svg') %}
       <svg class="ap-a-ico icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close"></use></svg>


### PR DESCRIPTION
Remove CSS as targeting i-amphtml-* is invalid AMP. Use amp-next-page's
built-in `next-page-hide` element instead to make sure that surveys are
not repeated.