### PR TITLE
Fix for incorrectly applied `[filter ...]` tags in Markdown processor

### DIFF
--- a/gulpfile.js/staticify.js
+++ b/gulpfile.js/staticify.js
@@ -108,6 +108,7 @@ async function staticify(done) {
           through.obj(async (file, enc, callback) => {
             const configObj = {
               requestPath: `${file.path.replace(requestPathRegex, '')}/`,
+              level: 'beginner', // Some filters require any level to be set, so we set a default here.
               format,
               requestedFormat: format,
             };


### PR DESCRIPTION
All component pages are missing _any_ section that has a `[filter ...]` rule applied, since those component markdown pages only list a `format` as a filter, never a `level`, but the filter pre-processor macro is expecting both of those to be set