### PR TITLE
update arcxp URL

### DIFF
--- a/pages/shared/data/cms.yaml
+++ b/pages/shared/data/cms.yaml
@@ -7,9 +7,9 @@ cmsUsers:
 
   - image:
       src: '/static/img/docs/guides/cms_logos/arcpublishing.jpg'
-      alt: Arc Publishing
-    label: Arc Publishing
-    url: https://www.arcpublishing.com/
+      alt: Arc XP
+    label: Arc XP
+    url: https://www.arcxp.com/
 
   - image:
       src: '/static/img/docs/guides/cms_logos/canvas.jpg'


### PR DESCRIPTION
arcpublishing.com is now arcxp.com