### PR TITLE
Update references to amphtml/builtins

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting.md
@@ -16,7 +16,7 @@ Guides and tutorials are submitted in [Markdown](https://www.markdownguide.org/)
 
 Content on amp.dev is pulled from two repositories, [amp.dev](https://github.com/ampproject/amp.dev) and [AMPHTML](https://github.com/ampproject/amphtml). All reference documentation under components is pulled from AMPHTML, either from builtins or extensions.
 
-*   [Built-in components ](https://github.com/ampproject/amphtml/tree/main/builtins)
+*   [Built-in components ](https://github.com/ampproject/amphtml/tree/main/src/builtins)
 *   [Components](https://github.com/ampproject/amphtml/tree/main/extensions)
 *   [Courses](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/courses)
 *   [Examples](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/examples)

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@ar.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@ar.md
@@ -16,7 +16,7 @@ author: CrystalOnScript
 
 يؤخذ المحتوى الموجود على amp.dev من مستودعين، [amp.dev](https://github.com/ampproject/amp.dev) و [AMPHTML](https://github.com/ampproject/amphtml). ويتم أخذ جميع المستندات المرجعية تحت المكونات من AMPHTML إما من الوحدات المدمجة أو من الملحقات.
 
-- [المكونات المدمجة ](https://github.com/ampproject/amphtml/tree/main/builtins)
+- [المكونات المدمجة ](https://github.com/ampproject/amphtml/tree/main/src/builtins)
 - [المكونات](https://github.com/ampproject/amphtml/tree/main/extensions)
 - [الدورات](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/courses)
 - [الأمثلة](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/examples)

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@es.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@es.md
@@ -16,7 +16,7 @@ Las guías y tutoriales se presentan en [Markdown](https://www.markdownguide.org
 
 El contenido de amp.dev se extrae de dos repositorios, [amp.dev](https://github.com/ampproject/amp.dev) y [AMPHTML](https://github.com/ampproject/amphtml). Toda la documentación de referencia sobre los componentes se extrae de AMPHTML, ya sea de los componentes integrados o de las extensiones.
 
-- [Componentes integrados ](https://github.com/ampproject/amphtml/tree/main/builtins)
+- [Componentes integrados ](https://github.com/ampproject/amphtml/tree/main/src/builtins)
 - [Componentes](https://github.com/ampproject/amphtml/tree/main/extensions)
 - [Cursos](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/courses)
 - [Ejemplos](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/examples)

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@it.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@it.md
@@ -16,7 +16,7 @@ Guide ed esercitazioni possono essere inviate sul sito [Markdown](https://www.ma
 
 I contenuti su amp.dev provengono da due archivi, [amp.dev](https://github.com/ampproject/amp.dev) e [AMPHTML](https://github.com/ampproject/amphtml). Tutta la documentazione di riferimento per i componenti proviene dagli elementi integrati o dalle estensioni di AMPHTML.
 
-- [Componenti integrati](https://github.com/ampproject/amphtml/tree/main/builtins)
+- [Componenti integrati](https://github.com/ampproject/amphtml/tree/main/src/builtins)
 - [Componenti](https://github.com/ampproject/amphtml/tree/main/extensions)
 - [Corsi](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/courses)
 - [Esempi](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/examples)

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@ja.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@ja.md
@@ -16,7 +16,7 @@ author: CrystalOnScript
 
 amp.dev のコンテンツは 、[amp.dev](https://github.com/ampproject/amp.dev) と [AMPHTML](https://github.com/ampproject/amphtml) の 2 つのレポジトリから pull されます。components の下のすべてのリファレンスドキュメントは、AMPHTML の builtins または extensions から pull されます。
 
-- [ビルトインコンポーネント ](https://github.com/ampproject/amphtml/tree/main/builtins)
+- [ビルトインコンポーネント ](https://github.com/ampproject/amphtml/tree/main/src/builtins)
 - [コンポーネント](https://github.com/ampproject/amphtml/tree/main/extensions)
 - [コース](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/courses)
 - [例](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/examples)

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@ko.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@ko.md
@@ -16,7 +16,7 @@ author: CrystalOnScript
 
 amp.dev 콘텐츠는 [amp.dev](https://github.com/ampproject/amp.dev) 및 [AMPHTML](https://github.com/ampproject/amphtml)의 저장소 두 곳에서 가져옵니다. 컴포넌트의 모든 참조 문서는 AMPHTML의 'builtins' 또는 'extensions'에 포함되어 있습니다.
 
-- [기본 제공 컴포넌트 ](https://github.com/ampproject/amphtml/tree/main/builtins)
+- [기본 제공 컴포넌트 ](https://github.com/ampproject/amphtml/tree/main/src/builtins)
 - [컴포넌트](https://github.com/ampproject/amphtml/tree/main/extensions)
 - [코스](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/courses)
 - [예제](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/examples)

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@pl.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@pl.md
@@ -9,7 +9,7 @@ Przewodniki i samouczki należy przesyłać w formacie [Markdown](https://www.ma
 
 Treść na amp.dev jest pobierana z dwóch repozytoriów, [amp.dev](https://github.com/ampproject/amp.dev) i [AMPHTML](https://github.com/ampproject/amphtml). Cała dokumentacja referencyjna pod składnikami jest pobierana z AMPHTML, albo z obiektów wbudowanych, albo z rozszerzeń.
 
-- [Wbudowane składniki ](https://github.com/ampproject/amphtml/tree/main/builtins)
+- [Wbudowane składniki ](https://github.com/ampproject/amphtml/tree/main/src/builtins)
 - [Składniki](https://github.com/ampproject/amphtml/tree/main/extensions)
 - [Kursy](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/courses)
 - [Przykłady](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/examples)

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@vi.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@vi.md
@@ -16,7 +16,7 @@ Các hướng dẫn và thực hành được gửi trong [Markdown](https://www
 
 Nội dung trên amp.dev được kéo từ hai kho lưu trữ, [amp.dev](https://github.com/ampproject/amp.dev) và [AMPHTML](https://github.com/ampproject/amphtml). Mọi tài liệu tham khảo trong các thành phần đều được kéo từ AMPHTML, từ các thành phần tích hợp hoặc mở rộng.
 
-- [Thành phần tích hợp ](https://github.com/ampproject/amphtml/tree/main/builtins)
+- [Thành phần tích hợp ](https://github.com/ampproject/amphtml/tree/main/src/builtins)
 - [Thành phần](https://github.com/ampproject/amphtml/tree/main/extensions)
 - [Khóa học](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/courses)
 - [Ví dụ](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/examples)

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@zh_CN.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/contribute-documentation/formatting@zh_CN.md
@@ -16,7 +16,7 @@ author: CrystalOnScript
 
 可从 [amp.dev](https://github.com/ampproject/amp.dev) 和 [AMPHTML](https://github.com/ampproject/amphtml) 这两个仓库中提取关于 amp.dev 的内容。组件下的所有参考文档均从 AMPHTML 的内置组件或扩展组件中提取。
 
-- [内置组件](https://github.com/ampproject/amphtml/tree/main/builtins)
+- [内置组件](https://github.com/ampproject/amphtml/tree/main/src/builtins)
 - [组件](https://github.com/ampproject/amphtml/tree/main/extensions)
 - [课程](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/courses)
 - [示例](https://github.com/ampproject/amp.dev/tree/future/pages/content/amp-dev/documentation/examples)

--- a/platform/lib/pipeline/componentReferenceDocument.test.js
+++ b/platform/lib/pipeline/componentReferenceDocument.test.js
@@ -14,7 +14,7 @@ test('Test first headline removal', (done) => {
       name: 'amp-test',
       version: '0.1',
       versions: ['0.1'],
-      githubPath: 'builtins/amp-test.md',
+      githubPath: 'src/builtins/amp-test.md',
     }
   );
 

--- a/platform/lib/pipeline/componentReferenceImporter.js
+++ b/platform/lib/pipeline/componentReferenceImporter.js
@@ -43,7 +43,7 @@ const DESTINATION_BASE_PATH =
 const FORMATS = ['AMP', 'AMP4ADS', 'AMP4EMAIL'];
 
 // ... this path
-const BUILT_IN_PATH = 'builtins';
+const BUILT_IN_PATH = 'src/builtins';
 const AMP_STORY_TAG = 'amp-story';
 const MARKDOWN_EXTENSION = '.md';
 


### PR DESCRIPTION
Companion PR to https://github.com/ampproject/amphtml/pull/35139, which move `builtins/` to `src/builtins/`.
This PR updates documentation links to the `builtins/` folder.

Context: https://github.com/ampproject/amphtml/issues/34866