### PR TITLE
🐛 Fix order of imports

### DIFF
--- a/frontend21/scss/amp-dev.scss
+++ b/frontend21/scss/amp-dev.scss
@@ -30,11 +30,11 @@
 @import 'components/content/teaser.scss';
 @import 'components/content/intro.scss';
 @import 'components/extra/about/components-showcase.scss';
-@import 'components/extra/home/newsletter.scss';
 @import 'components/content/circular-icon.scss';
 @import 'components/content/logo-stage.scss';
 @import 'components/extra/documentation/text-aside.scss';
 @import 'components/content/link.scss';
+@import 'components/extra/home/newsletter.scss';
 
 html,
 body {


### PR DESCRIPTION
Link styles overruled the special case for the newsletter due to the order in which they are imported.

Fixes #5998.