### PR TITLE
🚑 Add file extension to component docs serving path

### DIFF
--- a/platform/lib/pipeline/componentReferenceImporter.js
+++ b/platform/lib/pipeline/componentReferenceImporter.js
@@ -74,7 +74,7 @@ class ComponentReferenceImporter {
           experimental: growDoc.experimental,
           path:
             growDoc.servingPath ||
-            `/documentation/components/${growDoc.title}-v${growDoc.version}/`,
+            `/documentation/components/${growDoc.title}-v${growDoc.version}.html`,
           version: growDoc.version,
         });
       }


### PR DESCRIPTION
Compare [L456](https://github.com/ampproject/amp.dev/runs/2713031896?check_suite_focus=true#step:10:456) to L457. This slipped #5870's review.

Without the `.html` in the serving path Grow creates files without an extension which don't get picked up by `gulp.src`.