### PR TITLE
Fix typo in "Salesforce MArketing Cloud"

### DIFF
--- a/pages/shared/data/faq.yaml
+++ b/pages/shared/data/faq.yaml
@@ -859,7 +859,7 @@ email:
           url: https://www.moonmail.io
         - label: Pepipost
           url: https://pepipost.com/
-        - label: Salesforce MArketing Cloud
+        - label: Salesforce Marketing Cloud
           url: https://www.salesforce.com/products/marketing-cloud/overview/
         - label: SendPulse
           url: https://sendpulse.com/


### PR DESCRIPTION
Followup to https://github.com/ampproject/amp.dev/pull/6290