### PR TITLE
Also sanitize dots and parenthesises for slug generation

### DIFF
--- a/pages/extensions/markdown_toc_patch/custom_toc_tree_processor.py
+++ b/pages/extensions/markdown_toc_patch/custom_toc_tree_processor.py
@@ -1,11 +1,26 @@
+import re
+import unicodedata
 from markdown import util
 from markdown.extensions.toc import TocExtension
 from markdown.extensions.toc import TocTreeprocessor
+
+
+def slugify(value: str, separator: str = '-', unicode: bool = False) -> str:
+  """ Slugify a string, to make it URL friendly. """
+  slug = value.strip().lower()
+  slug = slug.replace(' ', '-')
+  slug = re.sub(r'[^\w-]', '', slug, flags=re.UNICODE)
+  return slug
+
 
 class CustomTocTreeProcessor(TocTreeprocessor):
   """
   Since html code that may be inside the headlines causes problems in the TOC we remove them
   """
+
+  def __init__(self, md, config):
+    super(CustomTocTreeProcessor, self).__init__(md, config)
+    self.slugify = slugify
 
   def strip_html_from_names(self, toc_list):
     for item in toc_list:


### PR DESCRIPTION
This is to address an issue that the titles' anchors are not sanitized properly, leaving dots and parenthesises there. This is not consistent with how github renders its page. We hereby remove them the same way.

I elected to use a new function name, instead of rewriting the `slug` function, to ensure that we do not accidentally fallback to the system default function.