### PR TITLE
🐛 Keep frontend21 static assets across build stages

### DIFF
--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -306,6 +306,7 @@ function buildPrepare(done) {
         './boilerplate/lib/',
         './boilerplate/dist/',
         './playground/dist/',
+        './frontend21/dist/',
         './frontend/templates/views/partials/pixi/webpack.j2',
         './.cache/',
         './examples/static/samples/samples.json',
@@ -455,6 +456,7 @@ function collectStatics(done) {
     .src([
       project.absolute('pages/static/**/*'),
       project.absolute('examples/static/**/*'),
+      project.absolute('frontend21/dist/static/**/*'),
     ])
     .pipe(
       through.obj(async function (file, encoding, callback) {


### PR DESCRIPTION
This should make the icons appear on the new about page.