### PR TITLE
Update language on courses and roadshow

### DIFF
--- a/pages/content/amp-dev/documentation/courses/teachers.md
+++ b/pages/content/amp-dev/documentation/courses/teachers.md
@@ -36,8 +36,5 @@ The course consists of a series of hands-on projects, most of which step you thr
 
 - The course uses the online editor Glitch. No IDE or local web server is required!
 
-### Certification
-If you are interested in our certification program, please <a href="mailto:morsssss@amp.dev">get in touch.</a>
-
 ### Talk to us
 Are you using these courses? Do you want to tell us about your experience? Or do you have ideas for how they can improved? Do you want to share your own version of the courses with the community? <a href="https://docs.google.com/forms/d/1H0qp9m5jq2ZaiaoU9zWu3Vd_WRGuluV7xPs14jxneSA/viewform" target="_blank">Give us feedback!</a>

--- a/pages/content/amp-dev/events/amp-roadshow.html
+++ b/pages/content/amp-dev/events/amp-roadshow.html
@@ -136,7 +136,7 @@ section_links:
         <div class="ap-a-ico ap-m-tip-icon">
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#warning"></use></svg>
         </div>
-        <p>{{ _('Due to concerns around coronavirus (COVID-19), and in accordance with health guidance from the <a href="https://www.cdc.gov/coronavirus/2019-ncov/index.html" target="_blank" rel="noopener noreferrer">CDC</a>, <a href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019" target="_blank" rel="noopener noreferrer">WHO</a>, and other health authorities, we have decided to postpone AMP roadshow events until further notice. We very much look forward to seeing you all as soon as we can!<br><br>Please see <a href="https://blog.amp.dev/2020/03/05/an-update-on-amp-conf/">here</a> for an update on AMP Conf 2020.') }} </p>
+        <p>{{ _('Due to concerns around COVID-19, and in accordance with health guidance from the <a href="https://www.cdc.gov/coronavirus/2019-ncov/index.html" target="_blank" rel="noopener noreferrer">CDC</a>, <a href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019" target="_blank" rel="noopener noreferrer">WHO</a>, and other health authorities, we are not holding in-person AMP events at present. This includes roadshows. Please check this page for updates.') }} </p>
       </div>
     </div>
     {% endif %}


### PR DESCRIPTION
Changing roadshows page to make it more clear that we're not doing roadshows right now.

And removing my email address and language about certification program from the courses area.