### PR TITLE
⏪  Add missing import

### DIFF
--- a/frontend21/scss/amp-dev.scss
+++ b/frontend21/scss/amp-dev.scss
@@ -30,6 +30,7 @@
 @import 'components/content/teaser.scss';
 @import 'components/content/intro.scss';
 @import 'components/extra/about/components-showcase.scss';
+@import 'components/code-snippet.scss';
 @import 'components/content/circular-icon.scss';
 @import 'components/content/logo-stage.scss';
 @import 'components/extra/documentation/text-aside.scss';


### PR DESCRIPTION
Fixes missing code examples on ```about/websites```.

Reverts this: https://github.com/ampproject/amp.dev/pull/5965/files#diff-b684e37d72ed1b64fc1c8cc9bf1a86366d64a0e05879877ff09cdc824f901c29L31