### PR TITLE
Remove IE11 listed support

### DIFF
--- a/pages/content/amp-dev/support/faq/supported-browsers.md
+++ b/pages/content/amp-dev/support/faq/supported-browsers.md
@@ -31,4 +31,4 @@ In general we support the latest two versions of major browsers like Chrome, Fir
 
 Beyond that, the core AMP library and built-in elements should aim for very wide browser support and we accept fixes for all browsers with market share greater than 1 percent.
 
-In particular, we try to maintain "it might not be perfect but isn't broken"-support for IE 11, iOS 8, the Android 4.0 system browser and Chrome 41.
+In particular, we try to maintain "it might not be perfect but isn't broken"-support for iOS 8, the Android 4.0 system browser and Chrome 41.


### PR DESCRIPTION
As part of Internet Explorer deprecation (code merge happened last week).