### PR TITLE
[Star Rating] Ensure inputs receive events

### DIFF
--- a/examples/source/interactivity-dynamic-content/Star_Rating/index.html
+++ b/examples/source/interactivity-dynamic-content/Star_Rating/index.html
@@ -57,6 +57,8 @@ author: sebastianbenz
       -webkit-tap-highlight-color: rgba(0,0,0,0);
       -webkit-tap-highlight-color: transparent;
       margin-bottom: 1em;
+      /* prevents fieldset from being wider than children to ensure inputs recieve events */
+      display: inline-block;
     }
     /* the stars */
     .rating > label {


### PR DESCRIPTION
This assists with UX of the component. 
Previously the fieldset could receive a touch event which would clear all stars, which looks like a bug.
Adding `display: inline-block;` to the fieldset will wrap it to the width of it's children, ensuring inputs are clicked.