### PR TITLE
Remove amp-ad-custom from documentation

### DIFF
--- a/netlify/functions/search_autosuggest/component-versions.json
+++ b/netlify/functions/search_autosuggest/component-versions.json
@@ -9,7 +9,6 @@
   "amp-accordion": "0.1",
   "amp-action-macro": "0.1",
   "amp-ad": "0.1",
-  "amp-ad-custom": "0.1",
   "amp-ad-exit": "0.1",
   "amp-ad-network-adsense-impl": "0.1",
   "amp-ad-network-adzerk-impl": "0.1",

--- a/platform/config/component-versions.json
+++ b/platform/config/component-versions.json
@@ -9,7 +9,6 @@
   "amp-accordion": "0.1",
   "amp-action-macro": "0.1",
   "amp-ad": "0.1",
-  "amp-ad-custom": "0.1",
   "amp-ad-exit": "0.1",
   "amp-ad-network-adsense-impl": "0.1",
   "amp-ad-network-adzerk-impl": "0.1",


### PR DESCRIPTION
We do not need the documentation even as reference since it had not been used in the past.