### PR TITLE
Do not ignore .git folder since it is actually being used

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 # If you would like to upload your .git directory, .gitignore file or files
 # from your .gitignore file, remove the corresponding line
 # below:
-.git
 .gitignore
 .github
 .cache


### PR DESCRIPTION
In the container, it is throwing bunch of errors due to .git is not there.