### PR TITLE
Specify namespace to avoid pollution, for real this time

### DIFF
--- a/frontend/scss/base.scss
+++ b/frontend/scss/base.scss
@@ -31,7 +31,7 @@ html, body {
  * Elements under .ap-o-code-preview are rendered from example code, so we
  * should not style them. This classname is set on documentation.j2.
  */
-:not(.ap-o-code-preview) .amp-carousel-button {
+body > * > :not(.ap-o-code-preview) > * > .amp-carousel-button {
   width: 3em;
   height: 3em;
   border-radius: 50%;


### PR DESCRIPTION
Fixes an issue where carousel button selectors for the host document pollutes rendered example snippets.

A followup to #6063, where I did not test that the exclusion selector actually worked. (I verified this time, apologies!)

This selector could be somewhat inefficient since it traverses up to `body`. Alternatively, we could scope it to the `amp-carousel` elements that we want by classname, but I'm not familiar with the parts of the `amp.dev` site that we would like to target.