### PR TITLE
dont overwrite rewrites when adding go links

### DIFF
--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -446,7 +446,10 @@ function buildPages(done) {
 
             netlifyConfig = toml.parse(netlifyConfig);
             netlifyConfig.build.publish = '.';
-            netlifyConfig.redirects = redirects;
+            netlifyConfig.redirects = [
+              ...(netlifyConfig.redirects || []),
+              ...redirects,
+            ];
 
             delete netlifyConfig.build.base;
 


### PR DESCRIPTION
Introduced this bug when I switched over to programmatically adding go links