### PR TITLE
Fix go link not redirecting issue

### DIFF
--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -440,14 +440,14 @@ function buildPages(done) {
               from = `https://go.amp.dev${from}`;
 
               // we only want to update the URL of shorturls that point to relative URLs
-              if (!to.startsWith('http')) {
+              if (!to.startsWith('http://') && !to.startsWith('https://')) {
                 to = `https://amp.dev${to}`;
               }
 
               return {
                 from,
                 to,
-                'status': 200,
+                'status': 302,
                 'force': true,
               };
             });


### PR DESCRIPTION
Hopefully this would fix the issue. But if it doesn't, I would remove this entire segment of code and it should fix it.

https://github.com/ampproject/amp.dev/issues/6761

In addition, the logic to determine whether a link is relative is updated to be more precise.