### PR TITLE
Removed HLS recommendation from docs

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/webstory_technical_details.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/webstory_technical_details.md
@@ -167,7 +167,7 @@ Try to keep HLS segments under 10 seconds in duration.
 
 Keep videos smaller than 4MB for optimal performance. Consider splitting large videos up over multiple pages.
 
-If you can only provide a single video format, provide MP4. When possible, use HLS video and specify MP4 as a fallback for browser compatibility. Use the following video codec:
+If you can only provide a single video format, provide MP4. Use the following video codec:
 
 <table>
   <tr>


### PR DESCRIPTION
HLS is not widely supported on Android browsers (`canPlayType` returns `maybe`) so we should not recommend it as the main video format for stories, as the browser doesn't fallback properly in many scenarios.