### PR TITLE
Video examples on amp.dev

### DIFF
--- a/examples/source/1.components/amp-vine.html
+++ b/examples/source/1.components/amp-vine.html
@@ -31,7 +31,7 @@ author: sebastianbenz
     A Vine embed has equal width and height. You can find the `vineid` in the each vine's URL.
   -->
   <amp-vine width="400" height="400"
-    data-vineid="MdKjXez002d">
+    data-vineid="bpxmJaHED09">
   </amp-vine>
 
   <!-- ## Responsive layout -->
@@ -39,7 +39,7 @@ author: sebastianbenz
     Resposive layout works as well. In that case you can use any value for `height` and `width` as long as they are the same.
   -->
   <amp-vine width="1" height="1" layout="responsive"
-    data-vineid="MdKjXez002d">
+    data-vineid="bpxmJaHED09">
   </amp-vine>
 </body>
 </html>

--- a/examples/source/multimedia-animations/Integrating_Videos_in_AMP_an_Overview.html
+++ b/examples/source/multimedia-animations/Integrating_Videos_in_AMP_an_Overview.html
@@ -153,7 +153,7 @@ author: kul3r4
   <amp-vine width="400"
             height="400"
             layout="responsive"
-            data-vineid="MdKjXez002d">
+            data-vineid="bpxmJaHED09">
   </amp-vine>
   <!-- ### amp-youtube -->
   <!--

--- a/examples/source/multimedia-animations/Video_Carousels_with_amp-carousel.html
+++ b/examples/source/multimedia-animations/Video_Carousels_with_amp-carousel.html
@@ -131,7 +131,7 @@ author: kul3r4
     </amp-springboard-player>
     <amp-twitter width="375" height="472" layout="responsive" data-tweetid="707569406105092096"></amp-twitter>
     <amp-vimeo data-videoid="27246366" width="500" height="281"></amp-vimeo>
-    <amp-vine width="400" height="300" layout="responsive" data-vineid="MdKjXez002d"></amp-vine>
+    <amp-vine width="400" height="300" layout="responsive" data-vineid="bpxmJaHED09"></amp-vine>
     <amp-youtube height="270" layout="fixed-height" data-videoid="SOx1XfOjJPI"></amp-youtube>
     <amp-iframe title="Video of Sintel, an independently produced short film"
                 width="400"

--- a/examples/static/samples/files/amp-video-iframe-videojs.html
+++ b/examples/static/samples/files/amp-video-iframe-videojs.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <link href="https://vjs.zencdn.net/7.3.0/video-js.css" rel="stylesheet">
+  <link href="https://vjs.zencdn.net/8.10.0/video-js.css" rel="stylesheet">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <script async src="https://cdn.ampproject.org/video-iframe-integration-v0.js"></script>
   <style type="text/css">
@@ -29,7 +29,7 @@
     </p>
   </video>
 
-  <script src="https://vjs.zencdn.net/7.3.0/video.js"></script>
+  <script src="https://vjs.zencdn.net/8.10.0/video.js"></script>
 
   <!-- Integration script -->
   <script>

--- a/examples/static/samples/files/custom-video-player.html
+++ b/examples/static/samples/files/custom-video-player.html
@@ -4,10 +4,8 @@
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <title>Custom Video Player</title>
-        <link href="https://vjs.zencdn.net/7.6.6/video-js.css" rel="stylesheet" />
+        <link href="https://vjs.zencdn.net/8.10.0/video-js.css" rel="stylesheet" />
       
-        <!-- If you'd like to support IE8 (for Video.js versions prior to v7) -->
-        <script src="https://vjs.zencdn.net/ie8/1.1.2/videojs-ie8.min.js"></script>
         <script async src="https://cdn.ampproject.org/video-iframe-integration-v0.js"></script>
 
       </head>
@@ -33,7 +31,7 @@
               
         </video>
       
-        <script src="https://vjs.zencdn.net/7.6.6/video.js"></script>
+        <script src="https://vjs.zencdn.net/8.10.0/video.js"></script>
         <script>
           // Wait for API to initialize
           (window.AmpVideoIframe = window.AmpVideoIframe || [])


### PR DESCRIPTION
While dealing with https://github.com/ampproject/amphtml/issues/39676, found a few examples broken (vine) and the videojs could be using later version of videojs.js. Updating them on amp.dev