### PR TITLE
fix: add pointer cursor to language selector

### DIFF
--- a/frontend/scss/base.scss
+++ b/frontend/scss/base.scss
@@ -79,3 +79,7 @@ body > * > :not(.ap-o-code-preview) > * > .amp-carousel-button {
   h5:target::before { height: 93px; margin-top: -93px; }
   h6:target::before { height: 97px; margin-top: -97px; }
 }
+
+.ap-language-selector select {
+  cursor: pointer;
+}


### PR DESCRIPTION
Fixes #40344-[Navbar Language Switcher Missing Hover Cursor and Styling](https://github.com/ampproject/amphtml/issues/40344)


This PR improves the user experience of the language selector by adding cursor: pointer to the <select>element inside ap-language-selector.


