### PR TITLE
Validator does not validate ampjs.org, temporarily revert the test

### DIFF
--- a/platform/lib/format-transform/index.test.js
+++ b/platform/lib/format-transform/index.test.js
@@ -61,7 +61,7 @@ describe('formatTransform', () => {
 <head>
 <link><meta><noscript></noscript>
 <meta charset="utf-8">
-<script async src="https://ampjs.org/v0.js"></script>
+<script async src="https://cdn.ampproject.org/v0.js"></script>
 <style amp-boilerplate></style>
 </head>
 <body></body>
@@ -70,7 +70,7 @@ describe('formatTransform', () => {
 <html ⚡4email data-css-strict>
 <head>
 <meta charset="utf-8">
-<script async src="https://ampjs.org/v0.js"></script>
+<script async src="https://cdn.ampproject.org/v0.js"></script>
 <style amp4email-boilerplate>body{visibility:hidden}</style>
 </head>
 <body></body>


### PR DESCRIPTION
So we can at least deploy the site now.