### PR TITLE
Specify .amp-carousel-button so it does not pollute rendered sample

### DIFF
--- a/frontend/scss/base.scss
+++ b/frontend/scss/base.scss
@@ -26,8 +26,12 @@ html, body {
   }
 }
 
-/* Default amp-carousel button styley */
-.amp-carousel-button {
+/*
+ * Default amp-carousel button styles
+ * Elements under .ap-o-code-preview are rendered from example code, so we
+ * should not style them. This classname is set on documentation.j2.
+ */
+:not(.ap-o-code-preview) .amp-carousel-button {
   width: 3em;
   height: 3em;
   border-radius: 50%;


### PR DESCRIPTION
We're inadvertently modifying and breaking [rendered code samples.](https://amp.dev/documentation/examples/components/amp-lightbox-gallery/?format=websites)

![image (3)](https://user-images.githubusercontent.com/254946/126695433-94be1d4b-9c6e-4f8b-aa34-630ffb7e9c80.png)
