### PR TITLE
🐛 Fix teaser carousel styles

### DIFF
--- a/frontend21/scss/components/content/teaser-carousel.scss
+++ b/frontend21/scss/components/content/teaser-carousel.scss
@@ -62,7 +62,7 @@
       grid-column-end: -1;
     }
 
-    .amp-carousel-button {
+    & > button.amp-carousel-button {
       width: var(--spacing);
       height: var(--spacing);
       background-size: 19px 19px;

--- a/pages/content/amp-dev/index-2021.html
+++ b/pages/content/amp-dev/index-2021.html
@@ -173,7 +173,7 @@ success_stories:
         [% set alt = post.title   %]
         [% set meta = post.date   %]
         [% set headline = post.headline %]
-        <a href="[= url =]" class="ap-teaser-news">
+        <a href="[= url =]" class="ap-teaser --news">
           <div class="ap-teaser-card">
             <div class="ap-teaser-card-header">
               [% if post.formats %]


### PR DESCRIPTION
- set missing class caused by d5745d2999c26499e4b1fb49ab67450c76e677b2
- overrides the styles for this specific section caused by #6087