### PR TITLE
Fix italicization of word

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/integrate/add-email.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/integrate/add-email.md
@@ -49,7 +49,7 @@ Content-Type: text/html; charset="UTF-8"
 
 ```
 [tip type="important"]
-    Some email clients will only render the last MIME part. To ensure an email is rendered, place the `text/x-amp-html` MIME part _before _the `text/html` MIME part.
+    Some email clients will only render the last MIME part. To ensure an email is rendered, place the `text/x-amp-html` MIME part _before_ the `text/html` MIME part.
 [/tip]
 
 # What happens when recipients forward or reply to an AMP Email?


### PR DESCRIPTION
It looks like the original intention was to italicize the word "before",
but there's a typo that causes it to be not italicized in the rendered
HTML.

@sebastianbenz 