### PR TITLE
Fix amp4email demo XHR endpoint inconsistent header

### DIFF
--- a/netlify/functions/examples_api_echo/examples_api_echo.js
+++ b/netlify/functions/examples_api_echo/examples_api_echo.js
@@ -7,7 +7,7 @@ function jsonReply(data, ev) {
       'Access-Control-Allow-Origin': ev.headers?.origin || '',
       'Access-Control-Allow-Credentials': 'true',
       'Content-Type': 'application/json',
-      'Cache-Control': 'max-age=365000000, immutable',
+      'Cache-Control': 'no-cache',
     },
     body: JSON.stringify(data),
   };

--- a/netlify/functions/examples_api_hello/examples_api_hello.js
+++ b/netlify/functions/examples_api_hello/examples_api_hello.js
@@ -41,16 +41,15 @@ const parseFormData = (ev) => {
 const handler = async (ev) => {
   const headers = {
     'Access-Control-Allow-Origin': ev.headers?.origin || '',
+    'Cache-Control': 'no-cache',
   };
   let name;
 
   if (ev.httpMethod === 'POST') {
-    headers['Cache-Control'] = 'no-cache';
     const parsedEvent = await parseFormData(ev);
 
     name = parsedEvent.body.name;
   } else if (ev.httpMethod === 'GET') {
-    headers['Cache-Control'] = 'max-age=365000000, immutable';
     name = ev.queryStringParameters.name;
   } else {
     return {statusCode: 405, body: 'Method Not Allowed'};

--- a/netlify/functions/examples_api_photo_stream/examples_api_photo_stream.js
+++ b/netlify/functions/examples_api_photo_stream/examples_api_photo_stream.js
@@ -15,15 +15,6 @@ function randomFalsy() {
   }
 }
 
-function getMaxAgeStr(maxAge, cdnMaxAge = '') {
-  if (cdnMaxAge) {
-    cdnMaxAge = `s-max-age=${cdnMaxAge}, `;
-  }
-  return ` max-age=${maxAge}, ${cdnMaxAge}stale-while-revalidate=${Math.floor(
-    maxAge * 2
-  )}`;
-}
-
 const handler = async (ev) => {
   const query = ev.queryStringParameters;
   let items = [];
@@ -39,7 +30,7 @@ const handler = async (ev) => {
     return {
       statusCode: 200,
       headers: {
-        'Cache-Control': getMaxAgeStr(60 * 60), // 1h
+        'Cache-Control': 'no-cache',
         'Access-Control-Allow-Origin': ev.headers?.origin || '',
         'Access-Control-Allow-Credentials': true,
         'Content-Type': 'application/json',

--- a/netlify/functions/examples_source_news_publishing_amp-live-list_api/examples_source_news_publishing_amp-live-list_api.js
+++ b/netlify/functions/examples_source_news_publishing_amp-live-list_api/examples_source_news_publishing_amp-live-list_api.js
@@ -243,15 +243,6 @@ function createMetaData(origin, baseUrl) {
   return result;
 }
 
-function getMaxAgeStr(maxAge, cdnMaxAge = '') {
-  if (cdnMaxAge) {
-    cdnMaxAge = `s-max-age=${cdnMaxAge}, `;
-  }
-  return ` max-age=${maxAge}, ${cdnMaxAge}stale-while-revalidate=${Math.floor(
-    maxAge * 2
-  )}`;
-}
-
 function readStatus(ev) {
   const Cookies = Cookie.parse(ev.headers.cookie || '');
   const cookie = Cookies[AMP_LIVE_LIST_COOKIE_NAME];
@@ -271,8 +262,7 @@ const handler = async (ev) => {
   return {
     statusCode: 200,
     headers: {
-      // set max-age to 15 s - the minimum refresh time for an amp-live-list
-      'Cache-Control': getMaxAgeStr(15),
+      'Cache-Control': 'no-cache',
       'Content-Type': 'text/html',
       'Set-Cookie': newStatus.cookie,
       'Access-Control-Allow-Origin': ev.headers?.origin || '',

--- a/netlify/functions/examples_static_samples_json_cart/examples_static_samples_json_cart.js
+++ b/netlify/functions/examples_static_samples_json_cart/examples_static_samples_json_cart.js
@@ -2,7 +2,7 @@ const cartJSON = require('./cart.json');
 
 const handler = async (ev) => {
   const headers = {
-    'Cache-Control': 'public, max-age=604800, stale-while-revalidate=0',
+    'Cache-Control': 'no-cache',
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': ev.headers?.origin || '',
   };

--- a/netlify/functions/search_autosuggest/search_autosuggest.js
+++ b/netlify/functions/search_autosuggest/search_autosuggest.js
@@ -1,11 +1,5 @@
 const componentVersions = require('./component-versions.json');
 
-const RESPONSE_MAX_AGE = {
-  search: 21600, // 6 hours
-  highlights: 86400, // 24 hours
-  autosuggest: 86400, // 24 hours
-};
-
 const {
   BUILT_IN_COMPONENTS,
   IMPORTANT_INCLUDED_ELEMENTS,
@@ -32,7 +26,7 @@ const handler = async () => {
     headers: {
       'Access-Control-Allow-Origin': ev.headers?.origin || '',
       'Content-Type': 'application/javascript',
-      'Cache-Control': `max-age=${RESPONSE_MAX_AGE.autosuggest}, immutable`,
+      'Cache-Control': 'no-cache',
     },
     body,
   };

--- a/netlify/functions/search_do/search_do.js
+++ b/netlify/functions/search_do/search_do.js
@@ -8,12 +8,6 @@ const MAX_HIGHLIGHT_COMPONENT_INDEX = 7;
 const COMPONENT_REFERENCE_DOC_PATTERN =
   /^(?:https?:\/\/[^/]+)?(?:\/[^/]+)?\/documentation\/components\/(amp-[^/]+)/;
 
-const RESPONSE_MAX_AGE = {
-  search: 21600, // 6 hours
-  highlights: 86400, // 24 hours
-  autosuggest: 86400, // 24 hours
-};
-
 const DEFAULT_LOCALE = 'en';
 
 /** Will remove/rewrite characters that cause problems when displaying */
@@ -146,7 +140,7 @@ const handler = async (ev) => {
       headers: {
         'Access-Control-Allow-Origin': ev.headers?.origin || '',
         'Content-Type': 'application/javascript',
-        'Cache-Control': `max-age=${RESPONSE_MAX_AGE.search}, immutable`,
+        'Cache-Control': 'no-cache',
       },
       body: JSON.stringify({error}),
     };
@@ -205,7 +199,7 @@ const handler = async (ev) => {
     headers: {
       'Access-Control-Allow-Origin': ev.headers?.origin || '',
       'Content-Type': 'application/javascript',
-      'Cache-Control': `max-age=${RESPONSE_MAX_AGE.search}, immutable`,
+      'Cache-Control': 'no-cache',
     },
     body: createResult(
       totalResults,


### PR DESCRIPTION
Gmail team has found out that this endpoint is returning inconsistent Access-Control-Allow-Origin header. It could be because it enables `public` cache. The problem is that this header depends on the origin header and therefore it cannot properly be cached without messing the response header up. This PR disables the cache on the Netlify. Given it is only a demo, I do not expect this to become a significant cost problem.

@zhangsu 