### PR TITLE
Update doc about one-time use access token

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email_fundamentals.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/email_fundamentals.md
@@ -181,11 +181,11 @@ The endpoint `https://example.com/personal-notes` is responsible for validating 
 
 Limited-Use Access Tokens provide protection from request spoofing and [replay attacks](https://en.wikipedia.org/wiki/Replay_attack), ensuring that the action is performed by the user the message was sent to. Protection is achieved by adding a unique token parameter to the request parameters and verifying it when the action is invoked.
 
-The token parameter should be generated as a key that can only be used for a specific action and a specific user. Before the requested action is performed, you should check that the token is valid and matches the one you generated for the user. If the token matches then the action can be performed and the token becomes invalid for future requests.
+The token parameter should be generated as a key that can only be used for a specific action and a specific user. Before the requested action is performed, you should check that the token is valid and matches the one you generated for the user. If the token matches then the action can be performed. If the action is supposed to be a one-time action, then the token should become invalid for future requests.
 
 Access tokens should be sent to the user as part of the url property of the HttpActionHandler. For instance, if your application handles approval requests at `http://www.example.com/approve?requestId=123`, you should consider including an additional `accessToken` parameter to it and listen to requests sent to `http://www.example.com/approve?requestId=123&accessToken=xyz`.
 
-The combination `requestId=123` and `accessToken=xyz` is the one that you have to generate in advance, making sure that the `accessToken` cannot be deduced from the `requestId`. Any approval request with `requestId=123` and no `accessToken` or with a `accessToken` not equal to `xyz` should be rejected. Once this request gets through, any future request with the same id and access token should be rejected too.
+The combination `requestId=123` and `accessToken=xyz` is the one that you have to generate in advance, making sure that the `accessToken` cannot be deduced from the `requestId`. Any approval request with `requestId=123` and no `accessToken` or with a `accessToken` not equal to `xyz` should be rejected. If the action is supposed to be a one-time action, once this request gets through, any future request with the same id and access token should be rejected too.
 
 ## Testing in different email clients
 


### PR DESCRIPTION
It appears that this section was copied from the Gmail Email Markup
documentation:

https://developers.google.com/gmail/markup/actions/limited-use-access-tokens

The particular mention about one-time use of the token is specific to
the One Click Action feature of Email Markup:

https://developers.google.com/gmail/markup/actions/limited-use-access-tokens

I don't think we should have such restriction for AMP for Email. For
example, an email that allows users to reply to a comment thread inline
should be able to use the same token to perform reply multiple times. We
should let sender decide whether to make the token one-time use only.

/to @patrickkettner 