### PR TITLE
build updates

### DIFF
--- a/.github/workflows/check-grow-link-integrity.yaml
+++ b/.github/workflows/check-grow-link-integrity.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'

--- a/.github/workflows/lint-js.yaml
+++ b/.github/workflows/lint-js.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'

--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'

--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'
@@ -62,7 +62,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: node_modules-${{ hashFiles('**/package-lock.json') }}
@@ -118,7 +118,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: node_modules-${{ hashFiles('**/package-lock.json') }}
@@ -131,7 +131,7 @@ jobs:
         with:
           python-version: '3.9'
 
-#      - uses: actions/cache@v2
+#      - uses: actions/cache@v3
 #        with:
 #          path: ${{ env.pythonLocation }}
 #          key: ${{ env.pythonLocation }}
@@ -177,7 +177,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: node_modules-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'
@@ -76,7 +76,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'
@@ -133,7 +133,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'
@@ -147,7 +147,7 @@ jobs:
         with:
           python-version: '3.9'
 
-#      - uses: actions/cache@v2
+#      - uses: actions/cache@v3
 #        with:
 #          path: ${{ env.pythonLocation }}
 #          key: ${{ env.pythonLocation }}
@@ -190,7 +190,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'

--- a/.github/workflows/release-static-production.yml
+++ b/.github/workflows/release-static-production.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Deploying
         run: |
           if ${{ github.ref_name }} != "production-amp-dev" ; then
-            npx gulp staticDeploy
-          else
             npx gulp staticDeploy --stage
+          else
+            npx gulp staticDeploy
           fi

--- a/.github/workflows/release-static-production.yml
+++ b/.github/workflows/release-static-production.yml
@@ -3,15 +3,13 @@ name: 'Release: Static Production'
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - static-production-amp-dev
+  pull_request:
 
 jobs:
   queue:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.skip_check.outputs.should_skip || steps.check_user.check-result == 'false' }}
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
@@ -21,6 +19,10 @@ jobs:
           skip_after_successful_duplicate: true
           paths_ignore: '["**/README.md", "**/docs/**"]'
           do_not_skip: '["workflow_dispatch", "schedule"]'
+      - id: check_user
+        uses: actions-cool/check-user-permission@main
+        with:
+           require: 'write'
   verify:
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +34,14 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - id: changes
+        uses: tj-actions/changed-files@main
+        with:
+          since_last_remote_commit: 'true'
+          files: |
+            netlify/**
+
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'
@@ -60,7 +69,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'
@@ -81,7 +90,6 @@ jobs:
         with:
           name: build-setup
           path: artifacts/setup.tar.gz
-
   build:
     env:
       APP_ENV: production
@@ -116,7 +124,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'
@@ -130,7 +138,7 @@ jobs:
         with:
           python-version: '3.9'
 
-#      - uses: actions/cache@v2
+#      - uses: actions/cache@v3
 #        with:
 #          path: ${{ env.pythonLocation }}
 #          key: ${{ env.pythonLocation }}
@@ -152,7 +160,13 @@ jobs:
 
       - name: Building pages
         run: |
-          npx gulp buildPages --locales ${{ matrix.language }}
+          if ${{ steps.changed-files-specific.outputs.only_changed == 'true'}}; then
+            echo 'only touching static server config, skipping the build...'
+          elif ${{ github.ref_name }} != "production-amp-dev"; then
+            npx gulp buildPages --locales ${{ matrix.language }} --env PR
+          else
+            npx gulp buildPages --locales ${{ matrix.language }}
+          fi
 
       - name: Storing build artifacts
         uses: actions/upload-artifact@v2
@@ -163,7 +177,6 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment: Production
     env:
       APP_ENV: production
       NETLIFY_DEPLOY_TOKEN: ${{ secrets.NETLIFY_DEPLOY_TOKEN }}
@@ -176,7 +189,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'
@@ -200,4 +213,8 @@ jobs:
 
       - name: Deploying
         run: |
-          npx gulp staticDeploy
+          if ${{ github.ref_name }} != "production-amp-dev" ; then
+            npx gulp staticDeploy
+          else
+            npx gulp staticDeploy --stage
+          fi

--- a/.github/workflows/test-grow-extensions.yaml
+++ b/.github/workflows/test-grow-extensions.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: '3.x'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}

--- a/.github/workflows/test-pixi.yaml
+++ b/.github/workflows/test-pixi.yaml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'

--- a/.github/workflows/test-platform.yaml
+++ b/.github/workflows/test-platform.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'

--- a/.github/workflows/test-playground.yaml
+++ b/.github/workflows/test-playground.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
           path: '**/node_modules'

--- a/gulpfile.js/deploy-static.js
+++ b/gulpfile.js/deploy-static.js
@@ -52,6 +52,9 @@ async function staticDeploy() {
       } --message "${git.message()}"`,
       {
         workingDir: SITE.DIR,
+        env: {
+          NETLIFY_SITE_ID: SITE.ID,
+        },
       }
     );
   }

--- a/gulpfile.js/deploy-static.js
+++ b/gulpfile.js/deploy-static.js
@@ -49,7 +49,7 @@ async function staticDeploy() {
     await sh(
       `npx netlify deploy ${branchInfo} --auth ${NETLIFY_DEPLOY_TOKEN} --site ${
         SITE.ID
-      } --message ${git.message()}`,
+      } --message "${git.message()}"`,
       {
         workingDir: SITE.DIR,
       }

--- a/gulpfile.js/deploy-static.js
+++ b/gulpfile.js/deploy-static.js
@@ -16,6 +16,9 @@
 
 'use strict';
 
+const git = require('@lib/utils/git');
+const mri = require('mri');
+const argv = mri(process.argv.slice(2));
 const {sh} = require('@lib/utils/sh.js');
 const {DIST, PAGES_DEST} = require('@lib/utils/project').paths;
 const {NETLIFY_DEPLOY_TOKEN} = process.env;
@@ -38,11 +41,15 @@ const SITES = [
 ];
 
 async function staticDeploy() {
+  const branchInfo = argv.stage ? `--alias ${git.version()}` : '--prod';
+
   for (const SITE of SITES) {
     console.log(`attempting to deploy ${SITE.DIR}`);
 
     await sh(
-      `npx netlify deploy --prod --auth ${NETLIFY_DEPLOY_TOKEN} --site ${SITE.ID}`,
+      `npx netlify deploy ${branchInfo} --auth ${NETLIFY_DEPLOY_TOKEN} --site ${
+        SITE.ID
+      } --message ${git.message()}`,
       {
         workingDir: SITE.DIR,
       }

--- a/platform/lib/config.js
+++ b/platform/lib/config.js
@@ -52,6 +52,46 @@ const AVAILABLE_LOCALES = [
   'vi',
 ];
 
+function generateStaticStagingHost(
+  host,
+  subdomain = '',
+  scheme = 'https',
+  port = ''
+) {
+  return {
+    scheme,
+    subdomain,
+    host,
+    port,
+  };
+}
+
+function generateStaticStagingConfig(commitHash) {
+  const TAG = commitHash || `${require('@lib/utils/git').version()}}`;
+
+  return {
+    'name': 'staging',
+    'hosts': {
+      'pages': generateStaticStagingHost('amp.dev', `${TAG}`),
+      'api': generateStaticStagingHost('amp.dev', `${TAG}`),
+      'platform': generateStaticStagingHost('amp.dev', `${TAG}`),
+      'log': generateStaticStagingHost('amp.dev', 'https', `${TAG}`),
+      'webocket': generateStaticStagingHost('amp.dev', 'wss', 'wss'),
+      'playground': generateStaticStagingHost(
+        `amp.dev`,
+        'https',
+        `${TAG}-playground`
+      ),
+      'preview': generateStaticStagingHost(
+        `amp.dev`,
+        'https',
+        `${TAG}-preview`
+      ),
+      'go': generateStaticStagingHost(`amp.dev`, 'https', `${TAG}-go`),
+    },
+  };
+}
+
 class Config {
   constructor(environment = ENV_DEV) {
     if (environment === 'test') {
@@ -65,9 +105,14 @@ class Config {
       this.test = false;
     }
     signale.info(`Config: environment=${environment} test=${this.test}`);
-    const env = require(utils.project.absolute(
-      `platform/config/environments/${environment}.json`
-    ));
+    let env;
+    if (env === 'PR') {
+      env = generateStaticStagingConfig();
+    } else {
+      env = require(utils.project.absolute(
+        `platform/config/environments/${environment}.json`
+      ));
+    }
 
     this.environment = env.name;
     this.hosts = env.hosts;


### PR DESCRIPTION
handful of build changes.
This should build a staging version of the static site if a push or PR is added by someone with write access on the repo.
If it is a commit the branch `production-amp-dev` (doesn't currently exist, just a random branch name I put in), then it will trigger a production deploy.
If the push is only modifying the netlify configs, then we reuse the last build cache, so server fixes should be an order of magnitude faster to deploy as all files would be cached.