### PR TITLE
Fix broken links pointing to spec/

### DIFF
--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@ar.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@ar.md
@@ -162,7 +162,7 @@ teaser:
 
 ##### إطارات iframe صديقة (من ذاكرة التخزين المؤقت لصفحات AMP مثلاً) <a name="on-friendly-iframes-eg-coming-from-an-amp-cache"></a>
 
-<amp-img alt="إعلان العرض المبسط في إطار iframe صديق" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-fie.gif" layout="fixed">
+<amp-img alt="إعلان العرض المبسط في إطار iframe صديق" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-fie.gif" layout="fixed">
 <noscript>
 <img alt="إعلان العرض المبسط في إطار iframe صديق" src="../../spec/img/lightbox-ad-fie.gif">
 </noscript>
@@ -170,7 +170,7 @@ teaser:
 
 ##### إطارات iframe خارجية (من خارج ذاكرة التخزين المؤقت لصفحات AMP مثلاً) <a name="on-third-party-iframes-eg-outside-the-amp-cache"></a>
 
-<amp-img alt="إعلان العرض المبسط في إطار iframe خارجي" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-3p.gif" layout="fixed">
+<amp-img alt="إعلان العرض المبسط في إطار iframe خارجي" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-3p.gif" layout="fixed">
 <noscript>
 <img alt="إعلان العرض المبسط في إطار iframe خارجي" src="../../spec/img/lightbox-ad-3p.gif">
 </noscript>

--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@es.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@es.md
@@ -151,7 +151,7 @@ En los ejemplos siguientes se muestra la transición de un anuncio AMP HTML que 
 
 ##### En friendly iframes (p. ej., procedente de una caché AMP) <a name="on-friendly-iframes-eg-coming-from-an-amp-cache"></a>
 
-<amp-img alt="lightbox ad in friendly iframe" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-fie.gif" layout="fixed">
+<amp-img alt="lightbox ad in friendly iframe" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-fie.gif" layout="fixed">
   <noscript>
     <img alt="lightbox ad in friendly iframe" src="../../spec/img/lightbox-ad-fie.gif">
     </noscript>
@@ -159,7 +159,7 @@ En los ejemplos siguientes se muestra la transición de un anuncio AMP HTML que 
 
 ##### En iframes de terceros (p. ej., no procedente de una caché AMP) <a name="on-third-party-iframes-eg-outside-the-amp-cache"></a>
 
-<amp-img alt="lightbox ad in 3p iframe" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-3p.gif" layout="fixed">
+<amp-img alt="lightbox ad in 3p iframe" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-3p.gif" layout="fixed">
   <noscript>
     <img alt="lightbox ad in 3p iframe" src="../../spec/img/lightbox-ad-3p.gif">
     </noscript>

--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@fr.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@fr.md
@@ -151,7 +151,7 @@ Dans les exemples ci-dessous, vous pouvez voir comment la transition recherche u
 
 ##### Sur des friendly iframes (provenant, par exemple, d'un cache AMP) <a name="on-friendly-iframes-eg-coming-from-an-amp-cache"></a>
 
-<amp-img alt="annonce Lightbox dans un friendly iframe" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-fie.gif" layout="fixed">
+<amp-img alt="annonce Lightbox dans un friendly iframe" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-fie.gif" layout="fixed">
   <noscript>
     <img alt="annonce Lightbox dans un friendly iframe" src="../../spec/img/lightbox-ad-fie.gif">
     </noscript>
@@ -159,7 +159,7 @@ Dans les exemples ci-dessous, vous pouvez voir comment la transition recherche u
 
 ##### Sur des cadres iFrame tiers (par exemple, en dehors du cache AMP) <a name="on-third-party-iframes-eg-outside-the-amp-cache"></a>
 
-<amp-img alt="annonce Lightbox dans un iFrame 3p" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-3p.gif" layout="fixed">
+<amp-img alt="annonce Lightbox dans un iFrame 3p" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-3p.gif" layout="fixed">
   <noscript>
     <img alt="annonce Lightbox dans un iFrame 3p" src="../../spec/img/lightbox-ad-3p.gif">
     </noscript>

--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@id.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@id.md
@@ -151,7 +151,7 @@ Pada contoh di bawah, kami menunjukkan tampilan transisi untuk iklan AMPHTML den
 
 ##### Pada iframe yang sesuai (misalnya, yang berasal dari cache AMP) <a name="on-friendly-iframes-eg-coming-from-an-amp-cache"></a>
 
-<amp-img alt="iklan lightbox dalam iframe yang sesuai" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-fie.gif" layout="fixed">
+<amp-img alt="iklan lightbox dalam iframe yang sesuai" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-fie.gif" layout="fixed">
   <noscript>
     <img alt="iklan lightbox dalam iframe yang sesuai" src="../../spec/img/lightbox-ad-fie.gif">
     </noscript>
@@ -159,7 +159,7 @@ Pada contoh di bawah, kami menunjukkan tampilan transisi untuk iklan AMPHTML den
 
 ##### Pada iframe pihak ketiga (misalnya, dari luar cache AMP) <a name="on-third-party-iframes-eg-outside-the-amp-cache"></a>
 
-<amp-img alt="iklan lightbox dalam iframe 3p" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-3p.gif" layout="fixed">
+<amp-img alt="iklan lightbox dalam iframe 3p" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-3p.gif" layout="fixed">
   <noscript>
     <img alt="iklan lightbox dalam iframe 3p" src="../../spec/img/lightbox-ad-3p.gif">
     </noscript>

--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@it.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@it.md
@@ -157,7 +157,7 @@ Negli esempi riportati di seguito, dimostriamo come si presenta la transizione p
 
 ##### In iframe semplici, ad esempio, provenienti da cache AMP <a name="on-friendly-iframes-eg-coming-from-an-amp-cache"></a>
 
-<amp-img alt="lightbox ad in friendly iframe" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-fie.gif" layout="fixed">
+<amp-img alt="lightbox ad in friendly iframe" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-fie.gif" layout="fixed">
   <noscript>
     <img alt="lightbox ad in friendly iframe" src="../../spec/img/lightbox-ad-fie.gif">
     </noscript>
@@ -165,7 +165,7 @@ Negli esempi riportati di seguito, dimostriamo come si presenta la transizione p
 
 ##### In iframe di terze parti, ad esempio, esterni a cache AMP <a name="on-third-party-iframes-eg-outside-the-amp-cache"></a>
 
-<amp-img alt="lightbox ad in 3p iframe" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-3p.gif" layout="fixed">
+<amp-img alt="lightbox ad in 3p iframe" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-3p.gif" layout="fixed">
   <noscript>
     <img alt="lightbox ad in 3p iframe" src="../../spec/img/lightbox-ad-3p.gif">
     </noscript>

--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@ja.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@ja.md
@@ -150,7 +150,7 @@ AMPHTML 広告がサードパーティ環境（非 AMP ドキュメントなど�
 
 ##### Friendly iframe の場合（AMP キャッシュ内の iframe など） <a name="on-friendly-iframes-eg-coming-from-an-amp-cache"></a>
 
-<amp-img alt="Friendly iframe 内のライトボックス広告" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-fie.gif" layout="fixed">
+<amp-img alt="Friendly iframe 内のライトボックス広告" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-fie.gif" layout="fixed">
   <noscript>
     <img alt="Friendly iframe 内のライトボックス広告" src="../../spec/img/lightbox-ad-fie.gif">
     </noscript>
@@ -158,7 +158,7 @@ AMPHTML 広告がサードパーティ環境（非 AMP ドキュメントなど�
 
 ##### サードパーティ iframe の場合（AMP キャッシュ外の iframe など） <a name="on-third-party-iframes-eg-outside-the-amp-cache"></a>
 
-<amp-img alt="サードパーティ iframe 内のライトボックス広告" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-3p.gif" layout="fixed">
+<amp-img alt="サードパーティ iframe 内のライトボックス広告" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-3p.gif" layout="fixed">
   <noscript>
     <img alt="サードパーティ iframe 内のライトボックス広告" src="../../spec/img/lightbox-ad-3p.gif">
     </noscript>

--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@ko.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@ko.md
@@ -157,7 +157,7 @@ AMPHTML 광고가 제3자 환경에서 실행 중인 경우(예: 비AMP 문서) 
 
 ##### 호환 iframe(예: AMP 캐시에서 가져옴) <a name="on-friendly-iframes-eg-coming-from-an-amp-cache"></a>
 
-<amp-img alt="호환 iframe의 라이트박스 광고" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-fie.gif" layout="fixed">
+<amp-img alt="호환 iframe의 라이트박스 광고" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-fie.gif" layout="fixed">
   <noscript>
     <img alt="호환 iframe의 라이트박스 광고" src="../../spec/img/lightbox-ad-fie.gif">
     </noscript>
@@ -165,7 +165,7 @@ AMPHTML 광고가 제3자 환경에서 실행 중인 경우(예: 비AMP 문서) 
 
 ##### 제3자 iframe(예: AMP 캐시 외부에서 가져옴) <a name="on-third-party-iframes-eg-outside-the-amp-cache"></a>
 
-<amp-img alt="제3자 iframe의 라이트박스 광고" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-3p.gif" layout="fixed">
+<amp-img alt="제3자 iframe의 라이트박스 광고" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-3p.gif" layout="fixed">
   <noscript>
     <img alt="제3자 iframe의 라이트박스 광고" src="../../spec/img/lightbox-ad-3p.gif">
     </noscript>

--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@pt_BR.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@pt_BR.md
@@ -151,7 +151,7 @@ Nos exemplos abaixo, demonstramos como a transição procura um anúncio HTML pa
 
 ##### Em iframes compatíveis (por exemplo, provenientes de um cache de AMP) <a name="on-friendly-iframes-eg-coming-from-an-amp-cache"></a>
 
-<amp-img alt="anúncio lightbox em iframe compatível" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-fie.gif" layout="fixed">
+<amp-img alt="anúncio lightbox em iframe compatível" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-fie.gif" layout="fixed">
   <noscript>
     <img alt="anúncio lightbox em iframe compatível" src="../../spec/img/lightbox-ad-fie.gif">
     </noscript>
@@ -159,7 +159,7 @@ Nos exemplos abaixo, demonstramos como a transição procura um anúncio HTML pa
 
 ##### Em iframes de terceiros (por exemplo, fora do cache de AMP) <a name="on-third-party-iframes-eg-outside-the-amp-cache"></a>
 
-<amp-img alt="anúncio lightbox em iframe de terceiro" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-3p.gif" layout="fixed">
+<amp-img alt="anúncio lightbox em iframe de terceiro" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-3p.gif" layout="fixed">
   <noscript>
     <img alt="anúncio lightbox em iframe de terceiro" src="../../spec/img/lightbox-ad-3p.gif">
     </noscript>

--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@tr.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@tr.md
@@ -152,7 +152,7 @@ Aşağıdaki örneklerde, bir güvenilir iframe ve bir üçüncü taraf iframe i
 
 ##### Güvenilir iframe'lerde (ör. AMP önbelleğinden gelmektedir) <a name="on-friendly-iframes-eg-coming-from-an-amp-cache"></a>
 
-<amp-img alt="güvenilir iframe içindeki lightbox reklamı" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-fie.gif" layout="fixed">
+<amp-img alt="güvenilir iframe içindeki lightbox reklamı" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-fie.gif" layout="fixed">
   <noscript>
     <img alt="güvenilir iframe içindeki lightbox reklamı" src="../../spec/img/lightbox-ad-fie.gif">
     </noscript>
@@ -160,7 +160,7 @@ Aşağıdaki örneklerde, bir güvenilir iframe ve bir üçüncü taraf iframe i
 
 ##### Üçüncü taraf iframe'lerde (ör. AMP önbelleği dışındadır) <a name="on-third-party-iframes-eg-outside-the-amp-cache"></a>
 
-<amp-img alt="3p iframe içindeki lightbox reklamı" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-3p.gif" layout="fixed">
+<amp-img alt="3p iframe içindeki lightbox reklamı" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-3p.gif" layout="fixed">
   <noscript>
     <img alt="3p iframe içindeki lightbox reklamı" src="../../spec/img/lightbox-ad-3p.gif">
     </noscript>

--- a/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@zh_CN.md
+++ b/pages/content/amp-dev/documentation/components/reference/amp-lightbox-v0.1@zh_CN.md
@@ -152,7 +152,7 @@ AMPHTML 广告不允许使用可滚动的灯箱。
 
 ##### 在友好型 iframe 中（例如来自 AMP 缓存） <a name="on-friendly-iframes-eg-coming-from-an-amp-cache"></a>
 
-<amp-img alt="友好型 iframe 中的灯箱广告" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-fie.gif" layout="fixed">
+<amp-img alt="友好型 iframe 中的灯箱广告" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-fie.gif" layout="fixed">
   <noscript>
     <img alt="友好型 iframe 中的灯箱广告" src="../../spec/img/lightbox-ad-fie.gif">
     </noscript>
@@ -160,7 +160,7 @@ AMPHTML 广告不允许使用可滚动的灯箱。
 
 ##### 在第三方 iframe 中（例如在 AMP 缓存之外） <a name="on-third-party-iframes-eg-outside-the-amp-cache"></a>
 
-<amp-img alt="第三方 iframe 中的灯箱广告" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/spec/img/lightbox-ad-3p.gif" layout="fixed">
+<amp-img alt="第三方 iframe 中的灯箱广告" width="360" height="480" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/lightbox-ad-3p.gif" layout="fixed">
   <noscript>
     <img alt="第三方 iframe 中的灯箱广告" src="../../spec/img/lightbox-ad-3p.gif">
     </noscript>

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure.md
@@ -42,7 +42,7 @@ To embed AMP within an email, add a new MIME part with a content type of `text/x
 <amp-img alt="AMP for Email MIME Parts Diagram"
     layout="responsive"
     width="752" height="246"
-    src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png">
+    src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png">
 <noscript>
 <img alt="AMP for Email MIME Parts Diagram" src="../img/amp-email-mime-parts.png" />
 </noscript>

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@ar.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@ar.md
@@ -35,7 +35,7 @@ limitations under the License.
 
 لتضمين AMP داخل بريد إلكتروني، أضف جزء MIME جديد بنوع محتوى `text/x-amp-html` كتابع لـ`multipart/alternative`. يجب أن يتواجد بجانب أجزاء `text/html` أو `text/plain` الموجودة. هذا يضمن أن رسالة البريد الإلكتروني تعمل على جميع العملاء.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="مخطط أجزاء AMP للبريد الإلكتروني MIME" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="مخطط أجزاء AMP للبريد الإلكتروني MIME" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 لمزيد من المعلومات حول النوع الفرعي `multipart/alternative` ، راجع [RFC 1521، القسم 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3).
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@de.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@de.md
@@ -35,7 +35,7 @@ Eine E-Mail besitzt die Struktur eines MIME Baumes. Dieser MIME Baum enthält de
 
 Um AMP in eine E-Mail einzubetten, füge einen neuen MIME Teil mit dem Inhaltstyp `text/x-amp-html` als Nachfolger von `multipart/alternative` hinzu. Er muss den vorhandenen Teilen `text/html` oder `text/plain` gleichgestellt sein. Dadurch wird sichergestellt, dass die E-Mail Nachricht auf allen Clients funktioniert.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP für E-Mail-MIME-Teilediagramm" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP für E-Mail-MIME-Teilediagramm" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 Weitere Informationen über den Untertyp `multipart/alternative` findest du in [RFC 1521, Abschnitt 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3).
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@es.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@es.md
@@ -35,7 +35,7 @@ El correo electrónico está estructurado como un árbol MIME. En este árbol MI
 
 Para integrar AMP en un correo electrónico, agregue una nueva sección del MIME que tenga un contenido tipo `text/x-amp-html` y sea descendiente de `multipart/alternative`. Debe establecerse junto con el actual `text/html` o las secciones de `text/plain`. Esto garantizará que el mensaje de correo electrónico funcione para todos los clientes.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP para diagrama de piezas de MIME de correo electrónico" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP para diagrama de piezas de MIME de correo electrónico" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 Para obtener más información sobre el subtipo `multipart/alternative` consulte el [RFC 1521, sección 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3).
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@fr.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@fr.md
@@ -35,7 +35,7 @@ L'e-mail est structuré comme une arborescence MIME. Cette arborescence MIME con
 
 Pour intégrer AMP dans un e-mail, ajoutez une nouvelle partie MIME avec un type de contenu `text/x-amp-html` descendant de `multipart/alternative`. Il doit cohabiter avec les parties `text/html` ou `text/plain` existantes. Cela garantit que le message électronique fonctionne sur tous les clients.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP pour le diagramme des pièces MIME de courrier électronique" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP pour le diagramme des pièces MIME de courrier électronique" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 Pour plus d'informations sur le sous-type `multipart/alternative`, reportez-vous à la [RFC 1521, section 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3).
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@id.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@id.md
@@ -35,7 +35,7 @@ Struktur email sama dengan pohon MIME. Pohon MIME ini berisi badan pesan dan lam
 
 Untuk menyematkan AMP di dalam sebuah email, tambahkan bagian MIME baru dengan jenis konten `text/x-amp-html` sebagai turunan `multipart/alternative`. Ini harus berada bersama bagian `text/html` atau `text/plain` yang sudah ada. Ini memastikan bahwa pesan email tersebut akan berfungsi pada semua klien.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"> <img data-md-type="raw_html" alt="AMP for Email MIME Parts Diagram" src="../img/amp-email-mime-parts.png"> </noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"> <img data-md-type="raw_html" alt="AMP for Email MIME Parts Diagram" src="../img/amp-email-mime-parts.png"> </noscript></amp-img>
 
 Untuk mendapatkan informasi selengkapnya tentang subjenis `multipart/alternative`, rujuk [RFC 1521, bagian 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3).
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@it.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@it.md
@@ -35,7 +35,7 @@ Le e-mail hanno la struttura di un albero MIME. Questo albero MIME contiene il c
 
 Per incorporare contenuti AMP in un'email, occorre aggiungere una nuova parte MIME con contenuto di tipo `text/x-amp-html` come discendente di `multipart/alternative`. Tale elemento dovrà coesistere con le parti `text/html` o `text/plain` esistenti. Ciò garantisce che il messaggio e-mail funzioni su tutti i client.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="Diagramma delle parti MIME di AMP per email" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="Diagramma delle parti MIME di AMP per email" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 Per ulteriori informazioni sul sottotipo `multipart/alternative`, fare riferimento allo standard [RFC 1521, sezione 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3).
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@ja.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@ja.md
@@ -35,7 +35,7 @@ limitations under the License.
 
 メール内に AMP を埋め込むには、コンテンツタイプ `text/x-amp-html` の新しい MIME パートを `multipart/alternative` の子孫として追加します。既存の `text/html` または `text/plain` パートとともに存在する必要があります。こうすることで、メールメッセージがすべてのクライアントで機能するようにすることができます。
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP for Email MIMEパーツ図" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP for Email MIMEパーツ図" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 `multipart/alternative` サブタイプについての詳細は、[RFC 1521, section 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3) を参照してください。
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@ko.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@ko.md
@@ -35,7 +35,7 @@ limitations under the License.
 
 이메일에 AMP를 임베딩하려면 콘텐츠 유형이 `text/x-amp-html`인 새 MIME 부분을 `multipart/alternative`의 하위 요소로 추가합니다. 해당 부분은 기존의 `text/html` 또는 `text/plain` 부분과 함께 사용되어야 하며 이를 통해 이메일 메시지가 모든 클라이언트에서 작동할 수 있습니다.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP for Email MIME 부품 다이어그램" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP for Email MIME 부품 다이어그램" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 `multipart/alternative` 서브타입과 관련한 자세한 정보는 [RFC 1521, 섹션 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3)을 참조하세요.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@pl.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@pl.md
@@ -35,7 +35,7 @@ Wiadomości e-mail nadawana jest struktura drzewa MIME. To drzewo MIME zawiera t
 
 Aby móc osadzić AMP w wiadomości e-mail, należy dodać nową część MIME z typem zawartości `text/x-amp-html` jako elementem potomnym wezła `multipart/alternative`. Powinna ona znajdować się obok istniejących części `text/html` lub `text/plain`. To zapewni działanie wiadomości e-mail na wszystkich klientach.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="Diagram części AMP dla poczty e-mail MIME" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="Diagram części AMP dla poczty e-mail MIME" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 Więcej informacji o podtypie `multipart/alternative` zawiera [dokument RFC 1521, sekcja 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3).
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@ru.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@ru.md
@@ -35,7 +35,7 @@ limitations under the License.
 
 Чтобы встроить AMP-контент в электронное письмо, добавьте новый MIME-блок с типом контента `text/x-amp-html` в качестве потомка `multipart/alternative`. Он должен находиться рядом с существующими блоками `text/html` или `text/plain`. Это действие позволит обеспечить отображение письма на всех клиентах.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP for Email MIME Parts Diagram" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="AMP for Email MIME Parts Diagram" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 Дополнительную информацию о подтипе `multipart/alternative` см. в [RFC 1521, раздел 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3).
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@tr.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@tr.md
@@ -35,7 +35,7 @@ E-posta bir MIME ağacı olarak yapılandırılmıştır. Bu MIME ağacı, mesaj
 
 AMP'yi bir e-postaya yerleştirmek için, `multipart/alternative` alt öğesi olarak `text/x-amp-html` içerik türüne sahip yeni bir MIME bölümü ekleyin. Mevcut `text/html` veya `text/plain` bölümlerin yanında yaşamalıdır. Bu, e-posta mesajının tüm istemcilerde çalışmasını sağlar.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="E-posta için AMP MIME Parça Şeması" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="E-posta için AMP MIME Parça Şeması" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 `multipart/alternative` alt türü hakkında daha fazla bilgi için bkz: [RFC 1521, bölüm 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3).
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@vi.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure@vi.md
@@ -35,7 +35,7 @@ Email được cấu trúc là một cây MIME. Cây MIME chứa nội dung emai
 
 Để nhúng AMP trong một email, bạn chỉ cần bổ sung một phần MIME mới với loại nội dung là `text/x-amp-html` làm con cháu của `multipart/alternative`. Nó phải cùng tồn tại với các phần `text/html` hoặc `text/plain` hiện có. Điều này đảm bảo nội dung email sẽ hoạt động trên tất cả các máy khách.
 
-<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="Sơ đồ bộ phận AMP cho Email MIME" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
+<amp-img alt="AMP for Email MIME Parts Diagram" layout="responsive" width="752" height="246" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/amp-email-mime-parts.png"><noscript data-md-type="raw_html" data-segment-id="12596198"><img data-md-type="raw_html" alt="Sơ đồ bộ phận AMP cho Email MIME" src="../img/amp-email-mime-parts.png"></noscript></amp-img>
 
 Để biết thêm thông tin về loại con `multipart/alternative`, hãy tham khảo [RFC 1521, phần 7.2.3](https://tools.ietf.org/html/rfc1521#section-7.2.3).
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state.md
@@ -137,9 +137,9 @@ In this scenario, the user receives a consistent shopping cart experience even t
 
 **To enable this and any experience involving user state, all contexts the user traverses must share their individually-maintained state with each other.** "Perfect!", you say, with the idea to share the cookie values with user identifiers across these contextual boundaries. One wrinkle: even though each of these contexts displays content controlled by the same publisher, they each see the other as a third-party because each context lives on different domains.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
   <noscript>
-    <img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" />
+    <img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" />
   </noscript>
 </amp-img>
 
@@ -163,9 +163,9 @@ After laying the foundation, we then visit a topic with a narrower range of use 
 
 In walking through the technical guidance below, let's assume that you’ll be binding **user state** to a stable **identifier** that represents the user. For example, the identifier might look like `n34ic982n2386n30`. On the server side you then associate `n34ic982n2386n30` to any set of user state information, such as shopping cart content, a list of previously read articles, or other data depending on the use case.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
   <noscript>
-    <img alt="A single identifier could be used to manage user state for many use cases" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" />
+    <img alt="A single identifier could be used to manage user state for many use cases" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" />
   </noscript>
 </amp-img>
 
@@ -396,9 +396,9 @@ In general, when reading and writing third-party cookies is disallowed, there wi
 
 In this task, we’ll cover an additional optimization that helps when the user is navigating across contexts from one page to another page either **via linking or form submissions**. In these situations, and with the implementation work described below, it is possible to set up a fully effective scheme for managing user state across contexts.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
   <noscript>
-    <img alt="Links can be used to pass the identifier information of one context into another (linked) context" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" />
+    <img alt="Links can be used to pass the identifier information of one context into another (linked) context" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" />
   </noscript>
 </amp-img>
 
@@ -452,9 +452,9 @@ By taking these steps, the Client ID is available to the target server and/or as
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
   <noscript>
-    <img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" />
+    <img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" />
   </noscript>
 </amp-img>
 
@@ -479,9 +479,9 @@ To process during redirect, handle the request on the server and extract the rel
 
 To process on the landing page, the approach will vary depending on whether that page is an AMP page or a non-AMP page.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
   <noscript>
-    <img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" />
+    <img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" />
   </noscript>
 </amp-img>
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@ar.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@ar.md
@@ -120,8 +120,8 @@ limitations under the License.
 
 **لتمكين هذا وأي تجربة تتعلق بحالة المستخدم، يجب على جميع السياقات التي يمر بها المستخدم مشاركة كل حالة تم الحصول عليه بشكل فردي مع بعضها البعض.** "مثالية!"، كما تقول، عن فكرة مشاركة قيم ملفات تعريف الارتباط مع معرفات المستخدم عبر هذه الحدود التي تصنعها السياقات. ولكن توجد مشكلة صغيرة واحدة: على الرغم من أن كل سياق من هذه السياقات يعرض محتوى يتحكم فيه الناشر بنفسه، فإن كل منهما يرى الآخر كطرف ثالث لأن كل سياق يتمركز في نطاقات مختلفة.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="تعني إمكانية عرض AMP في العديد من السياقات أن لكل من هذه السياقات مساحة تخزين خاصة به للمعرفات" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="تعني إمكانية عرض AMP في العديد من السياقات أن لكل من هذه السياقات مساحة تخزين خاصة به للمعرفات" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 كما سترى في المناقشة التالية، فإن كونك في موقع الطرف الثالث عند التفاعل مع ملفات تعريف الارتباط قد يمثل تحديات، اعتمادًا على كيفية تكوين إعدادات متصفح المستخدم. على وجه الخصوص، إذا تم حظر ملفات تعريف ارتباط الطرف الثالث في موقف معين، فسيؤدي ذلك إلى منع إمكانية مشاركة المعلومات عبر السياقات. من ناحية أخرى، إذا تم السماح بعمليات ملفات تعريف الارتباط للجهات الثالثة، فيمكن عندئذٍ مشاركة المعلومات.
 
@@ -142,8 +142,8 @@ limitations under the License.
 
 في مقدمة جولة الدليل الفني أدناه، لنفترض أنك ستربط **حالة المستخدم** **بمعرّف** ثابت يمثل المستخدم. على سبيل المثال، قد يبدو المعرّف في هذا الشكل `n34ic982n2386n30`. من طرف الخادم، تقوم بعد ذلك بربط `n34ic982n2386n30` بأي مجموعة من معلومات حالة المستخدم، مثل محتوى عربة التسوق، أو قائمة المقالات التي تمت قراءتها مسبقًا، أو البيانات الأخرى بناءً على حالة الاستخدام.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="يمكن استخدام معرّف واحد لإدارة حالة المستخدم للعديد من حالات الاستخدام" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="يمكن استخدام معرّف واحد لإدارة حالة المستخدم للعديد من حالات الاستخدام" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 من أجل الوضوح في باقي هذا المستند، سنقوم باستدعاء سلاسل مختلفة من الأحرف والتي تكون معرّفات بأسماء أكثر قابلية للقراءة مسبوقة بعلامة الدولار (`$`):
 
@@ -379,8 +379,8 @@ https://analytics.example.com/ping?type=pageview&user_id=$amp_client_id
 
 في هذه المهمة، سنغطي تحسينًا إضافيًا يساعد عندما يتنقل المستخدم عبر السياقات من صفحة إلى صفحة أخرى إما **عن طريق الارتباط أو عمليات إرسال النموذج**. في هذه المواقف، ومع أعمال التنفيذ الموضحة أدناه، من الممكن إعداد مخطط فعال بالكامل لإدارة حالة المستخدم عبر السياقات.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="يمكن استخدام الروابط لتمرير معلومات المعرف الخاصة بسياق ما إلى سياق آخر (مرتبط)" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="يمكن استخدام الروابط لتمرير معلومات المعرف الخاصة بسياق ما إلى سياق آخر (مرتبط)" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### استخدام ميزات بديلة <a name="using-substitution-features"></a>
 
@@ -435,8 +435,8 @@ data-amp-replace="CLIENT_ID"
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="مثال على كيفية تمرير معرّف في سياق عارض AMP عبر رابط إلى سياق أصل الناشر" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="مثال على كيفية تمرير معرّف في سياق عارض AMP عبر رابط إلى سياق أصل الناشر" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 عندما يصل المستخدم إلى صفحة تحتوي على قيمة `ref_id` إما كمعلمة عنوان URL أو في رأس الصفحة، تتاح لنا الفرصة لمعالجة المعرّف `ref_id` جنبًا إلى جنب مع معرّف يتم عرضه عبر الصفحة نفسها (أي قيمة ملف تعريف الارتباط). من خلال تضمين كلاهما في رسائل فحص التحليلات، يمكن لخادم التحليلات الخاص بك العمل مع كلتا القيمتين في وقت واحد، ومع العلم أنهما مرتبطان، يعكسلن هذه العلاقة في الواجهة الخلفية الخاصة بك. تُقدم الخطوة التالية تفاصيل حول كيفية القيام بذلك.
 
@@ -459,8 +459,8 @@ https://example.com/step2.html?ref_id=$amp_client_id
 
 للمعالجة على صفحة الوصول، سيختلف الأسلوب اعتمادًا على ما إذا كانت هذه الصفحة داعمة لـ AMP أو غير ذلك.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="مثال على كيفية إنشاء تحليل ping يحتوي على معرف من السياق السابق المقدم عبر عنوان URL ومعرف من السياق الحالي" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="مثال على كيفية إنشاء تحليل ping يحتوي على معرف من السياق السابق المقدم عبر عنوان URL ومعرف من السياق الحالي" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 _تحديثات صفحة AMP:_ استخدم ميزة استبدال "معلمة الاستفسار" في تهيئة amp-analytics للحصول على قيمة المعرف `ref_id` داخل عنوان URL. تأخذ ميزة "معلمة الاستفسار" معلمة تشير إلى "مفتاح" زوج القيمة الرئيسية المطلوب في عنوان URL وتعيد القيمة المقابلة. استخدم ميزة معرّف العميل كما فعلنا للحصول على المعرّف لسياق صفحة AMP.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@de.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@de.md
@@ -120,8 +120,8 @@ In diesem Szenario hat die Benutzerin ein einheitliches Erlebnis mit dem Warenko
 
 **Um dieses Erlebnis sowie alle anderen Erfahrungen mit Fokus auf Benutzerstatus zu ermöglichen, müssen alle Kontexte, die Benutzer durchlaufen, ihren individuell verwalteten Status miteinander teilen.** "Perfekt!", denkst du vielleicht und möchtest die Werte der Cookies mit Benutzer IDs über die Kontextgrenzen hinweg teilen. Ein kleines Problem: Obwohl in jedem dieser Kontexte Content angezeigt wird, der von ein und demselben Publisher kontrolliert wird, sehen die Kontexte einander als Drittanbieter, da sie sich in unterschiedlichen Domänen befinden.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="Die Fähigkeit von AMP, in vielen Kontexten angezeigt zu werden, bedeutet, dass jeder dieser Kontexte über einen eigenen Speicher für Bezeichner verfügt" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="Die Fähigkeit von AMP, in vielen Kontexten angezeigt zu werden, bedeutet, dass jeder dieser Kontexte über einen eigenen Speicher für Bezeichner verfügt" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 Wie du nachfolgend sehen wirst, kann es je nach Konfiguration der Browsereinstellungen des Benutzers eine Herausforderung darstellen, sich bei der Interaktion mit Cookies in der Position eines Drittanbieters zu befinden. Insbesondere gilt: Wenn Cookies von Drittanbietern in einer bestimmten Situation blockiert werden, können Informationen nicht kontextübergreifend ausgetauscht werden. Wenn Vorgänge mit Cookies von Drittanbietern zulässig sind, können Informationen gemeinsam genutzt werden.
 
@@ -142,8 +142,8 @@ Nach diesen Grundlagen sehen wir uns ein Thema mit einer engeren Auswahl an Use 
 
 In der folgenden technischen Anleitung gehen wir davon aus, dass du den **Benutzerstatus** an einen stabilen **Identifikator** bindest, der den Benutzer repräsentiert. Der Identifikator könnte zum Beispiel so aussehen: `n34ic982n2386n30`. Auf der Serverseite verknüpfst du den Identifikator `n34ic982n2386n30` dann mit einer beliebigen Auswahl von Informationen zum Benutzerstatus, z. B. dem Inhalt des Warenkorbs, einer Liste von bereits gelesenen Artikeln oder anderen Daten – je nach Use Case.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="Eine einzelne Kennung kann verwendet werden, um den Benutzerstatus für viele Anwendungsfälle zu verwalten" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="Eine einzelne Kennung kann verwendet werden, um den Benutzerstatus für viele Anwendungsfälle zu verwalten" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 Aus Gründen der Übersichtlichkeit werden wir im Weiteren die Zeichenfolgen, die als Identifikatoren fungieren, mit lesbaren Namen ersetzen, denen ein Dollarzeichen (`$`) vorangestellt ist:
 
@@ -374,8 +374,8 @@ Wenn das Lesen und Schreiben von Cookies von Drittanbietern nicht zulässig ist,
 
 Bei dieser Aufgabe besprechen wir eine zusätzliche Optimierung, die hilfreich ist, wenn Benutzer von einer Seite zur anderen **via Verlinkung oder Formularübermittlung** navigieren – und sich damit zwischen mehreren Kontexten bewegen. In solchen Situationen ist es mithilfe der nachfolgend beschriebenen Implementierungsschritte möglich, ein rundum wirksames Schema für die kontextübergreifende Verwaltung des Benutzerstatus einzurichten.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="Links können verwendet werden, um die Bezeichnungsinformationen eines Kontexts in einen anderen (verknüpften) Kontext zu übertragen" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="Links können verwendet werden, um die Bezeichnungsinformationen eines Kontexts in einen anderen (verknüpften) Kontext zu übertragen" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### Verwenden von Substitutionsfunktionen <a name="using-substitution-features"></a>
 
@@ -430,8 +430,8 @@ Diese Schritte sorgen dafür, dass die Client ID auf dem Zielserver und/oder als
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="Beispiel dafür, wie eine Kennung in einem AMP-Viewer-Kontext über einen Link in einen Publisher-Ursprungskontext übergeben werden kann" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="Beispiel dafür, wie eine Kennung in einem AMP-Viewer-Kontext über einen Link in einen Publisher-Ursprungskontext übergeben werden kann" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 Wenn Benutzer auf einer Seite landen, die den Wert `ref_id` entweder als URL Parameter oder im Header enthält, können wir den Identifikator `ref_id` zusammen mit dem Identifikator verarbeiten, den die Seite selbst zur Verfügung stellt (also einem Cookie Wert). Wenn du beide Identifikatoren in einen Analytics Ping aufnimmst, kann dein Analytics Server beide Werte gleichzeitig verarbeiten. Da dem Server bekannt ist, dass die Werte in Beziehung zueinander stehen, kann er diese Beziehung in deinem Backend widerspiegeln. Im nächsten Schritt findest du eine ausführliche Beschreibung dieser Vorgehensweise.
 
@@ -454,8 +454,8 @@ Bei einer Verarbeitung während der Weiterleitung musst du die Anfrage auf dem S
 
 Bei der Verarbeitung auf der Landing Page muss unterschieden werden, ob es sich dabei um eine AMP Seite oder um eine Seite ohne AMP handelt.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="Beispiel für die Erstellung eines Analyse-Pings, der einen Bezeichner aus dem vorherigen Kontext enthält, der über eine URL bereitgestellt wird, und einen Bezeichner aus dem aktuellen Kontext" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="Beispiel für die Erstellung eines Analyse-Pings, der einen Bezeichner aus dem vorherigen Kontext enthält, der über eine URL bereitgestellt wird, und einen Bezeichner aus dem aktuellen Kontext" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 _Aktualisierung einer AMP Seite:_ Verwende die Substitutionsfunktion "Query Parameter" in deiner amp-analytics Konfiguration, um den Identifikatorwert `ref_id` innerhalb der URL auszulesen. Die Funktion "Query Parameter" akzeptiert einen Parameter, der als "Schlüssel" für das gewünschte Schlüssel-Wert-Paar in der URL fungiert, und gibt den entsprechenden Wert zurück. Verwende die Client ID Funktion wie bisher, um den Identifikator für den Kontext der AMP Seite zu erhalten.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@es.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@es.md
@@ -120,8 +120,8 @@ En este escenario, el usuario recibe una experiencia uniforme en el carrito de c
 
 **Para habilitar esta y cualquier experiencia que involucre el estado de usuario, en todos los contextos por los que pase el usuario debe compartir su estado de administración que esté separado de otros.** “¡Perfecto!”, se menciona con la idea de compartir los valores de las cookies con identificadores de usuario mediante límites en los contextos. Indicación: aunque cada uno de estos contextos muestre contenido controlado por el mismo editor, cada uno ve al otro como un tercero porque cada contexto reside en dominios diferentes.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="La capacidad de AMP para mostrarse en muchos contextos significa que cada uno de esos contextos tiene su propio almacenamiento para identificadores" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="La capacidad de AMP para mostrarse en muchos contextos significa que cada uno de esos contextos tiene su propio almacenamiento para identificadores" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 Como podrá ver en la siguiente discusión, estar en la posición de un tercero cuando se interactúa con las cookies puede presentar desafíos, dependiendo de cómo se ajuste la configuración en el navegador del usuario. En particular, si las cookies de terceros se bloquean en una situación particular, entonces impedirá que la información se comparta entre los contextos. Por otro lado, si se permiten las operaciones de cookies de terceros, la información se puede compartir.
 
@@ -142,8 +142,8 @@ Después de sentar las bases, consultamos un tema con una variedad más limitada
 
 Al recorrer la guía técnica que se presenta a continuación, supongamos que vinculará el **estado de usuario** con un **identificador** estable que representa al usuario. Por ejemplo, el identificador podría verse como `n34ic982n2386n30`. Después asocie `n34ic982n2386n30` a cualquier conjunto de información que se encuentra en el estado del usuario, en el lado del servidor, ya sea el contenido del carrito de compras, una lista de artículos leídos anteriormente u otros datos, según el caso de uso.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="Se podría usar un único identificador para administrar el estado del usuario para muchos casos de uso" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="Se podría usar un único identificador para administrar el estado del usuario para muchos casos de uso" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 Para obtener mayor claridad en el resto de este documento, nombraremos varias cadenas de caracteres con un signo de dólar (`$`) previo ya que son identificadores con nombres más legibles:
 
@@ -379,8 +379,8 @@ En general, cuando no se permite la lectura y escritura de cookies de terceros, 
 
 En esta tarea, se abarcará una optimización adicional que ayuda cuando el usuario navega a través de los contextos de una página a otra, ya sea **mediante enlaces o envíos de formularios**. En estas situaciones, y con el trabajo de implementación que se describe a continuación, es posible establecer un esquema totalmente efectivo para administrar el estado del usuario en todos los contextos.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="Los enlaces se pueden utilizar para pasar la información del identificador de un contexto a otro contexto (vinculado)" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="Los enlaces se pueden utilizar para pasar la información del identificador de un contexto a otro contexto (vinculado)" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### Cómo utilizar las características de sustitución <a name="using-substitution-features"></a>
 
@@ -435,8 +435,8 @@ Al seguir estos pasos, el ID de cliente estará disponible para el servidor de d
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="Ejemplo de cómo un identificador en un contexto de visor de AMP se puede pasar a través de un enlace a un contexto de origen de editor" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="Ejemplo de cómo un identificador en un contexto de visor de AMP se puede pasar a través de un enlace a un contexto de origen de editor" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 Cuando el usuario llega a una página que contiene un valor `ref_id` ya sea un parámetro URL o en el encabezado, tenemos la oportunidad de coprocesar el identificador `ref_id` junto con el identificador que se muestre a través de la propia página (es decir, el valor de una cookie). Al incluir ambos en un ping analítico, su servidor de análisis puede trabajar con ambos valores de forma simultánea y, si sabe que están relacionados, reflejar esta relación en su backend. En el siguiente paso se proporcionan los detalles sobre cómo llevar a cabo esto.
 
@@ -459,8 +459,8 @@ Para procesar durante la redirección, maneje la solicitud en el servidor y extr
 
 Para procesar la página de destino, el enfoque variará dependiendo de si es una página AMP o una página sin AMP.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="Ejemplo de cómo construir un ping analítico que contiene un identificador del contexto anterior proporcionado a través de una URL y un identificador del contexto actual" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="Ejemplo de cómo construir un ping analítico que contiene un identificador del contexto anterior proporcionado a través de una URL y un identificador del contexto actual" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 _Actualizaciones de la página AMP:_ Utilice la característica de sustitución de parámetros de consulta en su configuración amp-analytics para obtener el valor de identificación `ref_id` dentro de la URL. La característica parámetros de consulta toma un parámetro que indica la “clave” del par clave-valor deseado en la URL y devuelve el valor correspondiente. Utilice la característica del ID de cliente como lo hicimos para obtener el identificador en el contexto de la página AMP.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@fr.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@fr.md
@@ -120,8 +120,8 @@ Dans ce scénario, l'utilisatrice reçoit une expérience de panier d'achat coh�
 
 **Pour activer cela ainsi que toute expérience impliquant l'état de l'utilisateur, tous les contextes traversés par l'utilisateur doivent partager leur état géré individuellement les uns avec les autres.** « Parfait! », Dites-vous, face à l'idée de partager les valeurs des cookies avec les identifiants des utilisateurs à travers ces frontières contextuelles. Un problème cependant: même si chacun de ces contextes affiche du contenu contrôlé par le même éditeur, chacun voit l'autre comme un tiers car chaque contexte vit sur des domaines différents.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="La capacité d'AMP à être affichée dans de nombreux contextes signifie que chacun de ces contextes a son propre stockage pour les identifiants" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="La capacité d'AMP à être affichée dans de nombreux contextes signifie que chacun de ces contextes a son propre stockage pour les identifiants" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 Comme vous le verrez dans la section suivante, être dans une position tierce lors de l'interaction avec les cookies peut présenter des défis, selon la façon dont les paramètres du navigateur de l'utilisateur sont configurés. En particulier, si les cookies tiers sont bloqués dans une situation particulière, cela empêchera le partage des informations entre les contextes. D'autre part, si les opérations de cookies tiers sont autorisées, les informations peuvent être partagées.
 
@@ -142,8 +142,8 @@ Après avoir posé les bases, nous visitons ensuite un sujet avec une série plu
 
 En parcourant le guide technique ci-dessous, supposons que vous liez **l'état de l'utilisateur** à un **identificateur** stable qui représente l'utilisateur. Par exemple, l'identificateur pourrait ressembler à `n34ic982n2386n30`. Côté serveur, vous associez alors `n34ic982n2386n30` à tout ensemble d'informations sur l'état de l'utilisateur, comme le contenu du panier, une liste d'articles précédemment lus ou d'autres données selon le cas d'utilisation.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="Un identifiant unique pourrait être utilisé pour gérer l'état de l'utilisateur dans de nombreux cas d'utilisation" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="Un identifiant unique pourrait être utilisé pour gérer l'état de l'utilisateur dans de nombreux cas d'utilisation" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 Pour plus de clarté dans le reste de ce document, nous appellerons diverses chaînes de caractères qui sont des identifiants par des noms plus lisibles précédés d'un signe dollar (`$`):
 
@@ -380,8 +380,8 @@ En général, lorsque la lecture et l'écriture de cookies tiers sont interdites
 
 Dans cette tâche, nous aborderons une optimisation supplémentaire qui est utile lorsque l'utilisateur navigue dans différents contextes d'une page à une autre, soit **via des liens ou des soumissions de formulaires**. Dans ces situations, et avec le travail d'implémentation décrit ci-dessous, il est possible de mettre en place un système totalement efficace pour gérer l'état des utilisateurs dans tous les contextes.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="Les liens peuvent être utilisés pour transmettre les informations d'identification d'un contexte dans un autre contexte (lié)" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="Les liens peuvent être utilisés pour transmettre les informations d'identification d'un contexte dans un autre contexte (lié)" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### Utilisation des fonctionnalités de substitution <a name="using-substitution-features"></a>
 
@@ -436,8 +436,8 @@ En suivant ces étapes, l'ID client est disponible sur le serveur cible et/ou en
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="Exemple de transmission d'un identifiant dans un contexte de visionneuse AMP via un lien dans un contexte d'origine d'éditeur" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="Exemple de transmission d'un identifiant dans un contexte de visionneuse AMP via un lien dans un contexte d'origine d'éditeur" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 Lorsque l'utilisateur atterrit sur une page contenant une valeur `ref_id` soit comme paramètre d'URL soit dans l'en-tête, nous avons la possibilité de co-traiter l'identifiant `ref_id` avec l'identifiant exposé via la page elle-même (c-à-d une valeur de cookie). En incluant les deux dans un ping d'analyse, votre serveur d'analyse peut travailler simultanément avec les deux valeurs, et sachant qu'elles sont liées, ressortir cette relation dans votre back-end. Les étapes à suivre montrent comment y parvenir.
 
@@ -460,8 +460,8 @@ Pour traiter les informations lors de la redirection, gérez la demande sur le s
 
 Pour traiter les informations sur la page de destination, l'approche variera selon que cette page est une page AMP ou une page non AMP.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="Exemple de construction d'un ping analytique contenant un identifiant du contexte précédent fourni via l'URL et un identifiant du contexte actuel" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="Exemple de construction d'un ping analytique contenant un identifiant du contexte précédent fourni via l'URL et un identifiant du contexte actuel" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 _Mises à jour de la page AMP:_ utilisez la fonctionnalité de substitution de paramètre de requête dans votre configuration amp-analytics pour obtenir la valeur de l'identifiant `ref_id` dans l'URL. La fonction de paramètre de requête prend un paramètre qui indique la « clé » de la paire clé-valeur souhaitée dans l'URL et renvoie la valeur correspondante. Utilisez la fonction d'ID client comme nous l'avons fait pour obtenir l'identifiant du contexte de la page AMP.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@id.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@id.md
@@ -120,8 +120,8 @@ Di dalam skenario ini, pengguna menerima pengalaman keranjang belanja yang konsi
 
 **Untuk memungkinkan ini dan pengalaman apa pun yang melibatkan status pengguna, semua konteks yang dilalui pengguna harus saling berbagi status yang disimpan secara individual.** “Sempurna!”, kata Anda, tentang ide berbagi nilai cookie dengan pengenal pengguna di semua batasan kontekstual ini. Ada satu masalah: walaupun setiap konteks ini menampilkan konten yang dikontrol oleh penayang yang sama, mereka saling melihat sebagai pihak ketiga karena setiap konteks berada di domain yang berbeda.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="Kemampuan AMP untuk ditampilkan dalam banyak konteks berarti bahwa setiap konteks tersebut memiliki penyimpanannya sendiri untuk pengenal" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="Kemampuan AMP untuk ditampilkan dalam banyak konteks berarti bahwa setiap konteks tersebut memiliki penyimpanannya sendiri untuk pengenal" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 Sebagaimana Anda lihat di dalam pembahasan berikut ini, mempunyai posisi pihak ketiga saat berinteraksi dengan cookie dapat menimbulkan kesulitan, tergantung bagaimana pengaturan browser pengguna dikonfigurasi. Secara khusus, jika cookie pihak ketiga diblokir di dalam suatu situasi tertentu, maka ini akan menghalangi kemampuan berbagi informasi di semua konteks. Pada sisi lain, jika operasi cookie pihak ketiga diizinkan, maka informasi dapat dibagikan.
 
@@ -142,8 +142,8 @@ Setelah memaparkan dasarnya, kita akan membahas topik dengan kisaran yang lebih 
 
 Dalam menelusuri panduan teknis di bawah ini, kita akan menganggap bahwa Anda akan mengikatkan **status pengguna** ke sebuah **pengenal** stabil yang mewakili pengguna. Contohnya: pengenal mungkin terlihat seperti `n34ic982n2386n30`. Di bagian server, Anda kemudian mengaitkan `n34ic982n2386n30` ke seperangkat informasi status pengguna apa pun, seperti isi keranjang belanja, daftar artikel yang telah dibaca sebelumnya, atau data lain sesuai dengan contoh penggunaan.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="Pengenal tunggal dapat digunakan untuk mengelola status pengguna untuk banyak kasus penggunaan" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="Pengenal tunggal dapat digunakan untuk mengelola status pengguna untuk banyak kasus penggunaan" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 Demi kejelasan di seluruh bagian dokumen berikutnya, kita akan menyebut berbagai untai karakter yang merupakan pengenal dengan nama yang lebih mudah dibaca dan diawali dengan tanda dolar (`$`):
 
@@ -378,8 +378,8 @@ Secara umum, jika membaca dan menulis cookie pihak ketiga tidak diizinkan, akan 
 
 Di dalam tugas ini, kita akan membahas pengoptimalan tambahan yang akan membantu saat pengguna bergerak menelusuri konteks dari satu halaman ke halaman lainnya, baik **melalui penautan maupun pengiriman formulir**. Di dalam situasi ini, dan dengan kerja penerapan yang dijelaskan di bawah ini, kita dapat menyiapkan rencana yang sepenuhnya efektif untuk mengelola status pengguna di semua konteks.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="Tautan dapat digunakan untuk meneruskan informasi pengenal dari satu konteks ke konteks lain (terkait)" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="Tautan dapat digunakan untuk meneruskan informasi pengenal dari satu konteks ke konteks lain (terkait)" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### Menggunakan fitur-fitur penggantian <a name="using-substitution-features"></a>
 
@@ -434,8 +434,8 @@ Dengan mengambil langkah-langkah ini, ID Klien tersedia untuk server target dan/
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="Contoh bagaimana pengenal dalam konteks AMP viewer dapat diteruskan melalui link ke konteks asal penerbit" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="Contoh bagaimana pengenal dalam konteks AMP viewer dapat diteruskan melalui link ke konteks asal penerbit" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 Jika pengguna tiba di halaman yang berisi nilai `ref_id`, baik sebagai parameter URL atau pada tajuk, kita berpeluang untuk memproses pengenal `ref_id` bersama pengenal yang diungkap melalui halaman itu sendiri (yaitu sebuah nilai cookie). Dengan menyertakan keduanya di dalam ping analitis, server analitis Anda dapat bekerja dengan kedua nilai ini secara serentak, dan, karena mengetahui bahwa keduanya terkait, merefleksikan hubungan ini di backend Anda. Langkah selanjutnya memberikan uraian tentang cara melakukan hal ini.
 
@@ -458,8 +458,8 @@ Untuk memproses selama pengalihan, tangani permintaan di server dan ekstrak para
 
 Untuk memproses pada halaman landing atau halaman tujuan, pendekatan akan berbeda-beda tergantung apakah halaman tersebut sebuah halaman AMP atau halaman non-AMP.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="Contoh cara membuat ping analitik yang berisi pengenal dari konteks sebelumnya yang disediakan melalui URL dan pengenal dari konteks saat ini" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="Contoh cara membuat ping analitik yang berisi pengenal dari konteks sebelumnya yang disediakan melalui URL dan pengenal dari konteks saat ini" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 _Pembaruan pada halaman AMP:_ Gunakan fitur penggantian Parameter Kueri di konfigurasi amp-analytics Anda untuk memperoleh nilai pengenal `ref_id` di dalam URL tersebut. Fitur Parameter Kueri mengambil sebuah parameter yang mengindikasikan “kunci” pasangan kunci-nilai yang diinginkan di dalam URL dan menghasilkan nilai yang sesuai. Gunakan fitur ID Klien seperti yang telah kita kerjakan untuk mendapatkan pengenal untuk konteks halaman AMP.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@it.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@it.md
@@ -120,8 +120,8 @@ In questo scenario, l'utente può usufruire di un servizio carrello degli acquis
 
 **Per realizzare esperienze di questo tipo che coinvolgono la gestione dello stato utente, tutti i contesti che l'utente attraversa devono condividere un unico stato gestito individualmente.** Benissimo! Basta condividere tra questi contesti i valori dei cookie con gli identificatori utente. Ma c'è un problema: anche se ognuno di questi contesti mostra contenuti controllati dallo stesso editore, ognuno di essi vede gli altri come contesti esterno, perché ognuno di essi risiede su domini diversi.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="La capacità di AMP di essere visualizzato in molti contesti significa che ognuno di questi contesti ha il proprio spazio di archiviazione per gli identificatori" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="La capacità di AMP di essere visualizzato in molti contesti significa che ognuno di questi contesti ha il proprio spazio di archiviazione per gli identificatori" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 Come vedremo nel seguito, gestire un'applicazione di terzi quando si interagisce con i cookie può presentare difficoltà, a seconda di come sono configurate le impostazioni del browser dell'utente. In particolare, se i cookie di terzi sono bloccati in una situazione particolare, questo impedirà la condivisione delle informazioni tra i contesti. D'altra parte, se le operazioni dei cookie di terzi sono consentite, le informazioni possono essere condivise.
 
@@ -142,8 +142,8 @@ Dopo aver gettato le basi, ci occupiamo di una gamma più ristretta di casi d'us
 
 Nell'applicazione della procedura tecnica descritta di seguito, assumiamo di associare lo **stato utente** a un **identificatore** stabile che rappresenta l'utente. Ad esempio, un identificatore potrebbe avere questo aspetto: `n34ic982n2386n30`. Sul lato server quindi si associa l'identificatore `n34ic982n2386n30` a un dato insieme di informazioni utente, quali contenuto del carrello della spesa, elenco di articoli precedentemente letti, o altri dati in base al caso d'uso.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="È possibile utilizzare un unico identificatore per gestire lo stato utente per molti casi d'uso" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="È possibile utilizzare un unico identificatore per gestire lo stato utente per molti casi d'uso" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 Per maggiore chiarezza, nel resto di questo documento chiameremo le varie stringhe di caratteri che fungono da identificatori con nomi più leggibili preceduti dal simbolo del dollaro (`$`):
 
@@ -380,8 +380,8 @@ In generale, quando la lettura e la scrittura di cookie di terzi non è consenti
 
 In questa attività, implementiamo un'ottimizzazione aggiuntiva che serve quando l'utente naviga da una pagina all'altra attraverso più contesti **tramite collegamenti o invii di moduli**. In queste situazioni, e con l'implementazione descritta di seguito, è possibile impostare uno schema completamente efficace per la gestione dello stato utente multi-contesto.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="I collegamenti possono essere utilizzati per passare le informazioni sull'identificatore di un contesto in un altro contesto (collegato)" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="I collegamenti possono essere utilizzati per passare le informazioni sull'identificatore di un contesto in un altro contesto (collegato)" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### Utilizzo delle funzioni di sostituzione <a name="using-substitution-features"></a>
 
@@ -436,8 +436,8 @@ Implementando questa procedura, l'ID client è disponibile per il server di dest
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="Esempio di come un identificatore nel contesto di un visualizzatore AMP può essere passato tramite link a un contesto di origine del publisher" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="Esempio di come un identificatore nel contesto di un visualizzatore AMP può essere passato tramite link a un contesto di origine del publisher" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 Quando l'utente arriva su una pagina contenente un valore `ref_id` come parametro URL o nell'intestazione, abbiamo l'opportunità di gestire l'identificatore `ref_id` insieme all'identificatore esposto dalla pagina stessa (cioè un valore del cookie). Includendo entrambi in un ping di analisi, il server di analisi può funzionare con entrambi i valori contemporaneamente e, sapendo che sono correlati, trasmettere questa relazione al sistema backend. Il passaggio successivo fornisce i dettagli su come eseguire questa operazione.
 
@@ -460,8 +460,8 @@ Per effettuare l'elaborazione durante il reindirizzamento, occorre gestire la ri
 
 Per effettuare l'elaborazione sulla pagina di destinazione, l'approccio varierà a seconda che la pagina sia una pagina AMP o meno.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="Esempio di come costruire un ping di analisi che contiene un identificatore dal contesto precedente fornito tramite URL e un identificatore dal contesto corrente" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="Esempio di come costruire un ping di analisi che contiene un identificatore dal contesto precedente fornito tramite URL e un identificatore dal contesto corrente" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 _Aggiornamenti alla pagina AMP:_ utilizzare la funzione di sostituzione dei parametri di query nella configurazione di amp-analytics per ottenere il valore dell'identificatore `ref_id` all'interno dell'URL. La funzione Query Parameter accetta un parametro che indica la "chiave" della coppia chiave-valore richiesta nell'URL e restituisce il valore corrispondente. Utilizzare la funzione ID client come abbiamo fatto per ottenere l'identificatore per il contesto della pagina AMP.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@ja.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@ja.md
@@ -120,8 +120,8 @@ AMP キャッシュの場合と同様、AMP ビューアのドメインは、サ
 
 **ユーザー状態を伴うエクスペリエンスを有効化するには、ユーザーが移動するすべてのコンテキスト間で、個別に管理された状態が共有されている必要があります。**これらのコンテキストの境界をまたいで cookie の値をユーザー ID と共有する、という考えに「なるほど！」と納得するかもしれませんが、アドバイスが 1 つあります。これらのコンテキストはそれぞれ、同一のサイト運営者が制御するコンテンツを表示してはいますが、コンテキストは別々のドメインに存在するため、互いをサードパーティとみなします。
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="多くのコンテキストで表示されるAMPの機能は、それらのコンテキストのそれぞれが識別子用の独自のストレージを持っていることを意味します" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="多くのコンテキストで表示されるAMPの機能は、それらのコンテキストのそれぞれが識別子用の独自のストレージを持っていることを意味します" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 次の議論からわかるように、cookie を操作する際にサードパーティであれば、ユーザーのブラウザ設定がどのように構成されているかによって、問題となることがあります。特に、特定の状況でサードパーティ cookie がブロックされている場合、コンテキスト間での情報共有が行えなくなります。一方、サードパーティ cookie の操作が許可されている場合は、情報を共有することができます。
 
@@ -142,8 +142,8 @@ AMP キャッシュの場合と同様、AMP ビューアのドメインは、サ
 
 以下の技術ガイダンスを説明するにあたり、**ユーザー状態**をユーザーを表す安定した **ID** にバインドすることを前提とします。ID を `n34ic982n2386n30` とした場合、サーバー側で `n34ic982n2386n30` を、買い物かごの内容、以前に読んだ記事のリスト、または使用事例に応じたその他のデータなどのユーザー状態情報に関連付けます。
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="単一の識別子を使用して、多くのユースケースのユーザー状態を管理できます" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="単一の識別子を使用して、多くのユースケースのユーザー状態を管理できます" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 このドキュメントの残りでは、わかりやすいように、ID を示す文字列をドル記号（`$`）の後に読みやすい名前をつなげた形式で示します。次にその例を示します。
 
@@ -380,8 +380,8 @@ AMP クライアント ID がマッピングに見つからない場合は、マ
 
 このタスクでは、ユーザーが**リンクまたはフォーム送信によって**あるページから別のページにコンテキストをまたがって移動する場合に役立つ追加の最適化方法を説明します。このような状況において、以下に説明する実装を行うと、コンテキスト間でユーザー状態を管理するための完全に有効なスキームをセットアップすることができます。
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="リンクを使用して、あるコンテキストの識別子情報を別の（リンクされた）コンテキストに渡すことができます" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="リンクを使用して、あるコンテキストの識別子情報を別の（リンクされた）コンテキストに渡すことができます" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### 置換機能を使用する <a name="using-substitution-features"></a>
 
@@ -434,8 +434,8 @@ data-amp-replace="CLIENT_ID"
 
 [sourcecode:http] https://example.com/step2.html?ref_id=$amp_client_id [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="AMPビューアコンテキストの識別子をリンク経由でパブリッシャーオリジンコンテキストに渡す方法の例" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="AMPビューアコンテキストの識別子をリンク経由でパブリッシャーオリジンコンテキストに渡す方法の例" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 ユーザーが、URL パラメータとしてまたはヘッダー内に `ref_id` 値を含むページにアクセスすると、ページ自体が公開する ID（cookie 値）とともに `ref_id` ID を同時処理することができます。両方をアナリティクス ping に含めることで、アナリティクスサーバーは両方の値を同時に操作し、それらが関連していることを理解した上で、バックエンドにこの関係を反映させます。次の手順では、このやり方を説明します。
 
@@ -458,8 +458,8 @@ data-amp-replace="CLIENT_ID"
 
 ランディングページで処理するには、そのページが AMP ページであるか非 AMP ページであるかによって、アプローチが異なります。
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="URLを介して提供された以前のコンテキストからの識別子と現在のコンテキストからの識別子を含む分析pingを構築する方法の例" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="URLを介して提供された以前のコンテキストからの識別子と現在のコンテキストからの識別子を含む分析pingを構築する方法の例" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 これらの手順を行うと、リンククリックやフォーム送信後にユーザーがたどり着くページ（<strong>リンク先コンテキスト</strong>）のターゲットサーバーや URL パラメータとして、クライアント ID が利用できるようになります。上記の実装で定義したように、名前（または「キー」）は `ref_id` で、クライアント ID と同じ関連付けられた値が指定されます。たとえば、上記で定義したリンク（<code><a></code> タグ）をたどると、ユーザーは次の URL に移動します。
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@ko.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@ko.md
@@ -120,8 +120,8 @@ AMP 캐시 사례와 마찬가지로 AMP 뷰어의 도메인도 퍼블리셔 출
 
 **이 기능 및 사용자 상태가 포함된 모든 경험을 구현하려면 사용자가 이동하는 모든 컨텍스트는 개별적으로 관리되는 상태를 서로 공유해야 합니다.** 컨텍스트의 경계를 가로질러 사용자 식별자가 포함된 쿠키 값을 공유한다는 아이디어가 “완벽!”하다고 생각하시겠죠. 다만, 한 가지 작은 문제가 있습니다. 바로 이러한 각각의 컨텍스트는 동일한 퍼블리셔에서 제어되는 ​​콘텐츠를 표시하지만, 각 컨텍스트의 도메인이 다르기 때문에 서로를 타사로 간주한다는 점입니다.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="AMP가 여러 컨텍스트에 표시되는 기능은 각 컨텍스트에 식별자를위한 자체 저장소가 있음을 의미합니다." src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="AMP가 여러 컨텍스트에 표시되는 기능은 각 컨텍스트에 식별자를위한 자체 저장소가 있음을 의미합니다." src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 다음 논의에서 확인하실 수 있는 것처럼 쿠키와 상호작용 시 타사 위치에 있을 경우 사용자의 브라우저 설정 구성 방식에 따라 문제가 발생할 수 있습니다. 특히 타사 쿠키가 특정 상황에서 차단된 경우 컨텍스트 사이에서 정보 공유 기능도 차단됩니다. 반면 타사 쿠키 작동이 허용된 경우 정보가 공유될 수 있습니다.
 
@@ -142,8 +142,8 @@ AMP 캐시 사례와 마찬가지로 AMP 뷰어의 도메인도 퍼블리셔 출
 
 아래의 기술 지침을 한 단계씩 따라가는 과정에서 **사용자 상태**를 사용자를 대표하는 안정적 **식별자**에 바인딩한다고 가정하겠습니다. 예를 들어 식별자는 `n34ic982n2386n30`처럼 표시될 것입니다. 다음으로 서버 측에서 장바구니 콘텐츠, 이전에 읽은 기사 목록 또는 사용 사례별 기타 데이터와 같은 사용자 상태 정보의 집합에 `n34ic982n2386n30`를 연결합니다.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="단일 식별자를 사용하여 많은 사용 사례에서 사용자 상태를 관리 할 수 있습니다." src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="단일 식별자를 사용하여 많은 사용 사례에서 사용자 상태를 관리 할 수 있습니다." src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 이 문서의 나머지 부분에서 명확한 표현을 위해 달러(`$`) 기호를 앞에 붙여 가독성을 높인 식별자인 다양한 문자열을 호출합니다.
 
@@ -380,8 +380,8 @@ AMP 클라이언트 ID `$amp_client_id`에 해당하는 강조 표시된 부분�
 
 이 태스크에서는 사용자가 **연결 또는 양식 제출을 통해** 한 페이지에서 다른 페이지로 이동하는 경우 유용한 최적화를 추가적으로 다룰 예정입니다. 이 사례에 아래 설명된 구현 작업이 추가되면 컨텍스트 간 사용자 상태를 관리하는 완벽하게 효율적인 방식을 설정할 수 있습니다.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="링크를 사용하여 한 컨텍스트의 식별자 정보를 다른 (연결된) 컨텍스트로 전달할 수 있습니다." src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="링크를 사용하여 한 컨텍스트의 식별자 정보를 다른 (연결된) 컨텍스트로 전달할 수 있습니다." src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### 대체 기능 사용 <a name="using-substitution-features"></a>
 
@@ -436,8 +436,8 @@ data-amp-replace="CLIENT_ID"
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="AMP 뷰어 컨텍스트의 식별자가 링크를 통해 게시자 원본 컨텍스트로 전달되는 방법의 예" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="AMP 뷰어 컨텍스트의 식별자가 링크를 통해 게시자 원본 컨텍스트로 전달되는 방법의 예" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 사용자가 URL 매개변수로 또는 헤더 내에 `ref_id` 값이 포함된 페이지를 방문할 경우 `ref_id` 식별자를 페이지에서 자체적으로 노출된 식별자(쿠키 값)와 함께 처리할 수 있습니다. 분석 핑에 식별자 두 개를 모두 포함하면 분석 서버는 동시에 두 값을 처리할 수 있으며 두 값이 연결되어 있음을 이해하여 백엔드에 해당 관계를 반영합니다. 다음 단계에서는 자세한 실행 방법을 살펴보겠습니다.
 
@@ -460,8 +460,8 @@ URL을 통해 정보가 제공되며 해당 정보를 처리하고자 할 경우
 
 랜딩 페이지에서 처리할 경우 페이지가 AMP 페이지인지 비 AMP 페이지인지에 따라 접근 방식이 다릅니다.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="URL을 통해 제공된 이전 컨텍스트의 식별자와 현재 컨텍스트의 식별자를 포함하는 분석 핑을 구성하는 방법의 예" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="URL을 통해 제공된 이전 컨텍스트의 식별자와 현재 컨텍스트의 식별자를 포함하는 분석 핑을 구성하는 방법의 예" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 분석 요청이 퍼블리셔 출처의 페이지에서 발생한 경우 <code>uid</code>에 해당하는 값을 분석 기록 식별자로 선택해야 합니다. `orig_uid` 값은 “별칭”으로 선택합니다.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@pl.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@pl.md
@@ -120,8 +120,8 @@ W tym scenariuszu użytkownik otrzymuje spójną obsługę koszyka, mimo że prz
 
 **Aby umożliwić tę i każdą inną obsługę zależną od stanu użytkownika, wszystkie konteksty, przez które przechodzą użytkownicy, muszą udostępniać sobie nawzajem swój indywidualnie utrzymywany stan.**. Powiesz „Doskonale!”, mając na myśli pomysł udostępniania wartości plików cookie z identyfikatorami użytkowników ponad tymi granicami kontekstowymi. Jest pewien drobiazg: mimo że każdy z tych kontekstów wyświetla treści kontrolowane przez tego samego wydawcę, każdy z nich postrzega drugi kontekst jako stronę trzecią, ponieważ każdy z kontekstów znajduje się w innej domenie.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="Łącza mogą służyć do przekazywania informacji identyfikujących jeden kontekst do innego (połączonego) kontekstu" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="Łącza mogą służyć do przekazywania informacji identyfikujących jeden kontekst do innego (połączonego) kontekstu" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 Jak zobaczysz w poniższym omówieniu, działanie z pozycji strony trzeciej podczas interakcji z plikami cookie może stanowić wyzwanie, w zależności od tego, jak skonfigurowane są ustawienia przeglądarki użytkownika. W szczególności, jeśli pliki cookie stron trzecich zostaną zablokowane w określonej sytuacji, uniemożliwi to udostępnianie informacji między różnymi kontekstami. Z drugiej strony, jeśli operacje z plikami cookie stron trzecich są dozwolone, informacje można udostępniać.
 
@@ -142,8 +142,8 @@ Po ułożeniu fundamentów odwiedzimy temat o węższym zakresie zastosowań, al
 
 Przechodząc przez poniższe wskazówki techniczne, załóżmy, że będziesz wiązać **stan użytkownika** ze stabilnym **identyfikatorem**, reprezentującym użytkownika. Identyfikator może wyglądać na przykład tak: `n34ic982n2386n30`. Po stronie serwera należy wówczas powiązać identyfikator `n34ic982n2386n30` z dowolnym zestawem informacji o stanie użytkownika, takim jak zawartość koszyka, lista wcześniej przeczytanych artykułów lub inne dane zależne od przypadku użycia.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="Przykład tego, jak identyfikator w kontekście przeglądarki AMP można przekazać za pośrednictwem linku do kontekstu źródła wydawcy" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="Przykład tego, jak identyfikator w kontekście przeglądarki AMP można przekazać za pośrednictwem linku do kontekstu źródła wydawcy" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 Dla przejrzystości w pozostałej części tego dokumentu będziemy nazywać różne ciągi znaków, będące identyfikatorami, stosując bardziej zrozumiałe nazwy poprzedzone znakiem dolara (`$`):
 
@@ -378,8 +378,8 @@ Gdy odczytywanie i zapisywanie plików cookie stron trzecich jest niedozwolone, 
 
 W tym zadaniu zajmiemy się dodatkową optymalizacją, która pozwala użytkownikowi przechodzić między kontekstami z jednej strony na drugą **za pomocą linków lub wysyłania formularzy**. W tych sytuacjach oraz dzięki opisanej poniżej implementacji możliwe jest utworzenie w pełni efektywnego schematu zarządzania stanem użytkownika w różnych kontekstach.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="Przykład tworzenia analitycznego polecenia ping, które zawiera identyfikator z poprzedniego kontekstu podany za pośrednictwem adresu URL i identyfikator z bieżącego kontekstu" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="Przykład tworzenia analitycznego polecenia ping, które zawiera identyfikator z poprzedniego kontekstu podany za pośrednictwem adresu URL i identyfikator z bieżącego kontekstu" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 ##### Stosowanie funkcji podstawiania <a name="using-substitution-features"></a>
 
@@ -434,8 +434,8 @@ Dzięki podjęciu tych kroków Client ID jest dostępny dla serwera docelowego i
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="Możliwość wyświetlania AMP w wielu kontekstach oznacza, że każdy z tych kontekstów ma własną pamięć na identyfikatory" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="Możliwość wyświetlania AMP w wielu kontekstach oznacza, że każdy z tych kontekstów ma własną pamięć na identyfikatory" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 Gdy użytkownik wyląduje na stronie zawierającej wartość `ref_id` w postaci parametru adresu URL lub w nagłówku, mamy możliwość wspólnego przetwarzania identyfikatora `ref_id` wraz z identyfikatorem wyeksponowanym za pomocą samej strony (czyli wartością pliku cookie). Dzięki zawarciu obu tych wartości w analitycznym pakiecie ping Twój serwer analityki może pracować z obiema wartościami jednocześnie, a wiedząc, że są one powiązane, odzwierciedlać tę zależność w Twoim zapleczu. W następnym kroku podano szczegóły wykonania.
 
@@ -458,8 +458,8 @@ Aby przetwarzać żądanie podczas przekierowania, należy obsłużyć je na ser
 
 W przypadku przetwarzania żądania na stronie docelowej podejście będzie się różnić w zależności od tego, czy strona ta jest stroną AMP, czy bez AMP.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="Pojedynczy identyfikator może służyć do zarządzania stanem użytkownika w wielu przypadkach użycia" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="Pojedynczy identyfikator może służyć do zarządzania stanem użytkownika w wielu przypadkach użycia" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 _Aktualizacje strony AMP:_ w konfiguracji składnika amp-analytics użyj funkcji podstawiania parametru zapytania, aby uzyskać wartość identyfikatora `ref_id` w adresie URL. Funkcja parametru zapytania pobiera parametr, który wskazuje „klucz” żądanej pary klucz-wartość w adresie URL i zwraca odpowiednią wartość. Użyj funkcji Client ID, tak jak to robiliśmy, aby uzyskać identyfikator do kontekstu strony AMP.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@ru.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@ru.md
@@ -120,8 +120,8 @@ AMP можно рассматривать как переносимый форм
 
 **Чтобы сделать возможным этот и любой другой сценарий, связанный с состоянием пользователя, все контексты, сквозь которые проходит пользователь, должны делиться своим индивидуально поддерживаемым состоянием друг с другом**. «Идеально!» — скажете вы. — «Нужно просто делиться значениями файлов cookie с идентификаторами пользователей, передавая их сквозь границы контекстов». Не все так просто: несмотря на то, что каждый из этих контекстов отображает контент, контролируемый одним и тем же издателем, каждый контекст рассматривает другой как сторонний объект, поскольку они находятся в разных доменах.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="Способность AMP отображаться во многих контекстах означает, что каждый из этих контекстов имеет собственное хранилище для идентификаторов." src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="Способность AMP отображаться во многих контекстах означает, что каждый из этих контекстов имеет собственное хранилище для идентификаторов." src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 Как вы увидите в дальнейшем обсуждении, пребывание в позиции третьей стороны при взаимодействии с файлами cookie может создавать проблемы в зависимости от того, какие настройки использует браузер пользователя. В частности, если в определенной ситуации сторонние файлы cookie окажутся заблокированы, это лишит нас возможности передавать информацию между контекстами. С другой стороны, если операции со сторонними файлами cookie разрешены, делиться информацией можно.
 
@@ -142,8 +142,8 @@ AMP можно рассматривать как переносимый форм
 
 При разборе технических инструкций, представленных ниже, мы исходим из того, что вы будете привязывать **состояние пользователя** к постоянному **идентификатору**, представляющему пользователя. Например, идентификатор может выглядеть как `n34ic982n2386n30`. Далее на стороне сервера вы ассоциируете `n34ic982n2386n30` с любым набором данных о состоянии пользователя (например, с данными о содержимом корзины пользователя, списке ранее прочитанных статей или другими данными, в зависимости от сценария).
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="Один идентификатор может использоваться для управления состоянием пользователя во многих случаях использования." src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="Один идентификатор может использоваться для управления состоянием пользователя во многих случаях использования." src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 Для простоты понимания в остальной части этого документа мы будем называть соответствующие идентификаторам строки символов более удобочитаемыми именами, начинающимися со знака доллара (`$`):
 
@@ -379,8 +379,8 @@ https://analytics.example.com/ping?type=pageview&user_id=$amp_client_id
 
 В этой задаче мы рассмотрим дополнительную оптимизацию, которая помогает, когда пользователь меняет контексты при перемещении с одной страницы на другую **с помощью ссылок или отправки форм**. В таких ситуациях с помощью описанных ниже действий можно создать полностью эффективную схему управления состоянием пользователя в разных контекстах.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="Ссылки могут использоваться для передачи информации идентификатора одного контекста в другой (связанный) контекст." src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="Ссылки могут использоваться для передачи информации идентификатора одного контекста в другой (связанный) контекст." src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### Использование функций подстановки <a name="using-substitution-features"></a>
 
@@ -435,8 +435,8 @@ data-amp-replace="CLIENT_ID"
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="Пример того, как идентификатор в контексте средства просмотра AMP может быть передан через ссылку в контекст источника издателя" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="Пример того, как идентификатор в контексте средства просмотра AMP может быть передан через ссылку в контекст источника издателя" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 Когда пользователь попадает на страницу, содержащую значение `ref_id` в заголовке или в виде параметра URL, у нас появляется возможность совместно обработать идентификатор `ref_id` с идентификатором, доступным из самой страницы (т. е. значением cookie). Если вы включите оба идентификатора в аналитический запрос, ваш сервер аналитики сможет работать с обоими значениями одновременно и, зная, что они связаны, зафиксировать эту взаимосвязь в вашем бэкенде. На следующем этапе подробно описывается, как это сделать.
 
@@ -459,8 +459,8 @@ https://example.com/step2.html?ref_id=$amp_client_id
 
 Какой метод обработки нужно использовать на целевой странице — зависит от того, является ли эта страница AMP-страницей или традиционной страницей.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="Пример создания аналитического пинга, который содержит идентификатор из предыдущего контекста, предоставленный через URL, и идентификатор из текущего контекста" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="Пример создания аналитического пинга, который содержит идентификатор из предыдущего контекста, предоставленный через URL, и идентификатор из текущего контекста" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 _Обновление AMP-страницы:_ используйте в своей конфигурации amp-analytics функцию подстановки параметров запроса (Query Parameter) для получения значения идентификатора `ref_id` из URL-адреса. Функция Query Parameter принимает параметр, обозначающий «ключ» нужной пары «ключ — значение» в URL и возвращает соответствующее значение. Чтобы получить идентификатор контекста AMP-страницы, используйте функцию Client ID, как мы делали это раньше.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@tr.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@tr.md
@@ -120,8 +120,8 @@ Bu senaryoda, kullanıcı, AMP görüntüleyici bağlamından yayıncı kaynak b
 
 **Bunu ve kullanıcı durumunu içeren herhangi bir deneyimi etkinleştirmek için, kullanıcının geçtiği tüm bağlamların ayrı ayrı tutulan durumlarını birbirleriyle paylaşması gerekir.** Çerez değerlerini bu bağlamsal sınırlar boyunca kullanıcı tanımlayıcılarla paylaşma fikrini düşünüp "Mükemmel!" diyeceksinizdir. Ama bir pürüz var: Bu bağlamların her biri aynı yayıncının kontrolündeki içeriği görüntülese de, her biri diğerini üçüncü taraf olarak görüyor çünkü her bağlam farklı etki alanında barındırılıyor.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="AMP'nin birçok bağlamda görüntülenebilme yeteneği, bu bağlamların her birinin tanımlayıcılar için kendi depolamasına sahip olduğu anlamına gelir" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="AMP'nin birçok bağlamda görüntülenebilme yeteneği, bu bağlamların her birinin tanımlayıcılar için kendi depolamasına sahip olduğu anlamına gelir" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 Aşağıdaki tartışmada göreceğiniz gibi, çerezlerle etkileşim kurarken üçüncü taraf konumunda olmak, kullanıcının tarayıcı ayarlarının nasıl yapılandırıldığına bağlı olarak zorluklara neden olabilir. Özellikle, üçüncü taraf çerezleri belirli bir durumda engellenirse, bilgiler bağlamlar arasında paylaşılamayacaktır. Öte yandan, üçüncü taraf çerez işlemlerine izin verilirse, bilgiler paylaşılabilecektir.
 
@@ -142,8 +142,8 @@ Temeli oluşturduktan sonra, daha dar bir kullanım alanı yelpazesine sahip anc
 
 Aşağıdaki teknik kılavuzu incelerken, **kullanıcı durumunu**, kullanıcıyı temsil eden kararlı bir **tanımlayıcıya** bağlayacağınızı varsayalım. Örneğin, tanımlayıcı `n34ic982n2386n30` şeklinde görünebilir. Ardından, sunucu tarafında, `n34ic982n2386n30` tanımlayıcısını alışveriş sepeti içeriği, önceden okunan makalelerin listesi veya kullanım durumuna bağlı olarak diğer veriler gibi herhangi bir kullanıcı durumu bilgisi kümesiyle ilişkilendirirsiniz.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="Birçok kullanım durumunda kullanıcı durumunu yönetmek için tek bir tanımlayıcı kullanılabilir" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="Birçok kullanım durumunda kullanıcı durumunu yönetmek için tek bir tanımlayıcı kullanılabilir" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 Bu belgenin geri kalanında netlik sağlamak için, önünde dolar işareti (`$`) bulunan, daha okunabilir adlara sahip tanımlayıcılardan oluşan çeşitli karakter dizilerini çağıracağız:
 
@@ -381,8 +381,8 @@ Genel olarak, üçüncü taraf çerezlerinin okunmasına ve yazılmasına izin v
 
 Bu görevde, kullanıcı **bağlantı veya form gönderimleri yoluyla** bir sayfadan diğerine bağlamlar arasında gezinirken yardımcı olan ek bir optimizasyonu ele alacağız. Bu durumlarda ve aşağıda açıklanan uygulama çalışmasıyla, bağlamlar arasında kullanıcı durumunu yönetmek için tamamen etkili bir şema kurmak mümkündür.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="Bağlantılar, bir bağlamın tanımlayıcı bilgilerini başka bir (bağlantılı) bağlama geçirmek için kullanılabilir." src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="Bağlantılar, bir bağlamın tanımlayıcı bilgilerini başka bir (bağlantılı) bağlama geçirmek için kullanılabilir." src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### Değiştirme özelliklerini kullanma <a name="using-substitution-features"></a>
 
@@ -437,8 +437,8 @@ Bu adımları uygulayarak, İstemci Kimliği, hedef sunucu tarafından kullanıl
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="AMP görüntüleyici bağlamındaki bir tanımlayıcının bağlantı yoluyla bir yayıncı kaynak bağlamına nasıl geçirilebileceğine ilişkin örnek" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="AMP görüntüleyici bağlamındaki bir tanımlayıcının bağlantı yoluyla bir yayıncı kaynak bağlamına nasıl geçirilebileceğine ilişkin örnek" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 Kullanıcı, URL parametresi olarak veya başlık içinde bir `ref_id` değeri bulunan bir sayfaya geldiğinde, `ref_id` tanımlayıcısını sayfa aracılığıyla gösterilen tanımlayıcı (yani bir çerez değeri) ile birlikte işleme şansımız olur. Analiz sunucunuz her ikisini de bir analiz ping'ine dahil ederek her iki değerle aynı anda çalışabilir ve birbirleriyle ilişkili olduklarını bilerek bu ilişkiyi arka ucunuza yansıtabilir. Bir sonraki adım, bunun nasıl yapılacağına dair ayrıntıları sunuyor.
 
@@ -461,8 +461,8 @@ Yeniden yönlendirme sırasında işlemek için, sunucudaki isteği gerçekleşt
 
 Açılış sayfasında işlemek için yaklaşım, söz konusu sayfanın bir AMP sayfası veya AMP olmayan bir sayfa olmasına bağlı olarak değişecektir.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="URL aracılığıyla sağlanan önceki bağlamdan bir tanımlayıcı ve geçerli bağlamdan bir tanımlayıcı içeren bir analiz pinginin nasıl oluşturulacağına ilişkin örnek" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="URL aracılığıyla sağlanan önceki bağlamdan bir tanımlayıcı ve geçerli bağlamdan bir tanımlayıcı içeren bir analiz pinginin nasıl oluşturulacağına ilişkin örnek" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 _AMP sayfasında yapılan güncellemeler:_ URL içindeki `ref_id` tanımlayıcı değerini almak için amp-analytics yapılandırmanızdaki Sorgu Parametresi değiştirme özelliğini kullanın. Sorgu Parametresi özelliği, URL'de istenen anahtar/değer çiftinin "anahtarını" belirten bir parametre alır ve karşılık gelen değeri yanıt olarak döndürür. AMP sayfa bağlamı tanımlayıcısını almak için yaptığımız gibi İstemci Kimliği özelliğini kullanın.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@vi.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state@vi.md
@@ -120,8 +120,8 @@ Trong tình huống này, người dùng nhận được một trải nghiệm g
 
 **Để cho phép trải nghiệm này và mọi trải nghiệm liên quan đến trạng thái người dùng, mọi ngữ cảnh sử dụng của người dùng đều phải có chung trạng thái (được duy trì riêng biệt với nhau).** “Thật hoàn hảo!”, bạn thốt lên, với ý tưởng là chia sẻ giá trị cookie với các mã định danh người dùng trên các ranh giới ngữ cảnh này. Một vấn đề: tuy mỗi ngữ cảnh này đều hiển thị nội dung được kiểm soát bởi cùng một nhà phát hành, chúng sẽ đều coi nhau như bên thứ ba bởi mỗi ngữ cảnh đều sống trên các tên miền khác nhau.
 
-<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png" width="1030" height="868">
-  <noscript><img alt="Khả năng hiển thị của AMP trong nhiều ngữ cảnh có nghĩa là mỗi ngữ cảnh đó đều có bộ nhớ riêng cho số nhận dạng" src="https://github.com/ampproject/amphtml/raw/main/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
+<amp-img alt="AMP's ability to be displayed in many contexts means that each of those contexts has its own storage for identifiers" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png" width="1030" height="868">
+  <noscript><img alt="Khả năng hiển thị của AMP trong nhiều ngữ cảnh có nghĩa là mỗi ngữ cảnh đó đều có bộ nhớ riêng cho số nhận dạng" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/contexts-with-different-storage.png"></noscript></amp-img>
 
 Như bạn có thể thấy trong cuộc thảo luận sau, việc ở vị thế của một bên thứ ba khi tương tác với cookie có thể mang đến nhiều thách thức tùy thuộc vào cách cấu hình cài đặt trình duyệt của người dùng. Cụ thể, nếu các cookie của bên thứ ba bị chặn trong một tình huống cụ thể, nó sẽ ngăn thông tin được chia sẻ trên nhiều ngữ cảnh. Mặt khác, nếu cookie của bên thứ ba được phép hoạt động, thông tin sẽ có thể được chia sẻ.
 
@@ -142,8 +142,8 @@ Sau khi thiết lập nền tảng, chúng ta sẽ xem xét một chủ đề v�
 
 Khi thực hiện các hướng dẫn kỹ thuật dưới đây, hãy giả sử rằng bạn sẽ ràng buộc **trạng thái người dùng** với một **mã định danh** ổn định đại diện cho người dùng. Ví dụ, mã định danh có thể có dạng `n34ic982n2386n30`. Ở phía máy chủ, bạn sẽ liên kết `n34ic982n2386n30` với mọi nhóm thông tin trạng thái người dùng, ví dụ như nội dung giỏ hàng, một danh sách các bài viết đã đọc trước đó, hoặc các dữ liệu khác tùy thuộc vào trường hợp sử dụng.
 
-<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
-  <noscript><img alt="Một số nhận dạng duy nhất có thể được sử dụng để quản lý trạng thái người dùng cho nhiều trường hợp sử dụng" src="https://github.com/ampproject/amphtml/raw/main/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
+<amp-img alt="A single identifier could be used to manage user state for many use cases" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png" width="1276" height="376">
+  <noscript><img alt="Một số nhận dạng duy nhất có thể được sử dụng để quản lý trạng thái người dùng cho nhiều trường hợp sử dụng" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/identifiers-for-use-cases.png"></noscript></amp-img>
 
 Để đảm bảo sự rõ ràng ở phần còn lại của tài liệu này, chúng ta sẽ gọi những chuỗi ký tự khác nhau, là các mã định danh, bằng các tên dễ đọc, đứng trước bởi một ký tự đô-la (`$`):
 
@@ -379,8 +379,8 @@ Nhìn chung, khi việc đọc và ghi các cookie của bên thứ ba bị cấ
 
 Trong tác vụ này, chúng ta sẽ bao gồm một biện pháp tối ưu bổ sung cho trường hợp người dùng điều hướng trên nhiều ngữ cảnh khác nhau, từ trang này đến trang kia **thông qua liên kết hoặc gửi đi biểu mẫu**. Trong các tình huống này, và với việc triển khai như được mô tả dưới đấy, bạn có thể thiết lập một kế hoạch hoàn toàn hiệu quả để quản lý trạng thái người dùng trên nhiều ngữ cảnh.
 
-<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
-  <noscript><img alt="Các liên kết có thể được sử dụng để chuyển thông tin nhận dạng của một ngữ cảnh này sang một ngữ cảnh (được liên kết) khác" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
+<amp-img alt="Links can be used to pass the identifier information of one context into another (linked) context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png" width="866" height="784">
+  <noscript><img alt="Các liên kết có thể được sử dụng để chuyển thông tin nhận dạng của một ngữ cảnh này sang một ngữ cảnh (được liên kết) khác" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-form-identifier-forwarding.png"></noscript></amp-img>
 
 ##### Sử dụng các tính năng thay thế <a name="using-substitution-features"></a>
 
@@ -435,8 +435,8 @@ Thông qua việc thực hiện các bước này, ID Máy khách có thể đư
 https://example.com/step2.html?ref_id=$amp_client_id
 [/sourcecode]
 
-<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
-  <noscript><img alt="Ví dụ về cách một số nhận dạng trong ngữ cảnh của trình xem AMP có thể được chuyển qua liên kết vào ngữ cảnh nguồn gốc của nhà xuất bản" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
+<amp-img alt="Example of how an identifier in an AMP viewer context can be passed via link into a publisher origin context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png" width="1038" height="890">
+  <noscript><img alt="Ví dụ về cách một số nhận dạng trong ngữ cảnh của trình xem AMP có thể được chuyển qua liên kết vào ngữ cảnh nguồn gốc của nhà xuất bản" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-1.png"></noscript></amp-img>
 
 Khi người dùng đến một trang chứa giá trị `ref_id` dưới dạng tham số URL hoặc trong đầu đề của nó, chúng ta sẽ có cơ hội xử lý đồng thời mã định danh `ref_id` và mã định danh được hiển thị thông qua chính trang đó (nghĩa là một giá trị cookie). Thông qua việc bao gồm một ping phân tích, máy chủ phân tích của bạn có thể làm việc với cả 2 giá trị cùng lúc, và, bởi chúng liên quan đến nhau, phản ánh mối quan hệ này trong backend của bạn. Bước tiếp theo cung cấp thông tin về cách để làm điều này.
 
@@ -459,8 +459,8 @@ Nếu thông tin này có sẵn trong URL và bạn muốn xử lý nó, có m�
 
 Để xử lý trên trang đích đến, lối tiếp cận này sẽ thay đổi tùy vào việc đó là một trang AMP hay không phải AMP.
 
-<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
-  <noscript><img alt="Ví dụ về cách tạo một ping phân tích có chứa một số nhận dạng từ ngữ cảnh trước đó được cung cấp qua URL và một số nhận dạng từ ngữ cảnh hiện tại" src="https://github.com/ampproject/amphtml/raw/main/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
+<amp-img alt="Example of how to construct an analytics ping that contains an identifier from the previous context provided via URL and an identifier from the current context" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png" width="1326" height="828">
+  <noscript><img alt="Ví dụ về cách tạo một ping phân tích có chứa một số nhận dạng từ ngữ cảnh trước đó được cung cấp qua URL và một số nhận dạng từ ngữ cảnh hiện tại" src="https://github.com/ampproject/amphtml/raw/main/docs/spec/img/link-identifier-forwarding-example-2.png"></noscript></amp-img>
 
 _Cập nhật cho trang AMP:_ Sử dụng tính năng thay thế Tham số Truy vấn trong cấu hình amp-analytics của bạn để thu giá trị mã định danh `ref_id` trong URL. Tính năng Tham số Truy vấn nhận một tham số chỉ báo “khóa” của cặp giá trị khóa mong muốn trong URL và trả về giá trị tương ứng. Sử dụng tính năng ID Máy khách như bình thường để nhận mã định danh cho ngữ cảnh trang AMP.
 


### PR DESCRIPTION
Docs & images in `amphtml` were moved to a new `docs/` folder (https://github.com/ampproject/amphtml/pull/34160). This updates the URLs pointing to the old `main/spec` to the new `main/docs/spec/` directory.