### PR TITLE
Remove unnecessary new paragraph in style_pages.md

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages.md
@@ -19,13 +19,11 @@ Warning: AMP for Email specifies additional CSS constraints which are described 
 [AMP for Email Supported CSS](../../../../documentation/guides-and-tutorials/learn/email-spec/amp-email-css.md).
 [/filter]
 
-Like all web pages, AMP pages are styled with CSS,
-but you can’t reference external
 [filter formats="websites, ads, stories"]
-stylesheets (with the exception of [custom fonts](#the-custom-fonts-exception)).
+Like all web pages, AMP pages are styled with CSS, but you can’t reference external stylesheets (with the exception of [custom fonts](#the-custom-fonts-exception)).
 [/filter]
 [filter formats="email"]
-stylesheets.
+Like all web pages, AMP pages are styled with CSS, but you can’t reference external stylesheets.
 [/filter]
 Also certain styles are disallowed due to performance implications.
 


### PR DESCRIPTION
https://github.com/ampproject/amp.dev/pull/6833 took a shortcut and applied the format filter on just part of the sentence. This resulted in the word "stylesheets" being put in a new paragraph after the word "external". Apparently, the filter mechanism always creates a new paragraph as opposed to coalescing all whitespace characters into a single space.

To fix this, we will have to duplicate some parts of the sentence, unfortunately.

/to @powerivq 