### PR TITLE
👽 Use new preferred division notation

### DIFF
--- a/frontend21/scss/components/home/formats.scss
+++ b/frontend21/scss/components/home/formats.scss
@@ -5,7 +5,7 @@ $gap: 10px;
 .#{project('formats')} {
   --width: 100vw;
   --skew-angle: #{$skew-angle};
-  --skew-tan: #{math.tan($skew-angle) / 2};
+  --skew-tan: #{math.div(math.tan($skew-angle), 2)};
   --skew-padding: calc(var(--width) * var(--skew-tan));
 
   grid-column: 1/-1;
@@ -141,7 +141,8 @@ $gap: 10px;
       }
     }
 
-    &.websites, &.ads {
+    &.websites,
+    &.ads {
       color: color('white');
     }
 
@@ -154,11 +155,13 @@ $gap: 10px;
     @include respond-to('medium') {
       transform: skewY(0deg);
       @include shadow-large;
-      transition: box-shadow .3s ease-in-out, transform 0.3s ease-in-out;
+      transition: box-shadow 0.3s ease-in-out, transform 0.3s ease-in-out;
       flex: 1 0 calc(50% - (2 * #{$gap}));
       border-radius: 4px;
 
-      &:hover, &:focus, &:focus-within {
+      &:hover,
+      &:focus,
+      &:focus-within {
         transform: translateY(-0.125em);
         @include shadow-small;
       }
@@ -205,7 +208,8 @@ $gap: 10px;
     @include respond-to('medium') {
       display: initial;
 
-      .websites &, .ads & {
+      .websites &,
+      .ads & {
         fill: color('white');
       }
     }


### PR DESCRIPTION
In response of

```
(node:35283) [DEP_WEBPACK_COMPILATION_OPTIMIZE_CHUNK_ASSETS] DeprecationWarning: optimizeChunkAssets is deprecated (use Compilation.hooks.processAssets instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)
(Use `node --trace-deprecation ...` to show where the warning was created)
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(math.tan($skew-angle), 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
8 │   --skew-tan: #{math.tan($skew-angle) / 2};
  │                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    scss/components/home/formats.scss 8:17  @import
    scss/amp-dev.scss 43:9                  root stylesheet
```