### PR TITLE
Remove unsafe terser optimizations

### DIFF
--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -44,7 +44,6 @@ module.exports = (env, argv) => {
             ecma: '2015',
             compress: {
               defaults: true,
-              unsafe: true,
             },
           },
         }),


### PR DESCRIPTION
This optimizer feature was causing  the native `Symbol` implementation to be replaced for some reason. This in turn causes the Closure polyfills code to break inside `validator_wasm.js` Once the Closure Polyfills break inside validator_wasm.js the whole validator is non operational.

Fixes the issue below:

![Screenshot 2025-03-19 at 12 18 26 PM](https://github.com/user-attachments/assets/338f5898-bd6c-43a7-a058-faf629113796)
