### PR TITLE
Yet another fix for preview.amp.dev

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,8 @@ on:
         default: Staging
   push:
     branches:
-      - main
+      - 'main'
+      - 'gha-deploy-*'
 
 jobs:
   queue:

--- a/netlify/configs/preview.amp.dev/netlify.toml
+++ b/netlify/configs/preview.amp.dev/netlify.toml
@@ -74,5 +74,10 @@
   to = "https://amp.dev/static/samples/img/:splat"
   status = 200
 
+[[redirects]]
+  from = "/*"
+  to = "/sources/:splat"
+  status = 200
+
 [functions]
   directory = "./netlify/functions/"


### PR DESCRIPTION
Broken in #6781, not entirely fixed in #6783

Tag-along change:
- Make it so that any branch called `gha-deploy-*` also deploys to Staging - helps with debugging