### PR TITLE
Ignore temporary files generated by Vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 *.log
 node_modules
 .com.apple.timemachine.supported
+*.swp
+*.swo
 
 dist
 /build


### PR DESCRIPTION
These are already ignored by the `amphtml` project.

/to @sebastianbenz 