### PR TITLE
🐛 Make determination of commit SHA failable

### DIFF
--- a/platform/lib/utils/git.js
+++ b/platform/lib/utils/git.js
@@ -19,6 +19,8 @@ module.exports.version = () => {
   try {
     return execSync('git log -1 --pretty=format:%h ').toString().trim();
   } catch (e) {
+    // This method is called from gulpfile.js/deploy.js even if in a
+    // non-git context, like the development Docker image
     return 'detached';
   }
 };

--- a/platform/lib/utils/git.js
+++ b/platform/lib/utils/git.js
@@ -16,7 +16,11 @@
 const {execSync} = require('child_process');
 
 module.exports.version = () => {
-  return execSync('git log -1 --pretty=format:%h ').toString().trim();
+  try {
+    return execSync('git log -1 --pretty=format:%h ').toString().trim();
+  } catch (e) {
+    return 'detached';
+  }
 };
 
 module.exports.message = () => {


### PR DESCRIPTION
By the nature of our gulpfile the deployment tasks get required with every task run. The deployment tasks do some configuration on module level which also involves calling git commands. That failed.

Moving the configuration into a method would make the deploy task file less readable, hence I settled for the try/catch fallback.

Fixes #6067.