### PR TITLE
Update a couple of go links

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -30,9 +30,10 @@
 /email-support: /support/faq/email-support/
 /email-tools: /documentation/tools/?format=email
 /email-viewer: https://github.com/ampproject/amp-email-viewer
+/getting-started: https://github.com/ampproject/amphtml/blob/main/docs/getting-started-quick.md
 /github: https://github.com/ampproject/amphtml
 /governance: /community/governance/
-/i2i: https://github.com/ampproject/amphtml/issues/new?assignees=&labels=INTENT+TO+IMPLEMENT&template=intent-to-implement--i2i-.md&title=I2I:%20%3Cyour%20change/update%3E
+/i2i: https://github.com/ampproject/amphtml/issues/new?assignees=&labels=INTENT+TO+IMPLEMENT&template=intent-to-implement.yml
 /io-email: /documentation/examples/interactivity-dynamic-content/conference_survey_email/
 /learn: /documentation/courses/
 /learn-advanced: /documentation/guides-and-tutorials/start/add_advanced/


### PR DESCRIPTION
- The I2I link has changed due to the adoption of a new yaml template (https://github.com/ampproject/amphtml/pull/34431)
- The getting-started link will be used by our PR template (https://github.com/ampproject/amphtml/pull/34473)