### PR TITLE
🎨 Remove currently unused CSS from new frontend bundle

### DIFF
--- a/frontend21/scss/amp-dev.scss
+++ b/frontend21/scss/amp-dev.scss
@@ -7,9 +7,6 @@
 @import 'functions.scss';
 @import 'mixins.scss';
 
-@import 'components/sidebar.scss';
-@import 'components/sidebar-toggle.scss';
-@import 'components/toc.scss';
 @import 'components/section.scss';
 @import 'components/text-media.scss';
 @import 'components/text-block.scss';
@@ -17,25 +14,13 @@
 @import 'components/pie-chart.scss';
 @import 'components/highlight-stripes.scss';
 @import 'components/header.scss';
+
 @import 'components/format-toggle.scss';
 @import 'components/banner.scss';
 @import 'components/language-selector.scss';
 @import 'components/search-trigger.scss';
 @import 'components/nav-link.scss';
 @import 'components/icon.scss';
-@import 'components/content.scss';
-@import 'components/icon-text.scss';
-@import 'components/teaser-grid.scss';
-@import 'components/table-component.scss';
-@import 'components/component-intro.scss';
-@import 'components/code-snippet.scss';
-@import 'components/code-preview.scss';
-@import 'components/copy-script.scss';
-@import 'components/clip.scss';
-@import 'components/breadcrumbs.scss';
-@import 'components/tag.scss';
-@import 'components/filter-bubbles-list.scss';
-@import 'components/pill.scss';
 @import 'components/content/stage.scss';
 @import 'components/content/center-stage.scss';
 @import 'components/content/cards.scss';
@@ -51,7 +36,8 @@
 @import 'components/extra/documentation/text-aside.scss';
 @import 'components/content/link.scss';
 
-html, body {
+html,
+body {
   color: color('charade');
 }
 
@@ -131,7 +117,8 @@ a {
   font-size: 16px;
 }
 
-p, .#{project('p')} {
+p,
+.#{project('p')} {
   max-width: 920px;
   font-size: 16px;
   line-height: 1.625;

--- a/platform/lib/utils/cssTransformer.js
+++ b/platform/lib/utils/cssTransformer.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { nextNode, hasAttribute, firstChildByTag } =
+const {nextNode, hasAttribute, firstChildByTag} =
   require('@ampproject/toolbox-optimizer').NodeUtils;
 const rcs = require('rcs-core');
 
@@ -132,7 +132,7 @@ class CssTransformer {
 
     // Rewrite the selectors inside the CSS
     const css = style.children[0].data;
-    rcs.fillLibraries(css, { prefix: '-', ignoreCssVariables: true });
+    rcs.fillLibraries(css, {prefix: '-', ignoreCssVariables: true});
     const styles = rcs.replace.css(css);
     style.children[0].data = styles;
 

--- a/platform/lib/utils/cssTransformer.js
+++ b/platform/lib/utils/cssTransformer.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const {nextNode, hasAttribute, firstChildByTag} =
+const { nextNode, hasAttribute, firstChildByTag } =
   require('@ampproject/toolbox-optimizer').NodeUtils;
 const rcs = require('rcs-core');
 
@@ -90,6 +90,11 @@ const SAFE_CLASS_NAMES = [
   'ap-t-template',
   'ap-t-use-cases',
   'ap-t-what-is-amp',
+  'ap-header',
+  'ap-home-stage',
+  'ap-stage',
+  'ap-intro',
+  'ap-teaser',
 ];
 
 rcs.selectorsLibrary.setExclude(
@@ -127,7 +132,7 @@ class CssTransformer {
 
     // Rewrite the selectors inside the CSS
     const css = style.children[0].data;
-    rcs.fillLibraries(css, {prefix: '-', ignoreCssVariables: true});
+    rcs.fillLibraries(css, { prefix: '-', ignoreCssVariables: true });
     const styles = rcs.replace.css(css);
     style.children[0].data = styles;
 


### PR DESCRIPTION
This reduces CSS bundle size from ~78KB down to ~57KB for new Home, Get Started and About Websites.

A more sophisticated splitting approach would be nice though. The disabled components will only be needed for the refactored documentation detail page which is not used yet. 