### PR TITLE
Don't fail with a 503 if packager instance is not available

### DIFF
--- a/platform/lib/routers/packager.js
+++ b/platform/lib/routers/packager.js
@@ -80,8 +80,14 @@ const packager = (request, response, next) => {
     sign: urlToSign,
   }).toString();
   const url = `/priv/doc?${searchParams}`;
-  // Serve webpackage via packager
-  sxgProxy(request, response, url, next);
+  try {
+    // Serve webpackage via packager
+    sxgProxy(request, response, url, next);
+  } catch (error) {
+    log.error('[SXG] could not proxy request to amppackager', error);
+    // Serve normal version of the page
+    next();
+  }
 };
 
 function sxgProxy(request, response, url) {


### PR DESCRIPTION
Instead return at least the non SXG document.