### PR TITLE
Update Node version to 16 and fix other config / API usage for newly-broken deps

### DIFF
--- a/.github/workflows/lint-js.yaml
+++ b/.github/workflows/lint-js.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
 
       - name: Installing Node.js packages

--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
 
       - name: Installing Node.js packages

--- a/.github/workflows/release-static-production.yaml
+++ b/.github/workflows/release-static-production.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
 
       - name: Installing Node.js packages
@@ -53,7 +53,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
 
       - name: Installing Node.js packages
@@ -104,7 +104,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
 
       - name: Installing Node.js packages
@@ -154,7 +154,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
 
       - name: Installing Node.js packages

--- a/.github/workflows/test-platform.yaml
+++ b/.github/workflows/test-platform.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
 
       - name: Installing Node.js packages

--- a/.github/workflows/test-playground.yaml
+++ b/.github/workflows/test-playground.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
 
       - name: Installing Node.js packages

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -11,7 +11,7 @@ RUN \
   rm -rf /var/lib/apt/lists/*
 
 RUN \
-  curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+  curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
   apt-get install -y nodejs && \
   npm i -g npm && \
   npm install -g gulp

--- a/gulpfile.js/staticify.js
+++ b/gulpfile.js/staticify.js
@@ -36,6 +36,7 @@ const {
   FORMAT_WEBSITES,
   SUPPORTED_FORMATS,
 } = require('@lib/amp/formatHelper.js');
+const {cheerioOptions} = require('../platform/lib/common/cheerioOptions');
 const coursesPath = '/documentation/courses';
 const coursesRegex = new RegExp(`^(.+)(?:${coursesPath})(.*)$`);
 
@@ -208,7 +209,7 @@ async function staticify(done) {
           through.obj(function (file, enc, callback) {
             let renderedPage = file.contents.toString();
 
-            const $ = Cheerio.load(renderedPage);
+            const $ = Cheerio.load(renderedPage, cheerioOptions);
             const $links = $('.nav-link');
             const $levelToggle = $('.toggle-button input');
 

--- a/pixi/webpack.config.js
+++ b/pixi/webpack.config.js
@@ -144,7 +144,9 @@ module.exports = (env, argv) => {
     },
 
     devServer: {
-      writeToDisk: true,
+      devMiddleware: {
+        writeToDisk: true,
+      },
     },
   };
 };

--- a/platform/lib/common/cheerioOptions.js
+++ b/platform/lib/common/cheerioOptions.js
@@ -1,0 +1,14 @@
+module.exports = {
+  /** @type {import('cheerio').CheerioOptions} */
+  cheerioOptions: {
+    // Simply setting an `xml` key here forces Cheerio to use htmlparser2 instead of the more strict parse5.
+    // https://cheerio.js.org/docs/advanced/configuring-cheerio#parsing-xml-with-htmlparser2
+    xml: {
+      // Our tests were written with this setting in mind.
+      decodeEntities: false,
+      // This indicates that we expect to parse HTML, not XML.
+      // https://cheerio.js.org/docs/advanced/configuring-cheerio#using-htmlparser2-for-html
+      xmlMode: false,
+    },
+  },
+};

--- a/platform/lib/format-transform/index.js
+++ b/platform/lib/format-transform/index.js
@@ -19,6 +19,7 @@ const amphtmlValidator = require('amphtml-validator');
 const {htmlContent} = require('@lib/utils/cheerioHelper');
 const config = require('@lib/config.js');
 const formats = require('./formats');
+const {cheerioOptions} = require('../common/cheerioOptions');
 
 const host = config.hosts.platform;
 const FORMATS_REGEXP = /@formats\(([^)]+)\)/;
@@ -49,7 +50,7 @@ class FormatTransform {
       throw new Error(`Unsupported transform format: ${target}`);
     }
     const {transforms, validatorRuntime} = this.formats[target];
-    const $ = cheerio.load(input, {decodeEntities: false});
+    const $ = cheerio.load(input, cheerioOptions);
     this.applyCommentFormatFilters_($, target);
     for (const selector of Object.keys(transforms)) {
       const elements = $(selector);

--- a/platform/lib/utils/cheerioHelper.js
+++ b/platform/lib/utils/cheerioHelper.js
@@ -22,7 +22,7 @@
  * @return {String}
  */
 function htmlContent(dom) {
-  let html = dom.html({_useHtmlParser2: true});
+  let html = dom.html();
   html = html.replace(
     'xmlns="http://www.w3.org/2000/svg" xlink="http://www.w3.org/1999/xlink"',
     'xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"'

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -34,6 +34,7 @@ module.exports = (env, argv) => {
       fallback: {
         util: require.resolve('util/util.js'),
         stream: require.resolve('stream-browserify'),
+        process: false,
       },
     },
     optimization: {


### PR DESCRIPTION
See individual commits for each step

Locally, all `npm run test:...` commands pass for me and some but not all the `npm run build:...` commands. It's really difficult to tell which ones are still relevant and which ones are legacy code :/

Importantly, I ran through the steps in `release-static-production.yaml` manually and it does seem to pass with Node 16, so I am optimistic about this PR :D