### PR TITLE
🎉 Bootstrap components section for new about page

### DIFF
--- a/frontend/templates/views/2021/partials/extras/about/components-showcase.j2
+++ b/frontend/templates/views/2021/partials/extras/about/components-showcase.j2
@@ -1,0 +1,33 @@
+<article class="ap-components-showcase">
+  <div class="ap-components-showcase-buttons" role="list">
+    <button class="ap-button">{{ _('Carousel') }}</button>
+    <button class="ap-button --inactive">{{ _('Accordion') }}</button>
+  </div>
+
+  <div class="ap-components-showcase-demos">
+    <div class="ap-components-showcase-demo --carousel">
+      <div class="ap-components-showcase-demo-code">
+        <div class="ap-code-snippet">
+          {% set code_snippet = g.doc('/shared/components-showcase/amp-carousel.html').content %}
+          {{ doc.pod.markdown.convert('```html\n' + code_snippet + '\n```')|safe }}
+        </div>
+      </div>
+
+      <div class="ap-components-showcase-demo-ui">
+        <!-- Styled demo here -->
+      </div>
+    </div>
+    <div class="ap-components-showcase --accordion">
+      <div class="ap-components-showcase-demo-code">
+        <div class="ap-code-snippet">
+          {% set code_snippet = g.doc('/shared/components-showcase/amp-accordion.html').content %}
+          {{ doc.pod.markdown.convert('```html\n' + code_snippet + '\n```')|safe }}
+        </div>
+      </div>
+
+      <div class="ap-components-showcase-demo-ui">
+        <!-- Styled demo here -->
+      </div>
+    </div>
+  </div>
+</article>

--- a/frontend21/scss/amp-dev.scss
+++ b/frontend21/scss/amp-dev.scss
@@ -38,6 +38,7 @@
 @import 'components/filter-bubbles-list.scss';
 @import 'components/pill.scss';
 @import 'components/content/stage.scss';
+@import 'components/extra/about/components-showcase.scss';
 
 main {
   @include grid;
@@ -115,7 +116,6 @@ p code {
   font-weight: 500;
   word-break: normal;
   color: color('black');
-  background: color('iron');
   font-size: 0.9em;
 }
 

--- a/frontend21/scss/components/button.scss
+++ b/frontend21/scss/components/button.scss
@@ -22,8 +22,13 @@
     box-shadow: 0 25px 20px -15px rgba(0, 0, 0, 0.15);
   }
 
-  &.--inverted {
+  &.--inverted,
+  &.--inactive {
     background: color('white');
     color: color('blue-ribbon');
+  }
+
+  &.--inactive {
+    color: inherit;
   }
 }

--- a/frontend21/scss/components/extra/about/components-showcase.scss
+++ b/frontend21/scss/components/extra/about/components-showcase.scss
@@ -1,0 +1,23 @@
+.#{project('components-showcase')} {
+  background: red;
+
+  &-buttons {
+    background: lime;
+  }
+
+  &-demos {
+    background: cyan;
+  }
+
+  &-demo {
+    background: yellow;
+
+    &-code {
+      background: slategray;
+    }
+
+    &-ui {
+      background: magenta;
+    }
+  }
+}

--- a/pages/content/amp-dev/about/websites-2021.html
+++ b/pages/content/amp-dev/about/websites-2021.html
@@ -1,7 +1,7 @@
 ---
 $title: AMP Websites
 $view: /views/2021/base.html
-description: "AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across ..."
+description: 'AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across ...'
 sharing_images:
   square: /static/img/sharing/about-websites-1x1.png
   wide: /static/img/sharing/about-websites-600x314.png
@@ -14,11 +14,16 @@ sharing_images:
         <h2>{{ _('AMP Websites') }}</h2>
         <h1>{{ _('A framework that amplifies page experience.') }}</h1>
         <p>
-          {{ _('AMP is a simple and robust web components framework that makes it easy to build fast websites that are user-first and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating costs.') }}
+          {{ _('AMP is a simple and robust web components framework that makes
+          it easy to build fast websites that are user-first and makes money.
+          AMP provides long-term success for your web strategy with distribution
+          across popular platforms and reduced operating costs.') }}
         </p>
 
-        <a class="ap-button --inverted"
-          href="{{ g.doc('/content/amp-dev/documentation/index.html', locale=doc.locale).url.path }}">
+        <a
+          class="ap-button --inverted"
+          href="{{ g.doc('/content/amp-dev/documentation/index.html', locale=doc.locale).url.path }}"
+        >
           {{ _('Get started with AMP') }}
         </a>
       </div>
@@ -26,13 +31,61 @@ sharing_images:
 
     <div class="ap-stage-backdrop">
       <svg width="457" height="457">
-        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/static/frontend/sprite.svg#deco-foundation"></use>
+        <use
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xlink:href="/static/frontend/sprite.svg#deco-foundation"
+        ></use>
       </svg>
     </div>
 
     <div class="ap-stage-media">
-      <amp-img src="/static/img/about/websites-amp-sidebar.jpg" layout="responsive" width="653" height="567"
-        alt="{{ _('A screenshot showing amp-sidebar.') }}"></amp-img>
+      <amp-img
+        src="/static/img/about/websites-amp-sidebar.jpg"
+        layout="responsive"
+        width="653"
+        height="567"
+        alt="{{ _('A screenshot showing amp-sidebar.') }}"
+      ></amp-img>
+    </div>
+  </section>
+
+  <section class="ap-section --col-4-23">
+    <div class="ap-text-block">
+      <h2 class="ap-h1">{{ _('Grab-and-go components') }}</h2>
+    </div>
+
+    <div class="ap-text-media --thirds --center --mobile-reverse">
+      <div class="ap-text-media-col">
+        <div class="ap-text-block">
+          <p>
+            {{ _('Quickly build pages with AMP’s extensive component library.
+            These components are copy-and-pastable and meet a wide range of UI
+            and functionality needs. They are customizable in behavior and style
+            through attributes and CSS. Best of all, they have a team of
+            engineers working full-time to guarantee performance.') }}
+          </p>
+        </div>
+        <a
+          href="{{ g.doc('/content/amp-dev/documentation/components/index.html', locale=doc.locale).url.path }}"
+          class="ap-m-lnk ap-m-lnk-square"
+        >
+          <div class="ap-a-ico ap-m-lnk-icon">
+            {% do doc.icons.useIcon('icons/internal.svg') %}
+            <svg>
+              <use
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xlink:href="#internal"
+              ></use>
+            </svg>
+          </div>
+          <span class="ap-m-lnk-text"
+            >{{ _('See the full component library') }}</span
+          >
+        </a>
+      </div>
+      <div class="ap-text-media-col">
+        {% include 'views/2021/partials/extras/about/components-showcase.j2' %}
+      </div>
     </div>
   </section>
 
@@ -45,20 +98,35 @@ sharing_images:
         <div class="ap-text-block">
           <h2 class="ap-h1">{{ _('Guaranteed Page Experience') }}</h2>
           <p>
-            {{ _('AMP provides you with the tools needed to build websites that meet Page Experience ranking signals while remaining flexible and customizable to your needs. Page experience is a set of signals from Google that measure how users perceive their experience interacting with a web page beyond its pure information value. AMP is a straightforward way to a high page experience score. Domains built with AMP are 5 times more likely to pass* Core Web Vitals metrics than non-AMP!') }}
+            {{ _('AMP provides you with the tools needed to build websites that
+            meet Page Experience ranking signals while remaining flexible and
+            customizable to your needs. Page experience is a set of signals from
+            Google that measure how users perceive their experience interacting
+            with a web page beyond its pure information value. AMP is a
+            straightforward way to a high page experience score. Domains built
+            with AMP are 5 times more likely to pass* Core Web Vitals metrics
+            than non-AMP!') }}
           </p>
         </div>
 
-        <a class="ap-button" href="{{ g.doc('/content/amp-dev/page-experience.html', locale=doc.locale).url.path }}">
+        <a
+          class="ap-button"
+          href="{{ g.doc('/content/amp-dev/page-experience.html', locale=doc.locale).url.path }}"
+        >
           {{ _('Check your page’s performance') }}
         </a>
 
-        <a href="{{g.doc('/content/amp-dev/about/page-experience.html', locale=doc.locale).url.path}}"
-          class="ap-m-lnk ap-m-lnk-square">
+        <a
+          href="{{g.doc('/content/amp-dev/about/page-experience.html', locale=doc.locale).url.path}}"
+          class="ap-m-lnk ap-m-lnk-square"
+        >
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
             <svg>
-              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use>
+              <use
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xlink:href="#internal"
+              ></use>
             </svg>
           </div>
           <span class="ap-m-lnk-text">{{ _('Learn more') }}</span>
@@ -75,23 +143,38 @@ sharing_images:
     <div class="ap-text-media --thirds --center --mobile-reverse">
       <div class="ap-text-media-col">
         <div class="ap-text-block">
-          <p>{{ _('Select a ready-to-go framework or integration-enabled CMS to get an AMP valid site up and running, fast. These platforms give you all the benefits of AMP without all the built-from-scratch hassle.') }}</p>
+          <p>
+            {{ _('Select a ready-to-go framework or integration-enabled CMS to
+            get an AMP valid site up and running, fast. These platforms give you
+            all the benefits of AMP without all the built-from-scratch hassle.')
+            }}
+          </p>
         </div>
-        <a href="{{ g.doc('/content/amp-dev/support/faq/platform-and-vendor-partners.md', locale=doc.locale).url.path }}" class="ap-m-lnk ap-m-lnk-square">
+        <a
+          href="{{ g.doc('/content/amp-dev/support/faq/platform-and-vendor-partners.md', locale=doc.locale).url.path }}"
+          class="ap-m-lnk ap-m-lnk-square"
+        >
           <div class="ap-a-ico ap-m-lnk-icon">
             {% do doc.icons.useIcon('icons/internal.svg') %}
-            <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
+            <svg>
+              <use
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xlink:href="#internal"
+              ></use>
+            </svg>
           </div>
           <span class="ap-m-lnk-text">{{ _('See supported platforms') }}</span>
         </a>
       </div>
       <div class="ap-text-media-col">
         <figure>
-          <amp-img alt="{{ _('Supported CMS’ and frameworks') }}"
-              src="/static/img/frameworks.jpg"
-              width="714"
-              height="288"
-              layout="responsive">
+          <amp-img
+            alt="{{ _('Supported CMS’ and frameworks') }}"
+            src="/static/img/frameworks.jpg"
+            width="714"
+            height="288"
+            layout="responsive"
+          >
           </amp-img>
         </figure>
       </div>

--- a/pages/shared/components-showcase/amp-accordion.html
+++ b/pages/shared/components-showcase/amp-accordion.html
@@ -1,0 +1,1 @@
+<amp-accordion></amp-accordion>

--- a/pages/shared/components-showcase/amp-carousel.html
+++ b/pages/shared/components-showcase/amp-carousel.html
@@ -1,0 +1,1 @@
+<amp-carousel></amp-carousel>


### PR DESCRIPTION
@dlemm, @lluerich: here's a solid starting point for the Grab and Go components section for the new [about websites](https://amp-dev-staging.appspot.com/about/websites-2021/) page:

![image](https://user-images.githubusercontent.com/12857772/117650873-87b39680-b191-11eb-9991-9e51f9a4d155.png)
