### PR TITLE
Filter out non-applicable content for email

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/responsive_design.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/responsive_design.md
@@ -96,7 +96,9 @@ The tricky part is having responsive elements render on the page without adverse
 
 ## Scaling media for the page <a name="scaling-media-for-the-page"></a>
 
-Probably the most challenging aspect of responsive design is displaying media correctly on the page so that it responds to the screen's characteristics. In this section, we'll look at how you can embed responsive videos and images on AMP pages.
+Probably the most challenging aspect of responsive design is displaying media correctly on the page so that it responds to the screen's characteristics. In this section, we'll look at how you can embed responsive media on AMP pages.
+
+[filter formats="websites, ads, stories"]
 
 ### Embedding videos
 
@@ -121,6 +123,8 @@ In the following example, we want to display an embedded YouTube video that resp
 [/example]
 
 There are many types of videos that you can add to your AMP pages. For details, see the list of available [media components](../../../../documentation/components/index.html#media).
+
+[/filter]
 
 ### Displaying responsive images <a name="displaying-responsive-images"></a>
 
@@ -288,6 +292,11 @@ Here are some examples that we hope inspire you to create responsive AMP pages:
 
 #### Made by AMP
 
+
+[filter formats="websites, ads, stories"]
 - [Examples](../../../../documentation/examples/index.html)
 - [Templates](../../../../documentation/templates/index.html)
 - [AMP Conf Workshop Codelab: Making beautiful AMPs](https://codelabs.developers.google.com/codelabs/amp-beautiful-interactive-canonical)
+[filter formats="email"]
+- [Examples](../../../../documentation/examples/index.html?format=email)
+[/filter]

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages.md
@@ -20,8 +20,13 @@ Warning: AMP for Email specifies additional CSS constraints which are described 
 [/filter]
 
 Like all web pages, AMP pages are styled with CSS,
-but you can’t reference external stylesheets
-(with the exception of [custom fonts](#the-custom-fonts-exception)).
+but you can’t reference external
+[filter formats="websites, ads, stories"]
+stylesheets (with the exception of [custom fonts](#the-custom-fonts-exception)).
+[/filter]
+[filter formats="email"]
+stylesheets.
+[/filter]
 Also certain styles are disallowed due to performance implications.
 
 Styles may live in the head of the document or as inline `style` attributes
@@ -37,6 +42,7 @@ to better manage your content.
 
 The following styles aren’t allowed in AMP pages:
 
+[filter formats="websites, ads, stories"]
 <table>
   <thead>
     <tr>
@@ -60,6 +66,32 @@ The following styles aren’t allowed in AMP pages:
     </tr>
   </tbody>
 </table>
+[/filter]
+[filter formats="email"]
+<table>
+  <thead>
+    <tr>
+      <th class="col-thirty" data-th="Banned style">Banned style</th>
+      <th data-th="Description">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Banned style"><code>!important</code> qualifier </td>
+      <td data-th="Description">Use and reference to <code>!important</code> is not allowed.
+      This is a necessary requirement to enable AMP to enforce its element sizing rules.</td>
+    </tr>
+    <tr>
+      <td data-th="Banned style"><code>&lt;link rel=”stylesheet”&gt;</code></td>
+      <td data-th="Description">Disallowed.</td>
+    </tr>
+    <tr>
+      <td data-th="Banned style"><code>i-amphtml-</code> class and <code>i-amphtml-</code> tag names.</td>
+      <td data-th="Description">The validator disallows class and tags names with the following regex `(^|\W)i-amphtml-`. These are reserved for internal use by the AMP framework. It follows, that the user's stylesheet may not reference CSS selectors for <code>i-amphtml-</code> classes and tags.</td>
+    </tr>
+  </tbody>
+</table>
+[/filter]
 
 ## Performance recommendations
 


### PR DESCRIPTION
1. Custom font is not supported
2. Embedding video is not supported
3. Examples link should point to the email examples
4. There's no design templates for email on amp.dev
5. The AMP Conf Workshop codelab link is broken and cannot be found in https://codelabs.developers.google.com/

/to @powerivq 